### PR TITLE
feat(leaderboard,feedback): add leaderboard page and in-group feedbac…

### DIFF
--- a/docs/adr/0001-self-hosted-vps-deployment.md
+++ b/docs/adr/0001-self-hosted-vps-deployment.md
@@ -1,0 +1,102 @@
+# ADR 0001 — Migrate deployment from Vercel to self-hosted VPS
+
+**Date:** 2026-06-29  
+**Status:** Accepted
+
+---
+
+## Context
+
+PStrack launched on Vercel (managed serverless) with Neon (managed Postgres), Upstash (managed Redis), and Resend (managed email). As the platform matures the priority shifts from "get it running fast" to "own the stack" — predictable billing, no vendor rate limits, and full operational control over every layer.
+
+The primary driver is **control**, not cost (though the cost outcome is favourable: ~€10/mo vs unpredictable Vercel function billing at scale).
+
+---
+
+## Decision
+
+Migrate the entire production stack to a self-hosted Hetzner VPS managed by Coolify. Build Docker images in GitHub Actions, push to GHCR, and trigger Coolify deploys via webhook.
+
+### Infrastructure
+
+| Layer | Before | After |
+|---|---|---|
+| Compute | Vercel serverless | Hetzner CAX21 (4 vCPU ARM64, 8 GB RAM, €7.49/mo) |
+| Orchestration | Vercel platform | Coolify (self-hosted on same VPS) |
+| Database | Neon (managed Postgres) | Postgres container on Coolify |
+| Redis | Upstash (managed, REST API) | Redis container on Coolify |
+| Email | Resend | Postal (self-hosted on same VPS) |
+| Background jobs | Trigger.dev cloud | Trigger.dev cloud (unchanged) |
+| Error tracking | Sentry cloud | Sentry cloud (unchanged) |
+| Image registry | N/A | GHCR (`ghcr.io/org/pstrack`) |
+
+### Runtime
+
+Switch Nitro preset from `vercel` to `bun`. The Docker image uses `oven/bun` as the base image and runs the app as `bun .output/server/index.mjs`. This is consistent with the rest of the project (dev, CI, and all scripts already run on Bun).
+
+### CI/CD pipeline (replacing the Vercel deploy job)
+
+```
+typecheck → lint → knip → test → build Docker image → push to GHCR → curl Coolify webhook
+```
+
+The image is tagged with both the commit SHA and `latest`. Coolify deploys on webhook receipt, not on a registry poll.
+
+### Zero-downtime deploys
+
+Coolify is configured with a health check on `GET /api/v3/health` (existing endpoint). It starts the new container, waits for the health check to pass (30s grace period), then terminates the old container. No downtime during normal deploys.
+
+### Database backups
+
+A dedicated backup repository runs a nightly `pg_dump` cron that pushes snapshots as commits. This is not point-in-time recovery — it is daily snapshot recovery. Acceptable for PStrack's current risk profile.
+
+### Email
+
+Postal runs on the same VPS. The Resend SDK is replaced with Postal's HTTP API (structurally identical: POST with `to`, `from`, `subject`, `html`). React Email templates are unchanged — they produce HTML strings that either transport can send.
+
+### Redis client
+
+The Upstash REST SDK (`@upstash/redis`) is replaced with a standard Redis client (`ioredis` or `redis` npm package) pointing at the Coolify-managed Redis container. The change is isolated to `src/server/lib/redis.ts`.
+
+### Cutover strategy
+
+Hard cutover during the **1–2am UTC maintenance window** — after `assign-daily-problem` fires at midnight and before users are likely solving problems.
+
+Steps:
+1. Lower DNS TTL to 60s 24 hours in advance
+2. Provision Hetzner CAX21, install Coolify
+3. Stand up Postgres + Redis containers on Coolify
+4. Set up Postal, configure SPF/DKIM/DMARC for the sending domain
+5. Restore Neon data: `pg_dump` from Neon → `pg_restore` to Coolify Postgres
+6. Run `prisma migrate deploy` against self-hosted Postgres to verify schema parity
+7. Build and push the Docker image to GHCR
+8. Deploy to Coolify, verify health check passes
+9. Update `BETTER_AUTH_URL` env var and OAuth callback URLs in Google + GitHub consoles
+10. Update Polar webhook endpoint URL
+11. Flip DNS to Hetzner IP
+12. Monitor logs for 30 minutes; roll back to Vercel (DNS flip back) if critical errors appear
+13. Once stable: delete Vercel project, remove Neon + Upstash + Resend accounts
+
+---
+
+## Alternatives considered
+
+**Stay on Vercel indefinitely** — eliminated because it conflicts with the goal of full stack ownership and creates a hard dependency on Vercel's pricing model as traffic grows.
+
+**Partial migration (keep Neon/Resend, move only compute)** — eliminated because it leaves managed dependencies that undermine the control motivation. If we're migrating, we migrate completely.
+
+**Self-host Trigger.dev** — rejected. Trigger.dev OSS requires Postgres + Redis + Electric + Kafka for high volume. The background jobs (daily cron + webhook tasks) are low-volume; the operational cost of self-hosting outweighs any benefit.
+
+**Self-host Sentry / GlitchTip** — rejected for the same reason. Error data is not user PII; the free tier is sufficient; the ops overhead is not justified.
+
+**Two-server setup (app VPS + mail VPS)** — considered to prevent Postal's memory competing with the app. Rejected in favour of simplicity; CAX21's 8 GB RAM provides sufficient headroom for all services.
+
+---
+
+## Consequences
+
+- **Ops responsibility**: backups, Postgres maintenance, Redis memory management, Postal deliverability (SPF/DKIM/DMARC, bounce handling) are now owned by the team.
+- **ARM64 build**: Docker image must target `linux/arm64`. GitHub Actions `docker/setup-qemu-action` + `docker/setup-buildx-action` handles cross-compilation or native ARM runners can be used.
+- **OAuth callback URLs**: Must be updated in Google Cloud Console and GitHub OAuth App settings before cutover.
+- **Polar webhook**: Must be updated to point at the new domain before cutover.
+- **`DIRECT_URL` pattern**: Neon required two connection strings (pooled + direct). Self-hosted Postgres uses a single direct connection string; `DIRECT_URL` can be set equal to `DATABASE_URL` or the two-URL Prisma config can be simplified.

