### PR TITLE
feat(users): add public GET /api/v3/users/count endpoint

### DIFF
--- a/src/server/users/users.controller.ts
+++ b/src/server/users/users.controller.ts
@@ -59,6 +59,10 @@ export const usersController = new Elysia({ prefix: "/users", tags: ["Users"] })
 		},
 		{ body: "users.validateHandle" }
 	)
+	.get("/count", async () => {
+		const count = await usersDao.count()
+		return { count }
+	})
 	.get("/me", async ({ request }) => {
 		const { user, response } = await requireSessionUser(request)
 		if (!user) return response

--- a/src/server/users/users.dao.ts
+++ b/src/server/users/users.dao.ts
@@ -144,4 +144,6 @@ export const usersDao = {
 		if (!me) throw new Error("User vanished after notifications update")
 		return me
 	},
+
+	count: async (): Promise<number> => db.user.count(),
 }


### PR DESCRIPTION
Returns `{ count: number }` — total rows in the user table — with no auth required.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UuaqvpbtW5o3yf2n5XKdtJ)_