--- a/prisma/migrations/20260629100050_add_feedback_model/migration.sql
+++ b/prisma/migrations/20260629100050_add_feedback_model/migration.sql
@@ -1,0 +1,27 @@
+-- CreateEnum
+CREATE TYPE "FeedbackCategory" AS ENUM ('BUG', 'SUGGESTION', 'GENERAL');
+
+-- CreateTable
+CREATE TABLE "feedback" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "groupId" TEXT NOT NULL,
+    "category" "FeedbackCategory" NOT NULL,
+    "description" TEXT,
+    "reviewed" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "feedback_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "feedback_groupId_reviewed_idx" ON "feedback"("groupId", "reviewed");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "feedback_userId_groupId_key" ON "feedback"("userId", "groupId");
+
+-- AddForeignKey
+ALTER TABLE "feedback" ADD CONSTRAINT "feedback_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "feedback" ADD CONSTRAINT "feedback_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "Group"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ model User {
   accounts                      Account[]
   badges                        UserBadge[]
   adminAuditLogs                AdminAuditLog[]    @relation("AdminAuditLogActor")
+  feedbacks                     Feedback[]
 
   @@index([totalPoints])
   @@index([currentStreak])
@@ -82,6 +83,7 @@ model Group {
   joinRequests  GroupJoinRequest[]
   dailyProblems DailyProblem[]
   pointsHistory PointsHistory[]
+  feedbacks     Feedback[]
 
   @@index([type, isActive])
 }
@@ -443,6 +445,29 @@ enum SystemEventTargetType {
   USER
   GROUP
   SOLVE
+}
+
+model Feedback {
+  id          String           @id @default(cuid())
+  userId      String
+  groupId     String
+  category    FeedbackCategory
+  description String?
+  reviewed    Boolean          @default(false)
+  createdAt   DateTime         @default(now())
+
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  group Group @relation(fields: [groupId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, groupId])
+  @@index([groupId, reviewed])
+  @@map("feedback")
+}
+
+enum FeedbackCategory {
+  BUG
+  SUGGESTION
+  GENERAL
 }
 
 model FeatureFlag {

--- a/src/components/admin/admin-nav.tsx
+++ b/src/components/admin/admin-nav.tsx
@@ -6,6 +6,7 @@ import {
 	IconHistory,
 	IconInbox,
 	IconMail,
+	IconMessage,
 	IconSettings,
 	IconUsers,
 	IconUsersGroup,
@@ -20,6 +21,7 @@ export type AdminNavItem = {
 		| "/admin/groups"
 		| "/admin/join-requests"
 		| "/admin/problems"
+		| "/admin/feedbacks"
 		| "/admin/audit"
 		| "/admin/flags"
 		| "/admin/config"
@@ -62,6 +64,11 @@ export const ADMIN_NAV: AdminNavGroup[] = [
 				title: "Problems",
 				path: "/admin/problems",
 				icon: <IconBook className="size-4" />,
+			},
+			{
+				title: "Feedbacks",
+				path: "/admin/feedbacks",
+				icon: <IconMessage className="size-4" />,
 			},
 		],
 	},

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -17,7 +17,7 @@ const NAV_LINKS = [
 	{ to: "/dashboard", label: "Dashboard", icon: IconHome },
 	{ to: "/problems", label: "Problems", icon: IconCode },
 	{ to: "/groups", label: "Groups", icon: IconUsers },
-	// { to: "/leaderboard", label: "Leaderboard", icon: IconTrophy },
+	{ to: "/leaderboard", label: "Leaderboard", icon: IconTrophy },
 	{ to: "/badges", label: "Badges", icon: IconMedal },
 ] as const
 

--- a/src/features/groups/components/feedback-dialog.tsx
+++ b/src/features/groups/components/feedback-dialog.tsx
@@ -1,0 +1,130 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Controller, useForm } from "react-hook-form"
+import { sileo } from "sileo"
+
+import { Button } from "@/components/ui/button"
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog"
+import { Label } from "@/components/ui/label"
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import {
+	type FeedbackFormInput,
+	feedbackFormSchema,
+} from "@/server/feedback/feedback.type"
+import { useFeedbackPrompt } from "../hooks/use-feedback-prompt"
+import { useSubmitFeedback } from "../hooks/use-submit-feedback"
+
+const CATEGORY_LABELS: Record<string, string> = {
+	BUG: "Bug report",
+	SUGGESTION: "Suggestion",
+	GENERAL: "General",
+}
+
+export const FeedbackDialog = ({ groupId }: { groupId: string }) => {
+	const { data } = useFeedbackPrompt(groupId)
+	const submitFeedback = useSubmitFeedback()
+
+	const form = useForm<FeedbackFormInput>({
+		resolver: zodResolver(feedbackFormSchema),
+		defaultValues: { groupId, category: undefined, description: "" },
+	})
+	const { register, handleSubmit, control, formState, reset } = form
+	const isPending = submitFeedback.isPending
+
+	const onSubmit = handleSubmit(async (values) => {
+		await sileo.promise(submitFeedback.mutateAsync(values), {
+			loading: { title: "Sending feedback..." },
+			success: {
+				title: "Feedback sent!",
+				description: "Thank you for helping improve the group.",
+			},
+			error: () => ({
+				title: "Couldn't send feedback",
+				description: "Please try again.",
+			}),
+		})
+		reset()
+	})
+
+	return (
+		<Dialog open={!!data?.shouldShow}>
+			<DialogContent
+				className="sm:max-w-md"
+				onInteractOutside={(e) => e.preventDefault()}
+			>
+				<DialogHeader>
+					<DialogTitle>How's this group going?</DialogTitle>
+					<DialogDescription>
+						Quick feedback helps us improve the experience for everyone.
+					</DialogDescription>
+				</DialogHeader>
+
+				<form onSubmit={onSubmit} className="flex flex-col gap-4 pt-1">
+					<div className="grid gap-1.5">
+						<Label htmlFor="category">Category</Label>
+						<Controller
+							control={control}
+							name="category"
+							render={({ field }) => (
+								<Select
+									value={field.value}
+									onValueChange={field.onChange}
+									disabled={isPending}
+								>
+									<SelectTrigger id="category" className="w-full">
+										<SelectValue placeholder="Select a category" />
+									</SelectTrigger>
+									<SelectContent>
+										{Object.entries(CATEGORY_LABELS).map(([value, label]) => (
+											<SelectItem key={value} value={value}>
+												{label}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							)}
+						/>
+						{formState.errors.category && (
+							<p className="text-destructive text-xs">
+								{formState.errors.category.message}
+							</p>
+						)}
+					</div>
+
+					<div className="grid gap-1.5">
+						<Label htmlFor="description">
+							Description{" "}
+							<span className="text-muted-foreground text-xs">(optional)</span>
+						</Label>
+						<Textarea
+							id="description"
+							{...register("description")}
+							disabled={isPending}
+							placeholder="Tell us more..."
+							rows={3}
+							maxLength={1000}
+						/>
+					</div>
+
+					<div className="flex justify-end gap-2">
+						<Button type="submit" size="sm" disabled={isPending}>
+							Send feedback
+						</Button>
+					</div>
+				</form>
+			</DialogContent>
+		</Dialog>
+	)
+}

--- a/src/features/groups/components/group-layout.tsx
+++ b/src/features/groups/components/group-layout.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Route as GroupRoute } from "@/routes/groups_/$groupId"
 import type { GroupProblemsRange } from "@/server/groups/groups.type"
 import { useGroup } from "../hooks/use-group"
+import { FeedbackDialog } from "./feedback-dialog"
 import { GroupProblemsTabs } from "./group-problems-tabs"
 
 export const GroupLayout = () => {
@@ -46,6 +47,7 @@ export const GroupLayout = () => {
 
 	return (
 		<div className="flex h-full flex-col gap-4">
+			<FeedbackDialog groupId={group.id} />
 			<div className="shrink-0">
 				<Link
 					className="flex w-fit items-center gap-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground"

--- a/src/features/groups/components/group-problems-header-cell.tsx
+++ b/src/features/groups/components/group-problems-header-cell.tsx
@@ -1,3 +1,5 @@
+import { Link } from "@tanstack/react-router"
+
 import { HashAvatar } from "@/features/onboarding/components/hash-avatar"
 import { cn } from "@/lib/utils"
 import type { GroupProblemsMember } from "@/server/groups/groups.type"
@@ -10,13 +12,8 @@ export const GroupProblemsHeaderCell = ({
 	isCurrentUser: boolean
 }) => {
 	const label = member.username ?? member.name
-	return (
-		<div
-			className={cn(
-				"relative flex h-full w-full flex-col items-center gap-2 py-2",
-				isCurrentUser && "ring-2 ring-primary/60 ring-inset"
-			)}
-		>
+	const inner = (
+		<>
 			<div className="relative">
 				<HashAvatar username={label} size={28} shape="circle" />
 			</div>
@@ -30,6 +27,30 @@ export const GroupProblemsHeaderCell = ({
 			<div className="text-[10px] text-muted-foreground tabular-nums">
 				{member.solvedInRange}/{member.totalAssignedInRange}
 			</div>
-		</div>
+		</>
 	)
+
+	const containerClass = cn(
+		"relative flex h-full w-full flex-col items-center gap-2 py-2",
+		isCurrentUser && "ring-2 ring-primary/60 ring-inset"
+	)
+
+	if (member.username) {
+		return (
+			<Link
+				to="/$username"
+				params={{ username: member.username }}
+				target="_blank"
+				rel="noreferrer"
+				className={cn(
+					containerClass,
+					"cursor-pointer transition-colors hover:bg-muted/50"
+				)}
+			>
+				{inner}
+			</Link>
+		)
+	}
+
+	return <div className={containerClass}>{inner}</div>
 }

--- a/src/features/groups/hooks/use-feedback-prompt.ts
+++ b/src/features/groups/hooks/use-feedback-prompt.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { api } from "@/lib/api"
+
+export const useFeedbackPrompt = (groupId: string) =>
+	useQuery({
+		queryKey: ["feedback", "prompt", groupId],
+		queryFn: async () => {
+			const { data, error } = await api.v3.feedbacks.prompt.get({ query: { groupId } })
+			if (error) throw new Error("Failed to check feedback prompt")
+			return data
+		},
+		staleTime: Number.POSITIVE_INFINITY,
+	})

--- a/src/features/groups/hooks/use-submit-feedback.ts
+++ b/src/features/groups/hooks/use-submit-feedback.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { api } from "@/lib/api"
+import type { FeedbackFormInput } from "@/server/feedback/feedback.type"
+
+export const useSubmitFeedback = () => {
+	const queryClient = useQueryClient()
+	return useMutation({
+		mutationFn: async (input: FeedbackFormInput) => {
+			const { data, error } = await api.v3.feedbacks.post({
+				groupId: input.groupId,
+				category: input.category,
+				description: input.description ?? null,
+			})
+			if (error) throw new Error("Failed to submit feedback")
+			return data
+		},
+		onSuccess: (_, { groupId }) => {
+			queryClient.invalidateQueries({ queryKey: ["feedback", "prompt", groupId] })
+		},
+	})
+}

--- a/src/features/leaderboard/components/leaderboard-page.tsx
+++ b/src/features/leaderboard/components/leaderboard-page.tsx
@@ -1,0 +1,282 @@
+import { IconLock, IconTrophy } from "@tabler/icons-react"
+import { Link, useNavigate, useSearch } from "@tanstack/react-router"
+import { useCallback } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useMe } from "@/features/settings/hooks/use-me"
+import { cn } from "@/lib/utils"
+import { useGlobalLeaderboard } from "../hooks/use-global-leaderboard"
+import { useGroupLeaderboard } from "../hooks/use-group-leaderboard"
+import { useMyGroups } from "../hooks/use-my-groups"
+import { type LeaderboardMode, type LeaderboardPeriod, PERIODS } from "../types"
+import { LeaderboardTable } from "./leaderboard-table"
+
+// ─── Mode toggle (Group / Global) ─────────────────────────────────────────────
+
+const ModeToggle = ({
+	mode,
+	onChange,
+}: {
+	mode: LeaderboardMode
+	onChange: (m: LeaderboardMode) => void
+}) => (
+	<Tabs
+		value={mode}
+		onValueChange={(v) => {
+			if (v === "group" || v === "global") onChange(v)
+		}}
+	>
+		<TabsList variant="ghost">
+			<TabsTrigger value="group">Group</TabsTrigger>
+			<TabsTrigger value="global">Global</TabsTrigger>
+		</TabsList>
+	</Tabs>
+)
+
+// ─── Period tabs (Week / Month / All-time) ─────────────────────────────────────
+
+const PeriodTabs = ({
+	period,
+	onChange,
+}: {
+	period: LeaderboardPeriod
+	onChange: (p: LeaderboardPeriod) => void
+}) => (
+	<Tabs
+		value={period}
+		onValueChange={(v) => {
+			const next = PERIODS.find((p) => p.value === v)?.value
+			if (next) onChange(next)
+		}}
+	>
+		<TabsList variant="ghost">
+			{PERIODS.map((p) => (
+				<TabsTrigger key={p.value} value={p.value}>
+					{p.label}
+				</TabsTrigger>
+			))}
+		</TabsList>
+	</Tabs>
+)
+
+// ─── Group selector ────────────────────────────────────────────────────────────
+
+const GroupSelector = ({
+	groups,
+	activeGroupId,
+	onSelect,
+}: {
+	groups: { id: string; slug: string }[]
+	activeGroupId: string | undefined
+	onSelect: (id: string) => void
+}) => {
+	if (groups.length <= 1) return null
+	return (
+		<div className="flex flex-wrap gap-2">
+			{groups.map((g) => (
+				<button
+					key={g.id}
+					type="button"
+					onClick={() => onSelect(g.id)}
+					className={cn(
+						"rounded-full border px-3 py-1 font-medium text-xs transition-colors",
+						activeGroupId === g.id
+							? "border-primary bg-primary/10 text-primary"
+							: "border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground"
+					)}
+				>
+					{g.slug}
+				</button>
+			))}
+		</div>
+	)
+}
+
+// ─── Pro gate ─────────────────────────────────────────────────────────────────
+
+const ProGate = () => (
+	<div className="flex flex-col items-center gap-4 rounded-xl border border-border bg-background p-12 text-center">
+		<div className="flex size-12 items-center justify-center rounded-full bg-muted">
+			<IconLock className="size-5 text-muted-foreground" />
+		</div>
+		<div>
+			<p className="font-semibold text-base">Global Leaderboard is Pro only</p>
+			<p className="mt-1 text-muted-foreground text-sm">
+				Upgrade to Pro to see the top 100 solvers worldwide.
+			</p>
+		</div>
+		<Button asChild size="sm">
+			<Link to="/settings/account">Upgrade to Pro</Link>
+		</Button>
+	</div>
+)
+
+// ─── No group state ───────────────────────────────────────────────────────────
+
+const NoGroupState = () => (
+	<div className="rounded-xl border border-border bg-background p-8 text-center">
+		<IconTrophy className="mx-auto mb-3 size-8 text-muted-foreground" />
+		<p className="font-medium text-sm">You're not in any group yet.</p>
+		<p className="mt-1 text-muted-foreground text-sm">
+			Join a group to see its leaderboard.
+		</p>
+		<Button asChild className="mt-4" size="sm">
+			<Link to="/groups">Browse groups</Link>
+		</Button>
+	</div>
+)
+
+// ─── Group leaderboard section ────────────────────────────────────────────────
+
+const GroupLeaderboardSection = ({
+	groups,
+	period,
+	activeGroupId,
+	onGroupChange,
+	viewerUserId,
+}: {
+	groups: { id: string; slug: string }[]
+	period: LeaderboardPeriod
+	activeGroupId: string | undefined
+	onGroupChange: (id: string) => void
+	viewerUserId: string | null | undefined
+}) => {
+	const { data, isLoading } = useGroupLeaderboard(activeGroupId, period)
+
+	if (groups.length === 0) return <NoGroupState />
+
+	return (
+		<div className="flex flex-col gap-4">
+			<GroupSelector
+				groups={groups}
+				activeGroupId={activeGroupId}
+				onSelect={onGroupChange}
+			/>
+			<LeaderboardTable
+				entries={data?.entries ?? []}
+				viewerUserId={viewerUserId}
+				isLoading={isLoading}
+			/>
+		</div>
+	)
+}
+
+// ─── Global leaderboard section ───────────────────────────────────────────────
+
+const GlobalLeaderboardSection = ({
+	period,
+	isPro,
+	viewerUserId,
+}: {
+	period: LeaderboardPeriod
+	isPro: boolean
+	viewerUserId: string | null | undefined
+}) => {
+	const { data, isLoading } = useGlobalLeaderboard(period, isPro)
+
+	if (!isPro) return <ProGate />
+
+	return (
+		<LeaderboardTable
+			entries={data?.entries ?? []}
+			viewerUserId={viewerUserId}
+			isLoading={isLoading}
+		/>
+	)
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+type LeaderboardSearch = {
+	mode?: LeaderboardMode
+	period?: LeaderboardPeriod
+	groupId?: string
+}
+
+export const LeaderboardPage = () => {
+	const navigate = useNavigate({ from: "/leaderboard" })
+	const search = useSearch({ from: "/leaderboard" }) as LeaderboardSearch
+
+	const mode: LeaderboardMode = search.mode ?? "group"
+	const period: LeaderboardPeriod = search.period ?? "week"
+
+	const meQuery = useMe()
+	const groupsQuery = useMyGroups()
+
+	const groups = groupsQuery.data ?? []
+	const activeGroupId = search.groupId ?? (groups.length > 0 ? groups[0]?.id : undefined)
+
+	const setMode = useCallback(
+		(m: LeaderboardMode) => {
+			navigate({ search: (prev: LeaderboardSearch) => ({ ...prev, mode: m }) })
+		},
+		[navigate]
+	)
+
+	const setPeriod = useCallback(
+		(p: LeaderboardPeriod) => {
+			navigate({ search: (prev: LeaderboardSearch) => ({ ...prev, period: p }) })
+		},
+		[navigate]
+	)
+
+	const setGroupId = useCallback(
+		(id: string) => {
+			navigate({ search: (prev: LeaderboardSearch) => ({ ...prev, groupId: id }) })
+		},
+		[navigate]
+	)
+
+	const me = meQuery.data
+	const viewerUserId = me?.id
+
+	// Subtitle for group view
+	const activeGroup = groups.find((g) => g.id === activeGroupId)
+	const groupData = useGroupLeaderboard(activeGroupId, period)
+	const memberCount = groupData.data?.memberCount
+
+	const subtitle =
+		mode === "group" && activeGroup
+			? [period, "group", memberCount !== undefined ? `${memberCount} members` : null]
+					.filter(Boolean)
+					.join(" · ")
+			: mode === "global"
+				? `${period} · global · top 100`
+				: null
+
+	return (
+		<div className="mx-auto flex max-w-2xl flex-col gap-6">
+			{/* Header */}
+			<div className="flex items-start justify-between gap-4">
+				<div>
+					<h1 className="font-bold text-3xl tracking-tight">Leaderboard</h1>
+					{subtitle && <p className="mt-1 text-muted-foreground text-sm">{subtitle}</p>}
+					{groupsQuery.isLoading && <Skeleton className="mt-1 h-4 w-40" />}
+				</div>
+				<ModeToggle mode={mode} onChange={setMode} />
+			</div>
+
+			{/* Period tabs */}
+			<PeriodTabs period={period} onChange={setPeriod} />
+
+			{/* Content */}
+			{mode === "group" ? (
+				<GroupLeaderboardSection
+					groups={groups}
+					period={period}
+					activeGroupId={activeGroupId}
+					onGroupChange={setGroupId}
+					viewerUserId={viewerUserId}
+				/>
+			) : (
+				<GlobalLeaderboardSection
+					period={period}
+					isPro={me?.isPro ?? false}
+					viewerUserId={viewerUserId}
+				/>
+			)}
+		</div>
+	)
+}

--- a/src/features/leaderboard/components/leaderboard-row.tsx
+++ b/src/features/leaderboard/components/leaderboard-row.tsx
@@ -1,0 +1,81 @@
+import { IconFlame } from "@tabler/icons-react"
+
+import { HashAvatar } from "@/features/onboarding/components/hash-avatar"
+import { cn } from "@/lib/utils"
+import type { LeaderboardEntry } from "@/server/leaderboard/leaderboard.type"
+
+export const LeaderboardRow = ({
+	entry,
+	isViewer,
+	topScore,
+}: {
+	entry: LeaderboardEntry
+	isViewer: boolean
+	topScore: number
+}) => {
+	const barWidth = topScore > 0 ? Math.round((entry.periodPoints / topScore) * 100) : 0
+	const displayName = entry.username ?? entry.name
+
+	return (
+		<div
+			className={cn(
+				"group relative flex items-center gap-3 rounded-lg px-3 py-3 transition-colors",
+				isViewer ? "bg-primary/10 ring-1 ring-primary/30" : "hover:bg-muted/40"
+			)}
+		>
+			{/* Rank */}
+			<span className="w-10 shrink-0 font-mono text-muted-foreground text-sm tabular-nums">
+				#{String(entry.rank).padStart(2, "0")}
+			</span>
+
+			{/* Avatar */}
+			<div className="shrink-0">
+				<HashAvatar username={displayName} size={36} />
+			</div>
+
+			{/* Name + score bar */}
+			<div className="min-w-0 flex-1">
+				<div className="flex items-center gap-1.5">
+					<span className="truncate font-medium text-sm leading-none">{displayName}</span>
+					{entry.isPro && (
+						<span className="rounded bg-primary/15 px-1 py-0.5 font-mono text-[10px] text-primary leading-none">
+							pro
+						</span>
+					)}
+					{isViewer && (
+						<span className="text-[10px] text-muted-foreground leading-none">(you)</span>
+					)}
+				</div>
+				{/* Score bar */}
+				<div className="mt-1.5 h-0.5 w-full overflow-hidden rounded-full bg-border">
+					<div
+						className="h-full rounded-full bg-primary transition-all duration-500"
+						style={{ width: `${barWidth}%` }}
+					/>
+				</div>
+			</div>
+
+			{/* Points */}
+			<span
+				className={cn(
+					"w-20 shrink-0 text-right font-semibold text-sm tabular-nums",
+					isViewer ? "text-foreground" : "text-primary"
+				)}
+			>
+				{entry.periodPoints.toLocaleString()}
+			</span>
+
+			{/* Streak */}
+			<div className="flex w-16 shrink-0 items-center justify-end gap-1 text-sm tabular-nums">
+				{entry.currentStreak > 0 ? (
+					<>
+						<IconFlame className="size-4 text-orange-400" />
+						<span>{entry.currentStreak}d</span>
+					</>
+				) : (
+					<span className="text-muted-foreground">—</span>
+				)}
+			</div>
+		</div>
+	)
+}

--- a/src/features/leaderboard/components/leaderboard-table.tsx
+++ b/src/features/leaderboard/components/leaderboard-table.tsx
@@ -1,0 +1,64 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import type { LeaderboardEntry } from "@/server/leaderboard/leaderboard.type"
+import { LeaderboardRow } from "./leaderboard-row"
+
+const ColumnHeaders = () => (
+	<div className="flex items-center gap-3 px-3 pb-2">
+		<span className="w-10 shrink-0 font-mono text-[10px] text-muted-foreground uppercase tracking-widest">
+			RNK
+		</span>
+		<span className="w-9 shrink-0" />
+		<span className="flex-1 font-mono text-[10px] text-muted-foreground uppercase tracking-widest">
+			User · Score
+		</span>
+		<span className="w-20 shrink-0 text-right font-mono text-[10px] text-muted-foreground uppercase tracking-widest" />
+		<span className="w-16 shrink-0 text-right font-mono text-[10px] text-muted-foreground uppercase tracking-widest">
+			Streak
+		</span>
+	</div>
+)
+
+export const LeaderboardTable = ({
+	entries,
+	viewerUserId,
+	isLoading,
+}: {
+	entries: LeaderboardEntry[]
+	viewerUserId: string | null | undefined
+	isLoading: boolean
+}) => {
+	if (isLoading) {
+		return (
+			<div className="flex flex-col gap-1">
+				<ColumnHeaders />
+				{["a", "b", "c", "d", "e", "f", "g", "h"].map((k) => (
+					<Skeleton key={k} className="h-14 w-full rounded-lg" />
+				))}
+			</div>
+		)
+	}
+
+	if (entries.length === 0) {
+		return (
+			<div className="rounded-lg border border-border bg-background p-8 text-center">
+				<p className="text-muted-foreground text-sm">No entries yet for this period.</p>
+			</div>
+		)
+	}
+
+	const topScore = entries[0]?.periodPoints ?? 1
+
+	return (
+		<div className="flex flex-col gap-1">
+			<ColumnHeaders />
+			{entries.map((entry) => (
+				<LeaderboardRow
+					key={entry.userId}
+					entry={entry}
+					isViewer={entry.userId === viewerUserId}
+					topScore={topScore}
+				/>
+			))}
+		</div>
+	)
+}

--- a/src/features/leaderboard/hooks/use-global-leaderboard.ts
+++ b/src/features/leaderboard/hooks/use-global-leaderboard.ts
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { api } from "@/lib/api"
+import type { LeaderboardPeriod } from "../types"
+
+export const globalLeaderboardQueryKey = (period: LeaderboardPeriod) =>
+	["leaderboard", "global", period] as const
+
+export const useGlobalLeaderboard = (period: LeaderboardPeriod, enabled: boolean) =>
+	useQuery({
+		queryKey: globalLeaderboardQueryKey(period),
+		queryFn: async () => {
+			const { data, error } = await api.v3.leaderboard.global.get({
+				query: { period },
+			})
+			if (error) {
+				if (
+					typeof error === "object" &&
+					error !== null &&
+					"status" in error &&
+					error.status === 403
+				) {
+					throw Object.assign(new Error("Pro required"), { code: "PRO_REQUIRED" })
+				}
+				throw new Error("Failed to load global leaderboard")
+			}
+			return data
+		},
+		enabled,
+		staleTime: 1000 * 60,
+	})

--- a/src/features/leaderboard/hooks/use-group-leaderboard.ts
+++ b/src/features/leaderboard/hooks/use-group-leaderboard.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { api } from "@/lib/api"
+import type { LeaderboardPeriod } from "../types"
+
+export const groupLeaderboardQueryKey = (groupId: string, period: LeaderboardPeriod) =>
+	["leaderboard", "group", groupId, period] as const
+
+export const useGroupLeaderboard = (
+	groupId: string | undefined,
+	period: LeaderboardPeriod
+) =>
+	useQuery({
+		queryKey: groupId
+			? groupLeaderboardQueryKey(groupId, period)
+			: ["leaderboard", "group", "none"],
+		queryFn: async () => {
+			if (!groupId) return null
+			const { data, error } = await api.v3.leaderboard.groups({ id: groupId }).get({
+				query: { period },
+			})
+			if (error) throw new Error("Failed to load group leaderboard")
+			return data
+		},
+		enabled: !!groupId,
+		staleTime: 1000 * 60,
+	})

--- a/src/features/leaderboard/hooks/use-my-groups.ts
+++ b/src/features/leaderboard/hooks/use-my-groups.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { api } from "@/lib/api"
+
+export const myGroupsQueryKey = ["leaderboard", "my-groups"] as const
+
+export const useMyGroups = () =>
+	useQuery({
+		queryKey: myGroupsQueryKey,
+		queryFn: async () => {
+			const { data, error } = await api.v3.leaderboard["my-groups"].get()
+			if (error) throw new Error("Failed to load your groups")
+			return data
+		},
+		staleTime: 1000 * 60 * 5,
+	})

--- a/src/features/leaderboard/types.ts
+++ b/src/features/leaderboard/types.ts
@@ -1,0 +1,11 @@
+import type { LeaderboardPeriod } from "@/server/leaderboard/leaderboard.type"
+
+export type LeaderboardMode = "group" | "global"
+
+export type { LeaderboardPeriod }
+
+export const PERIODS: { value: LeaderboardPeriod; label: string }[] = [
+	{ value: "week", label: "Week" },
+	{ value: "month", label: "Month" },
+	{ value: "alltime", label: "All-time" },
+]

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -34,6 +34,7 @@ import { Route as AuthenticatedAppDashboardRouteImport } from './routes/_authent
 import { Route as AdminAdminProblemsRouteImport } from './routes/_admin/admin/problems'
 import { Route as AdminAdminJoinRequestsRouteImport } from './routes/_admin/admin/join-requests'
 import { Route as AdminAdminFlagsRouteImport } from './routes/_admin/admin/flags'
+import { Route as AdminAdminFeedbacksRouteImport } from './routes/_admin/admin/feedbacks'
 import { Route as AdminAdminEmailsRouteImport } from './routes/_admin/admin/emails'
 import { Route as AdminAdminConfigRouteImport } from './routes/_admin/admin/config'
 import { Route as AdminAdminAuditRouteImport } from './routes/_admin/admin/audit'
@@ -175,6 +176,11 @@ const AdminAdminFlagsRoute = AdminAdminFlagsRouteImport.update({
   path: '/admin/flags',
   getParentRoute: () => AdminRoute,
 } as any)
+const AdminAdminFeedbacksRoute = AdminAdminFeedbacksRouteImport.update({
+  id: '/admin/feedbacks',
+  path: '/admin/feedbacks',
+  getParentRoute: () => AdminRoute,
+} as any)
 const AdminAdminEmailsRoute = AdminAdminEmailsRouteImport.update({
   id: '/admin/emails',
   path: '/admin/emails',
@@ -281,6 +287,7 @@ export interface FileRoutesByFullPath {
   '/admin/audit': typeof AdminAdminAuditRoute
   '/admin/config': typeof AdminAdminConfigRoute
   '/admin/emails': typeof AdminAdminEmailsRoute
+  '/admin/feedbacks': typeof AdminAdminFeedbacksRoute
   '/admin/flags': typeof AdminAdminFlagsRoute
   '/admin/join-requests': typeof AdminAdminJoinRequestsRoute
   '/admin/problems': typeof AdminAdminProblemsRoute
@@ -319,6 +326,7 @@ export interface FileRoutesByTo {
   '/admin/audit': typeof AdminAdminAuditRoute
   '/admin/config': typeof AdminAdminConfigRoute
   '/admin/emails': typeof AdminAdminEmailsRoute
+  '/admin/feedbacks': typeof AdminAdminFeedbacksRoute
   '/admin/flags': typeof AdminAdminFlagsRoute
   '/admin/join-requests': typeof AdminAdminJoinRequestsRoute
   '/admin/problems': typeof AdminAdminProblemsRoute
@@ -361,6 +369,7 @@ export interface FileRoutesById {
   '/_admin/admin/audit': typeof AdminAdminAuditRoute
   '/_admin/admin/config': typeof AdminAdminConfigRoute
   '/_admin/admin/emails': typeof AdminAdminEmailsRoute
+  '/_admin/admin/feedbacks': typeof AdminAdminFeedbacksRoute
   '/_admin/admin/flags': typeof AdminAdminFlagsRoute
   '/_admin/admin/join-requests': typeof AdminAdminJoinRequestsRoute
   '/_admin/admin/problems': typeof AdminAdminProblemsRoute
@@ -402,6 +411,7 @@ export interface FileRouteTypes {
     | '/admin/audit'
     | '/admin/config'
     | '/admin/emails'
+    | '/admin/feedbacks'
     | '/admin/flags'
     | '/admin/join-requests'
     | '/admin/problems'
@@ -440,6 +450,7 @@ export interface FileRouteTypes {
     | '/admin/audit'
     | '/admin/config'
     | '/admin/emails'
+    | '/admin/feedbacks'
     | '/admin/flags'
     | '/admin/join-requests'
     | '/admin/problems'
@@ -481,6 +492,7 @@ export interface FileRouteTypes {
     | '/_admin/admin/audit'
     | '/_admin/admin/config'
     | '/_admin/admin/emails'
+    | '/_admin/admin/feedbacks'
     | '/_admin/admin/flags'
     | '/_admin/admin/join-requests'
     | '/_admin/admin/problems'
@@ -699,6 +711,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AdminAdminFlagsRouteImport
       parentRoute: typeof AdminRoute
     }
+    '/_admin/admin/feedbacks': {
+      id: '/_admin/admin/feedbacks'
+      path: '/admin/feedbacks'
+      fullPath: '/admin/feedbacks'
+      preLoaderRoute: typeof AdminAdminFeedbacksRouteImport
+      parentRoute: typeof AdminRoute
+    }
     '/_admin/admin/emails': {
       id: '/_admin/admin/emails'
       path: '/admin/emails'
@@ -839,6 +858,7 @@ interface AdminRouteChildren {
   AdminAdminAuditRoute: typeof AdminAdminAuditRoute
   AdminAdminConfigRoute: typeof AdminAdminConfigRoute
   AdminAdminEmailsRoute: typeof AdminAdminEmailsRoute
+  AdminAdminFeedbacksRoute: typeof AdminAdminFeedbacksRoute
   AdminAdminFlagsRoute: typeof AdminAdminFlagsRoute
   AdminAdminJoinRequestsRoute: typeof AdminAdminJoinRequestsRoute
   AdminAdminProblemsRoute: typeof AdminAdminProblemsRoute
@@ -853,6 +873,7 @@ const AdminRouteChildren: AdminRouteChildren = {
   AdminAdminAuditRoute: AdminAdminAuditRoute,
   AdminAdminConfigRoute: AdminAdminConfigRoute,
   AdminAdminEmailsRoute: AdminAdminEmailsRoute,
+  AdminAdminFeedbacksRoute: AdminAdminFeedbacksRoute,
   AdminAdminFlagsRoute: AdminAdminFlagsRoute,
   AdminAdminJoinRequestsRoute: AdminAdminJoinRequestsRoute,
   AdminAdminProblemsRoute: AdminAdminProblemsRoute,

--- a/src/routes/_admin/admin/feedbacks.tsx
+++ b/src/routes/_admin/admin/feedbacks.tsx
@@ -1,0 +1,202 @@
+import { IconExternalLink } from "@tabler/icons-react"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table"
+import { AdminEmpty } from "@/features/admin/components/admin-empty"
+import { AdminPageHeader } from "@/features/admin/components/admin-page-header"
+import { api } from "@/lib/api"
+
+const GITHUB_REPO = "husamahmud/pstrack"
+
+const searchSchema = z.object({
+	groupId: z.string().optional(),
+	reviewed: z.boolean().optional(),
+})
+
+export const Route = createFileRoute("/_admin/admin/feedbacks")({
+	validateSearch: searchSchema,
+	component: AdminFeedbacksPage,
+})
+
+function githubIssueUrl(
+	category: string,
+	description: string | null,
+	groupSlug: string,
+	username: string | null
+) {
+	const title = `Feedback [${category}] from @${username ?? "unknown"} in @${groupSlug}`
+	const body = [
+		`**Category:** ${category}`,
+		`**Group:** @${groupSlug}`,
+		`**User:** @${username ?? "unknown"}`,
+		description ? `\n**Description:**\n${description}` : "",
+	]
+		.filter(Boolean)
+		.join("\n")
+	return `https://github.com/${GITHUB_REPO}/issues/new?${new URLSearchParams({ title, body }).toString()}`
+}
+
+function AdminFeedbacksPage() {
+	const search = Route.useSearch()
+	const queryClient = useQueryClient()
+
+	const { data, isLoading } = useQuery({
+		queryKey: ["admin", "feedbacks", search],
+		queryFn: async () => {
+			const { data, error } = await api.v3.feedbacks.get({
+				query: {
+					...(search.groupId ? { groupId: search.groupId } : {}),
+					...(search.reviewed !== undefined ? { reviewed: search.reviewed } : {}),
+				},
+			})
+			if (error) throw new Error("Failed to load feedbacks")
+			return data
+		},
+	})
+
+	const markReviewed = useMutation({
+		mutationFn: async ({ id, reviewed }: { id: string; reviewed: boolean }) => {
+			const { data, error } = await api.v3.feedbacks({ id }).reviewed.patch({ reviewed })
+			if (error) throw new Error("Failed to update feedback")
+			return data
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["admin", "feedbacks"] })
+		},
+	})
+
+	const items = data ?? []
+
+	return (
+		<>
+			<AdminPageHeader
+				title="Feedbacks"
+				description="Group member feedback — review and escalate to GitHub issues."
+			/>
+
+			<div className="mb-4 flex gap-2">
+				{(["all", "pending", "reviewed"] as const).map((filter) => {
+					const active =
+						filter === "all"
+							? search.reviewed === undefined
+							: filter === "reviewed"
+								? search.reviewed === true
+								: search.reviewed === false
+					const href =
+						filter === "all"
+							? "?"
+							: `?${new URLSearchParams({ reviewed: String(filter === "reviewed") }).toString()}`
+					return (
+						<a key={filter} href={href}>
+							<Badge
+								variant={active ? "default" : "outline"}
+								className="cursor-pointer capitalize"
+							>
+								{filter}
+							</Badge>
+						</a>
+					)
+				})}
+			</div>
+
+			{isLoading ? (
+				<Skeleton className="h-96 w-full" />
+			) : items.length === 0 ? (
+				<AdminEmpty
+					title="No feedbacks yet"
+					description="Feedbacks submitted by group members will appear here."
+				/>
+			) : (
+				<div className="rounded-lg border bg-card">
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead className="whitespace-nowrap">When</TableHead>
+								<TableHead>User</TableHead>
+								<TableHead>Group</TableHead>
+								<TableHead>Category</TableHead>
+								<TableHead>Description</TableHead>
+								<TableHead>Status</TableHead>
+								<TableHead className="text-right">Actions</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{items.map((row) => (
+								<TableRow
+									key={row.id}
+									className={row.reviewed ? "opacity-50" : undefined}
+								>
+									<TableCell className="whitespace-nowrap text-muted-foreground text-xs">
+										{new Date(row.createdAt).toLocaleString()}
+									</TableCell>
+									<TableCell className="font-medium">
+										@{row.user.username ?? row.user.name}
+									</TableCell>
+									<TableCell>@{row.group.slug}</TableCell>
+									<TableCell>
+										<Badge variant="secondary" className="capitalize">
+											{row.category.toLowerCase()}
+										</Badge>
+									</TableCell>
+									<TableCell className="max-w-xs">
+										<p className="truncate text-muted-foreground text-sm">
+											{row.description ?? "—"}
+										</p>
+									</TableCell>
+									<TableCell>
+										{row.reviewed ? (
+											<Badge variant="outline">reviewed</Badge>
+										) : (
+											<Badge variant="default">pending</Badge>
+										)}
+									</TableCell>
+									<TableCell className="text-right">
+										<div className="flex items-center justify-end gap-2">
+											<Button
+												variant="ghost"
+												size="sm"
+												disabled={markReviewed.isPending}
+												onClick={() =>
+													markReviewed.mutate({ id: row.id, reviewed: !row.reviewed })
+												}
+											>
+												{row.reviewed ? "Unmark" : "Mark reviewed"}
+											</Button>
+											<Button variant="outline" size="sm" asChild>
+												<a
+													href={githubIssueUrl(
+														row.category,
+														row.description ?? null,
+														row.group.slug,
+														row.user.username ?? null
+													)}
+													target="_blank"
+													rel="noopener noreferrer"
+												>
+													<IconExternalLink className="mr-1.5 size-3.5" />
+													GH issue
+												</a>
+											</Button>
+										</div>
+									</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+				</div>
+			)}
+		</>
+	)
+}

--- a/src/routes/leaderboard.tsx
+++ b/src/routes/leaderboard.tsx
@@ -1,11 +1,33 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { z } from "zod"
 
 import { AppHeader } from "@/components/app-header"
+import { RouteErrorFallback } from "@/components/route-error-fallback"
+import { LeaderboardPage } from "@/features/leaderboard/components/leaderboard-page"
 import { createSeoHead } from "@/lib/seo"
+
+const searchSchema = z.object({
+	mode: z.enum(["group", "global"]).optional(),
+	period: z.enum(["week", "month", "alltime"]).optional(),
+	groupId: z.string().optional(),
+})
 
 export const Route = createFileRoute("/leaderboard")({
 	ssr: false,
-	component: LeaderboardPage,
+	validateSearch: searchSchema,
+	component: LeaderboardRouteComponent,
+	errorComponent: ({ error, reset }) => (
+		<div className="flex h-screen flex-col">
+			<AppHeader />
+			<main className="mx-auto min-h-0 w-full flex-1 overflow-y-auto px-8 pt-8 pb-4">
+				<RouteErrorFallback
+					error={error}
+					reset={reset}
+					title="Could not load the leaderboard"
+				/>
+			</main>
+		</div>
+	),
 	head: () =>
 		createSeoHead({
 			title: "Global LeetCode Leaderboard",
@@ -16,12 +38,12 @@ export const Route = createFileRoute("/leaderboard")({
 		}),
 })
 
-function LeaderboardPage() {
+function LeaderboardRouteComponent() {
 	return (
 		<div className="flex h-screen flex-col">
 			<AppHeader />
 			<main className="mx-auto min-h-0 w-full flex-1 overflow-y-auto px-8 pt-8 pb-4">
-				<div>Leaderboard</div>
+				<LeaderboardPage />
 			</main>
 		</div>
 	)

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -3,8 +3,10 @@ import { Elysia } from "elysia"
 import { adminController } from "@/server/admin/admin.controller"
 import { authController } from "@/server/auth/auth.controller"
 import { badgesController } from "@/server/badges/badges.controller"
+import { feedbackController } from "@/server/feedback/feedback.controller"
 import { groupsAdminController } from "@/server/groups/groups.admin.controller"
 import { groupsController } from "@/server/groups/groups.controller"
+import { leaderboardController } from "@/server/leaderboard/leaderboard.controller"
 import { auth } from "@/server/lib/auth"
 import {
 	captureServerException,
@@ -31,6 +33,8 @@ const api = new Elysia({ prefix: "/api/v3" })
 	.use(groupsController)
 	.use(problemsController)
 	.use(badgesController)
+	.use(feedbackController)
+	.use(leaderboardController)
 	.use(adminController)
 	.use(usersAdminController)
 	.use(groupsAdminController)

--- a/src/server/feedback/feedback.controller.ts
+++ b/src/server/feedback/feedback.controller.ts
@@ -1,0 +1,57 @@
+import { Elysia, status } from "elysia"
+
+import { requirePlatformAdmin, requireSessionUser } from "@/server/lib/session"
+import { feedbackDao } from "./feedback.dao"
+import { feedbackModel } from "./feedback.model"
+
+export const feedbackController = new Elysia({ prefix: "/feedbacks", tags: ["Feedback"] })
+	.use(feedbackModel)
+	.get(
+		"/prompt",
+		async ({ request, query }) => {
+			const { user, response } = await requireSessionUser(request)
+			if (!user) return response
+			return feedbackDao.shouldShowPrompt(user.id, query.groupId)
+		},
+		{ query: "feedback.promptQuery" }
+	)
+	.post(
+		"/",
+		async ({ request, body }) => {
+			const { user, response } = await requireSessionUser(request)
+			if (!user) return response
+			try {
+				return await feedbackDao.submit(
+					user.id,
+					body.groupId,
+					body.category,
+					body.description ?? undefined
+				)
+			} catch {
+				return status(409, { error: "Feedback already submitted for this group" })
+			}
+		},
+		{ body: "feedback.submit" }
+	)
+	.get(
+		"/",
+		async ({ request, query }) => {
+			const { user, response } = await requirePlatformAdmin(request)
+			if (!user) return response
+			return feedbackDao.list(query.groupId, query.reviewed)
+		},
+		{ query: "feedback.adminList" }
+	)
+	.patch(
+		"/:id/reviewed",
+		async ({ request, params, body }) => {
+			const { user, response } = await requirePlatformAdmin(request)
+			if (!user) return response
+			try {
+				return await feedbackDao.markReviewed(params.id, body.reviewed)
+			} catch {
+				return status(404, { error: "Feedback not found" })
+			}
+		},
+		{ params: "feedback.idParams", body: "feedback.markReviewed" }
+	)

--- a/src/server/feedback/feedback.dao.ts
+++ b/src/server/feedback/feedback.dao.ts
@@ -1,0 +1,56 @@
+import { type FeedbackCategory, GroupMemberStatus } from "@/generated/prisma/enums"
+import { db } from "@/server/lib/db"
+import { feedbackSelect } from "./feedback.type"
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
+
+export const feedbackDao = {
+	shouldShowPrompt: async (
+		userId: string,
+		groupId: string
+	): Promise<{ shouldShow: boolean }> => {
+		const membership = await db.groupMember.findUnique({
+			where: { groupId_userId: { groupId, userId } },
+			select: { joinedAt: true, status: true },
+		})
+		if (!membership || membership.status !== GroupMemberStatus.ACTIVE) {
+			return { shouldShow: false }
+		}
+		const sevenDaysAgo = new Date(Date.now() - SEVEN_DAYS_MS)
+		if (membership.joinedAt > sevenDaysAgo) return { shouldShow: false }
+
+		const existing = await db.feedback.findUnique({
+			where: { userId_groupId: { userId, groupId } },
+			select: { id: true },
+		})
+		return { shouldShow: !existing }
+	},
+
+	submit: async (
+		userId: string,
+		groupId: string,
+		category: FeedbackCategory,
+		description?: string
+	) =>
+		db.feedback.create({
+			data: { userId, groupId, category, description: description ?? null },
+			select: feedbackSelect,
+		}),
+
+	list: async (groupId?: string, reviewed?: boolean) =>
+		db.feedback.findMany({
+			where: {
+				...(groupId ? { groupId } : {}),
+				...(reviewed !== undefined ? { reviewed } : {}),
+			},
+			select: feedbackSelect,
+			orderBy: [{ reviewed: "asc" }, { createdAt: "desc" }],
+		}),
+
+	markReviewed: async (id: string, reviewed: boolean) =>
+		db.feedback.update({
+			where: { id },
+			data: { reviewed },
+			select: feedbackSelect,
+		}),
+}

--- a/src/server/feedback/feedback.model.ts
+++ b/src/server/feedback/feedback.model.ts
@@ -1,0 +1,24 @@
+import Elysia, { t } from "elysia"
+
+import { FeedbackCategory } from "@/generated/prisma/enums"
+
+export const feedbackModel = new Elysia({ name: "model/feedback" }).model({
+	"feedback.submit": t.Object({
+		groupId: t.String({ minLength: 1 }),
+		category: t.Enum(FeedbackCategory),
+		description: t.Optional(t.Union([t.String({ maxLength: 1000 }), t.Null()])),
+	}),
+	"feedback.promptQuery": t.Object({
+		groupId: t.String({ minLength: 1 }),
+	}),
+	"feedback.adminList": t.Object({
+		groupId: t.Optional(t.String({ minLength: 1 })),
+		reviewed: t.Optional(t.Boolean()),
+	}),
+	"feedback.idParams": t.Object({
+		id: t.String({ minLength: 1 }),
+	}),
+	"feedback.markReviewed": t.Object({
+		reviewed: t.Boolean(),
+	}),
+})

--- a/src/server/feedback/feedback.type.ts
+++ b/src/server/feedback/feedback.type.ts
@@ -1,0 +1,27 @@
+import { z } from "zod"
+
+import type { Prisma } from "@/generated/prisma/client"
+import { FeedbackCategory } from "@/generated/prisma/enums"
+
+export const feedbackSelect = {
+	id: true,
+	category: true,
+	description: true,
+	reviewed: true,
+	createdAt: true,
+	user: { select: { id: true, username: true, name: true } },
+	group: { select: { id: true, slug: true } },
+} satisfies Prisma.FeedbackSelect
+
+export type FeedbackResponse = Prisma.FeedbackGetPayload<{
+	select: typeof feedbackSelect
+}>
+
+export const feedbackFormSchema = z.object({
+	groupId: z.string().min(1, { error: "Group is required" }),
+	category: z.enum(FeedbackCategory),
+	description: z.string().max(1000).optional(),
+})
+export type FeedbackFormInput = z.infer<typeof feedbackFormSchema>
+
+export { FeedbackCategory }

--- a/src/server/leaderboard/leaderboard.controller.ts
+++ b/src/server/leaderboard/leaderboard.controller.ts
@@ -1,0 +1,50 @@
+import { Elysia, status } from "elysia"
+
+import { getSessionUser, requireSessionUser } from "@/server/lib/session"
+import { leaderboardDao } from "./leaderboard.dao"
+import { leaderboardModel } from "./leaderboard.model"
+import type { LeaderboardPeriod } from "./leaderboard.type"
+
+const DEFAULT_PERIOD: LeaderboardPeriod = "week"
+
+export const leaderboardController = new Elysia({
+	prefix: "/leaderboard",
+	tags: ["Leaderboard"],
+})
+	.use(leaderboardModel)
+	.get(
+		"/global",
+		async ({ query, request }) => {
+			const { user, response } = await requireSessionUser(request)
+			if (!user) return response
+
+			if (!user.isPro) {
+				return status(403, { error: "Global leaderboard requires a Pro account." })
+			}
+
+			const period = (query.period ?? DEFAULT_PERIOD) as LeaderboardPeriod
+			return leaderboardDao.getGlobalLeaderboard(period)
+		},
+		{ query: "leaderboard.query" }
+	)
+	.get(
+		"/groups/:id",
+		async ({ params, query, request }) => {
+			const user = await getSessionUser(request)
+
+			const period = (query.period ?? DEFAULT_PERIOD) as LeaderboardPeriod
+			const result = await leaderboardDao.getGroupLeaderboard(params.id, period)
+
+			if (!result) return status(404, { error: "Group not found." })
+
+			return { ...result, viewerUserId: user?.id ?? null }
+		},
+		{ params: "leaderboard.groupIdParams", query: "leaderboard.query" }
+	)
+	.get("/my-groups", async ({ request }) => {
+		const { user, response } = await requireSessionUser(request)
+		if (!user) return response
+
+		const memberships = await leaderboardDao.getUserGroups(user.id)
+		return memberships.map((m) => m.group)
+	})

--- a/src/server/leaderboard/leaderboard.dao.ts
+++ b/src/server/leaderboard/leaderboard.dao.ts
@@ -1,0 +1,205 @@
+import { GroupMemberStatus, PointReason } from "@/generated/prisma/enums"
+import { db } from "@/server/lib/db"
+import type {
+	GlobalLeaderboardResponse,
+	GroupLeaderboardResponse,
+	LeaderboardEntry,
+	LeaderboardPeriod,
+} from "./leaderboard.type"
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const EARN_REASONS: PointReason[] = [
+	PointReason.DAILY_SOLVE,
+	PointReason.FIRST_IN_GROUP,
+	PointReason.STREAK_MULTIPLIER_BONUS,
+	PointReason.COMEBACK,
+	PointReason.EARLY_BIRD,
+]
+
+const periodStart = (period: LeaderboardPeriod): Date | null => {
+	if (period === "alltime") return null
+	const now = new Date()
+	if (period === "week") {
+		const d = new Date(
+			Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+		)
+		d.setUTCDate(d.getUTCDate() - d.getUTCDay())
+		return d
+	}
+	return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
+}
+
+function rankEntries(
+	rows: {
+		userId: string
+		username: string | null
+		name: string
+		isPro: boolean
+		currentStreak: number
+		totalPoints: number
+		periodPoints: number
+	}[]
+): LeaderboardEntry[] {
+	return rows
+		.sort((a, b) => b.periodPoints - a.periodPoints)
+		.map((row, i) => ({ rank: i + 1, ...row }))
+}
+
+// ─── DAO ──────────────────────────────────────────────────────────────────────
+
+export const leaderboardDao = {
+	getGroupLeaderboard: async (
+		groupId: string,
+		period: LeaderboardPeriod
+	): Promise<GroupLeaderboardResponse | null> => {
+		const group = await db.group.findUnique({
+			where: { id: groupId },
+			select: {
+				id: true,
+				slug: true,
+				_count: { select: { members: { where: { status: GroupMemberStatus.ACTIVE } } } },
+			},
+		})
+		if (!group) return null
+
+		const members = await db.groupMember.findMany({
+			where: { groupId, status: GroupMemberStatus.ACTIVE },
+			select: {
+				user: {
+					select: {
+						id: true,
+						username: true,
+						name: true,
+						isPro: true,
+						currentStreak: true,
+						totalPoints: true,
+					},
+				},
+			},
+		})
+
+		const start = periodStart(period)
+
+		const rows = await Promise.all(
+			members.map(async ({ user }) => {
+				let periodPoints: number
+
+				if (period === "alltime" || !start) {
+					// Use the denormalized total directly for all-time
+					periodPoints = user.totalPoints
+				} else {
+					// groupId is null on solve points — sum by userId + period only
+					const agg = await db.pointsHistory.aggregate({
+						where: {
+							userId: user.id,
+							reason: { in: EARN_REASONS },
+							createdAt: { gte: start },
+						},
+						_sum: { delta: true },
+					})
+					periodPoints = agg._sum.delta ?? 0
+				}
+
+				return { userId: user.id, ...user, periodPoints }
+			})
+		)
+
+		return {
+			groupId: group.id,
+			groupSlug: group.slug,
+			memberCount: group._count.members,
+			period,
+			entries: rankEntries(rows),
+		}
+	},
+
+	getGlobalLeaderboard: async (
+		period: LeaderboardPeriod
+	): Promise<GlobalLeaderboardResponse> => {
+		const start = periodStart(period)
+
+		if (period === "alltime") {
+			const users = await db.user.findMany({
+				where: { banned: false },
+				orderBy: { totalPoints: "desc" },
+				take: 100,
+				select: {
+					id: true,
+					username: true,
+					name: true,
+					isPro: true,
+					currentStreak: true,
+					totalPoints: true,
+				},
+			})
+
+			const entries: LeaderboardEntry[] = users.map((u, i) => ({
+				rank: i + 1,
+				userId: u.id,
+				username: u.username,
+				name: u.name,
+				isPro: u.isPro,
+				currentStreak: u.currentStreak,
+				periodPoints: u.totalPoints,
+			}))
+
+			return { period, entries }
+		}
+
+		const agg = await db.pointsHistory.groupBy({
+			by: ["userId"],
+			where: {
+				reason: { in: EARN_REASONS },
+				createdAt: start ? { gte: start } : undefined,
+			},
+			_sum: { delta: true },
+			orderBy: { _sum: { delta: "desc" } },
+			take: 100,
+		})
+
+		const userIds = agg.map((r) => r.userId)
+		const users = await db.user.findMany({
+			where: { id: { in: userIds }, banned: false },
+			select: {
+				id: true,
+				username: true,
+				name: true,
+				isPro: true,
+				currentStreak: true,
+				totalPoints: true,
+			},
+		})
+		const userMap = new Map(users.map((u) => [u.id, u]))
+
+		const entries: LeaderboardEntry[] = agg
+			.filter((r) => userMap.has(r.userId))
+			.map((r, i) => {
+				const u = userMap.get(r.userId)
+				if (!u) return null
+				return {
+					rank: i + 1,
+					userId: u.id,
+					username: u.username,
+					name: u.name,
+					isPro: u.isPro,
+					currentStreak: u.currentStreak,
+					periodPoints: r._sum.delta ?? 0,
+				}
+			})
+			.filter((e): e is LeaderboardEntry => e !== null)
+
+		return { period, entries }
+	},
+
+	getUserGroups: async (userId: string) => {
+		return db.groupMember.findMany({
+			where: { userId, status: GroupMemberStatus.ACTIVE },
+			select: {
+				group: {
+					select: { id: true, slug: true },
+				},
+			},
+		})
+	},
+}

--- a/src/server/leaderboard/leaderboard.model.ts
+++ b/src/server/leaderboard/leaderboard.model.ts
@@ -1,0 +1,14 @@
+import Elysia, { t } from "elysia"
+
+const periodSchema = t.Union([
+	t.Literal("week"),
+	t.Literal("month"),
+	t.Literal("alltime"),
+])
+
+export const leaderboardModel = new Elysia({ name: "model/leaderboard" }).model({
+	"leaderboard.query": t.Object({
+		period: t.Optional(periodSchema),
+	}),
+	"leaderboard.groupIdParams": t.Object({ id: t.String({ minLength: 1 }) }),
+})

--- a/src/server/leaderboard/leaderboard.type.ts
+++ b/src/server/leaderboard/leaderboard.type.ts
@@ -1,0 +1,43 @@
+import type { Prisma } from "@/generated/prisma/client"
+
+// ─── Period ───────────────────────────────────────────────────────────────────
+
+export type LeaderboardPeriod = "week" | "month" | "alltime"
+
+// ─── Entry ────────────────────────────────────────────────────────────────────
+
+export const leaderboardUserSelect = {
+	id: true,
+	username: true,
+	name: true,
+	isPro: true,
+	currentStreak: true,
+	totalPoints: true,
+} satisfies Prisma.UserSelect
+
+export type LeaderboardEntry = {
+	rank: number
+	userId: string
+	username: string | null
+	name: string
+	isPro: boolean
+	periodPoints: number
+	currentStreak: number
+}
+
+// ─── Group leaderboard ────────────────────────────────────────────────────────
+
+export type GroupLeaderboardResponse = {
+	groupId: string
+	groupSlug: string
+	memberCount: number
+	period: LeaderboardPeriod
+	entries: LeaderboardEntry[]
+}
+
+// ─── Global leaderboard ───────────────────────────────────────────────────────
+
+export type GlobalLeaderboardResponse = {
+	period: LeaderboardPeriod
+	entries: LeaderboardEntry[]
+}


### PR DESCRIPTION
- Add /leaderboard route with group/global mode, period filters, and LeaderboardPage component
- Add leaderboard server controller and DAO
- Add Feedback Prisma model (one per user per group) with FeedbackCategory enum and migration
- Add FeedbackDialog to group layout and use-submit-feedback / use-feedback-prompt hooks
- Add /admin/feedbacks page and admin nav entry; register both controllers in app.ts
- Make group header cells link to user profiles; re-enable Leaderboard nav link