### PR TITLE
feat(#236): reliable admin notifications + platform events

### DIFF
--- a/docs/agdr/AgDR-0001-central-event-notification-forwarder.md
+++ b/docs/agdr/AgDR-0001-central-event-notification-forwarder.md
@@ -1,0 +1,33 @@
+# Central event-notification forwarder for admin bot
+
+> In the context of adding more admin push-notifications (churn, membership, growth) to the husam-bot Telegram channel, facing a choice between wiring a dedicated `notifyAdmin` call at every event site vs one central hook, I decided to route realtime-classed `SystemEventType` events through a single forwarder inside `systemEventsDao.log()`, to achieve one integration point + a tunable routing table, accepting a slightly less-rich payload for the forwarded events and a small coupling of the event-log DAO to the bot transport.
+
+## Context
+
+husam-bot already receives six event types from pstrack via `notifyAdmin(event, payload)` (a fire-and-forget POST to the bot's `/api/notify`). We want to add churn (`GROUP_LEFT`, `MEMBER_REMOVED`) and membership (`GROUP_JOINED`, `JOIN_REQUEST_APPROVED/REJECTED`) notifications, keep low-signal events (`SOLVE_VERIFIED`, `MISS_BATCH`, `PAUSE_USED`, handle changes) out of the realtime channel, and make it cheap to re-tune what's realtime vs digest vs ignored later.
+
+Every one of those events already flows through a single choke point: `systemEventsDao.log()`. Both the dedicated-emit and central-forwarder approaches must also address that the existing request-handler emits (`join.requested`, `feedback.submitted`, `user.created`, `purchase.pro`) are fire-and-forget and can be dropped when a serverless function freezes after the response — fixed separately by making `notifyAdmin` awaitable.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| Dedicated `notifyAdmin` at each new event site | Rich, per-event payloads; explicit | N call sites to add + maintain; easy to forget one; routing policy scattered |
+| **Central forwarder in `systemEventsDao.log()` + routing table** | One integration point; every current & future `SystemEventType` covered; realtime/digest/ignore policy lives in one map; trivial to re-tune | Payload limited to what the event log carries (actor + target); DAO gains a dependency on the bot transport |
+| Generic `system.event` carrier on the bot side | Bot doesn't need a new schema per event; forwards type + actor/target | Less bespoke formatting (mitigated by a per-type template map on the bot) |
+
+## Decision
+
+Chosen: **central forwarder in `systemEventsDao.log()` with a `SystemEventType → policy` routing table**, forwarding realtime-classed events to husam-bot as a generic `system.event` payload, because it makes coverage automatic and the noise policy a single tunable map. `join.requested` keeps its dedicated emit (it needs the Accept/Reject/Transfer button payload the generic carrier can't express). The forwarder is best-effort: a bot-notify failure must never break the primary write, so it's fired after the log row is committed and its errors are swallowed+logged.
+
+## Consequences
+
+- New realtime events are added by editing one routing table, not by hunting call sites.
+- `system-events.dao.ts` imports the bot transport — an acceptable, contained coupling; the DAO already owns "record that this happened," and "tell the admin" is adjacent.
+- Forwarded events carry actor + target only; richer context (e.g. group slug) is resolved best-effort from `metadata`/`targetId`.
+- Low-signal events default to `ignore`/`digest`, keeping the realtime channel actionable.
+
+## Artifacts
+
+- pstrack #236, branch `feature/#236-admin-notify-events`
+- husam-bot #1 / PR #2 (receiving side: `system.event` schema + per-type formatter)

--- a/docs/agdr/AgDR-0001-central-event-notification-forwarder.md
+++ b/docs/agdr/AgDR-0001-central-event-notification-forwarder.md
@@ -25,7 +25,9 @@ Chosen: **central forwarder in `systemEventsDao.log()` with a `SystemEventType �
 - New realtime events are added by editing one routing table, not by hunting call sites.
 - `system-events.dao.ts` imports the bot transport — an acceptable, contained coupling; the DAO already owns "record that this happened," and "tell the admin" is adjacent.
 - Forwarded events carry actor + target only; richer context (e.g. group slug) is resolved best-effort from `metadata`/`targetId`.
-- Low-signal events default to `ignore`/`digest`, keeping the realtime channel actionable.
+- Each realtime-classed GROUP event triggers one extra `group.findUnique` (to resolve the slug label) plus the bot round-trip, both bounded by a 5s fetch timeout. This is negligible at churn/membership volume, but must be revisited before promoting any high-frequency event (e.g. solves) into `REALTIME_EVENTS`.
+- The forward is fired inside `systemEventsDao.log()`, which most request-path callers invoke fire-and-forget — so a forwarded event can itself be dropped on a serverless freeze. Acceptable for best-effort churn/membership; the always-committed event row + daily digest are the backstop.
+- Low-signal events default to `ignore`/`digest`, keeping the realtime channel actionable. The implementation is currently a binary `Set` (`REALTIME_EVENTS`); promote it to the full `SystemEventType → policy` map when digest-classed forwarding lands.
 
 ## Artifacts
 

--- a/src/server/feedback/feedback.controller.ts
+++ b/src/server/feedback/feedback.controller.ts
@@ -28,7 +28,7 @@ export const feedbackController = new Elysia({ prefix: "/feedbacks", tags: ["Fee
 					body.category,
 					body.description ?? undefined
 				)
-				notifyAdmin("feedback.submitted", {
+				await notifyAdmin("feedback.submitted", {
 					userEmail: user.email,
 					text: body.description ?? "",
 					submittedAt: new Date().toISOString(),
@@ -49,7 +49,7 @@ export const feedbackController = new Elysia({ prefix: "/feedbacks", tags: ["Fee
 				user.id,
 				body.description ?? undefined
 			)
-			notifyAdmin("feedback.submitted", {
+			await notifyAdmin("feedback.submitted", {
 				userEmail: user.email,
 				text: body.description ?? "",
 				submittedAt: new Date().toISOString(),

--- a/src/server/groups/groups.controller.ts
+++ b/src/server/groups/groups.controller.ts
@@ -99,7 +99,7 @@ export const groupsController = new Elysia({ prefix: "/groups", tags: ["Groups"]
 			}
 
 			if (result.status === "REQUESTED") {
-				notifyAdmin("join.requested", {
+				await notifyAdmin("join.requested", {
 					requestId: result.requestId,
 					groupId: params.id,
 					groupName: `@${result.groupSlug}`,

--- a/src/server/internal/internal.controller.ts
+++ b/src/server/internal/internal.controller.ts
@@ -139,23 +139,37 @@ export const internalController = new Elysia({ prefix: "/internal" })
 				return status(401, { error: "Unauthorized" })
 			}
 
-			const [totalUsers, pendingRequests, unreviewedFeedbacks, solveStats] =
-				await Promise.all([
-					db.user.count(),
-					db.groupJoinRequest.count({ where: { status: JoinRequestStatus.PENDING } }),
-					db.feedback.findMany({
-						where: { reviewed: false },
-						orderBy: { createdAt: "desc" },
-						take: 5,
-						select: {
-							id: true,
-							description: true,
-							createdAt: true,
-							user: { select: { email: true } },
-						},
-					}),
-					getTodaySolveStats(),
-				])
+			const now = new Date()
+			const today = new Date(
+				Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+			)
+			const twoDaysAgo = new Date(now.getTime() - 2 * 86_400_000)
+
+			const [
+				totalUsers,
+				pendingRequests,
+				unreviewedFeedbacks,
+				solveStats,
+				dailyProblemCount,
+				signups48h,
+			] = await Promise.all([
+				db.user.count(),
+				db.groupJoinRequest.count({ where: { status: JoinRequestStatus.PENDING } }),
+				db.feedback.findMany({
+					where: { reviewed: false },
+					orderBy: { createdAt: "desc" },
+					take: 5,
+					select: {
+						id: true,
+						description: true,
+						createdAt: true,
+						user: { select: { email: true } },
+					},
+				}),
+				getTodaySolveStats(),
+				db.dailyProblem.count({ where: { assignedDate: today } }),
+				db.user.count({ where: { createdAt: { gte: twoDaysAgo } } }),
+			])
 
 			return {
 				users: { total: totalUsers },
@@ -172,6 +186,8 @@ export const internalController = new Elysia({ prefix: "/internal" })
 					today: solveStats.totalSolves,
 					activeUsers: solveStats.activeUsers,
 				},
+				dailyProblem: { assignedForToday: dailyProblemCount > 0 },
+				signups48h,
 			}
 		},
 		{ detail: { hide: true } }

--- a/src/server/lib/auth.ts
+++ b/src/server/lib/auth.ts
@@ -88,7 +88,7 @@ export const auth = betterAuth({
 					} catch (err) {
 						logger.error({ err, userId: user.id }, "welcome email failed")
 					}
-					notifyAdmin("user.created", {
+					await notifyAdmin("user.created", {
 						email: user.email,
 						name: user.name ?? undefined,
 						createdAt: new Date().toISOString(),
@@ -143,7 +143,7 @@ export const auth = betterAuth({
 							webhooks({
 								secret: env.POLAR_WEBHOOK_SECRET,
 								onOrderPaid: async (payload) => {
-									notifyAdmin("purchase.pro", {
+									await notifyAdmin("purchase.pro", {
 										email: payload.data.customer.email ?? undefined,
 										plan: payload.data.product?.name ?? "Pro",
 										amount: payload.data.netAmount,

--- a/src/server/lib/bot.ts
+++ b/src/server/lib/bot.ts
@@ -7,7 +7,12 @@ import { env } from "@/env"
  * dropped when the function freezes after the response returns. Callers in
  * request paths MUST `await` this; Trigger.dev tasks should too. Failures are
  * logged (never thrown) so a bot outage can't break the primary operation.
+ *
+ * Bounded by a 5s timeout so a hung bot can't add unbounded latency to the
+ * (now-awaited) request paths that call this.
  */
+const NOTIFY_TIMEOUT_MS = 5000
+
 export const notifyAdmin = async (
 	event: string,
 	payload: Record<string, unknown>
@@ -21,6 +26,7 @@ export const notifyAdmin = async (
 				Authorization: `Bearer ${env.BOT_NOTIFY_SECRET}`,
 			},
 			body: JSON.stringify({ event, payload }),
+			signal: AbortSignal.timeout(NOTIFY_TIMEOUT_MS),
 		})
 		if (!res.ok) {
 			const body = await res.text().catch(() => "")

--- a/src/server/lib/bot.ts
+++ b/src/server/lib/bot.ts
@@ -1,13 +1,32 @@
 import { env } from "@/env"
 
-export const notifyAdmin = (event: string, payload: Record<string, unknown>): void => {
+/**
+ * Fire an admin notification to husam-bot.
+ *
+ * Awaitable by design: on serverless request handlers an un-awaited fetch is
+ * dropped when the function freezes after the response returns. Callers in
+ * request paths MUST `await` this; Trigger.dev tasks should too. Failures are
+ * logged (never thrown) so a bot outage can't break the primary operation.
+ */
+export const notifyAdmin = async (
+	event: string,
+	payload: Record<string, unknown>
+): Promise<void> => {
 	if (!env.BOT_URL) return
-	fetch(`${env.BOT_URL}/api/notify`, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			Authorization: `Bearer ${env.BOT_NOTIFY_SECRET}`,
-		},
-		body: JSON.stringify({ event, payload }),
-	}).catch(() => {})
+	try {
+		const res = await fetch(`${env.BOT_URL}/api/notify`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${env.BOT_NOTIFY_SECRET}`,
+			},
+			body: JSON.stringify({ event, payload }),
+		})
+		if (!res.ok) {
+			const body = await res.text().catch(() => "")
+			console.error(`[notifyAdmin] ${event} failed: ${res.status} ${body}`)
+		}
+	} catch (err) {
+		console.error(`[notifyAdmin] ${event} error`, err)
+	}
 }

--- a/src/server/problems/problems.dao.ts
+++ b/src/server/problems/problems.dao.ts
@@ -7,6 +7,7 @@ import {
 	MemberRole,
 	PointReason,
 	SolveStatus,
+	SystemEventType,
 	WarningResolution,
 } from "@/generated/prisma/enums"
 import { badgesDao } from "@/server/badges/badges.dao"
@@ -376,20 +377,48 @@ export const problemsDao = {
 
 	getDailySolveStats: async (date: Date) => {
 		const yesterday = new Date(date.getTime() - 86_400_000)
-		const [totalSolves, solvers, newUsers] = await Promise.all([
-			db.userSolve.count({
-				where: { status: SolveStatus.SOLVED, dailyProblem: { assignedDate: yesterday } },
-			}),
-			db.userSolve.findMany({
-				where: { status: SolveStatus.SOLVED, dailyProblem: { assignedDate: yesterday } },
-				select: { userId: true },
-				distinct: ["userId"],
-			}),
-			db.user.count({
-				where: { createdAt: { gte: yesterday, lt: date } },
-			}),
-		])
-		return { totalSolves, activeUsers: solvers.length, newUsers }
+		const [totalSolves, solvers, newUsers, pausesUsed, handleChanges] = await Promise.all(
+			[
+				db.userSolve.count({
+					where: {
+						status: SolveStatus.SOLVED,
+						dailyProblem: { assignedDate: yesterday },
+					},
+				}),
+				db.userSolve.findMany({
+					where: {
+						status: SolveStatus.SOLVED,
+						dailyProblem: { assignedDate: yesterday },
+					},
+					select: { userId: true },
+					distinct: ["userId"],
+				}),
+				db.user.count({
+					where: { createdAt: { gte: yesterday, lt: date } },
+				}),
+				db.systemEventLog.count({
+					where: {
+						eventType: SystemEventType.PAUSE_USED,
+						createdAt: { gte: yesterday, lt: date },
+					},
+				}),
+				db.systemEventLog.count({
+					where: {
+						eventType: {
+							in: [SystemEventType.HANDLE_CHANGED, SystemEventType.USERNAME_CHANGED],
+						},
+						createdAt: { gte: yesterday, lt: date },
+					},
+				}),
+			]
+		)
+		return {
+			totalSolves,
+			activeUsers: solvers.length,
+			newUsers,
+			pausesUsed,
+			handleChanges,
+		}
 	},
 
 	getDailyDigestRecipients: async (date: Date) => {

--- a/src/server/system-events/system-events.dao.test.ts
+++ b/src/server/system-events/system-events.dao.test.ts
@@ -1,0 +1,58 @@
+// @ts-nocheck
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/server/lib/db", () => ({
+	db: {
+		systemEventLog: { create: vi.fn(), deleteMany: vi.fn() },
+		group: { findUnique: vi.fn() },
+	},
+}))
+
+vi.mock("@/server/lib/bot", () => ({
+	notifyAdmin: vi.fn(),
+}))
+
+import { notifyAdmin } from "@/server/lib/bot"
+import { db } from "@/server/lib/db"
+import { systemEventsDao } from "./system-events.dao"
+
+describe("systemEventsDao.log — bot forwarding (AgDR-0001)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		db.systemEventLog.create.mockResolvedValue({})
+		db.group.findUnique.mockResolvedValue({ slug: "daily-grind" })
+	})
+
+	it("always writes the event row", async () => {
+		await systemEventsDao.log({ eventType: "SOLVE_VERIFIED" })
+		expect(db.systemEventLog.create).toHaveBeenCalledTimes(1)
+	})
+
+	it("forwards realtime-classed events as system.event with a resolved group label", async () => {
+		await systemEventsDao.log({
+			eventType: "GROUP_LEFT",
+			actorName: "Sara",
+			actorUsername: "sara",
+			targetType: "GROUP",
+			targetId: "grp_1",
+		})
+		expect(notifyAdmin).toHaveBeenCalledTimes(1)
+		const [event, payload] = notifyAdmin.mock.calls[0]
+		expect(event).toBe("system.event")
+		expect(payload.type).toBe("GROUP_LEFT")
+		expect(payload.actorUsername).toBe("sara")
+		expect(payload.targetLabel).toBe("@daily-grind")
+	})
+
+	it("does NOT forward low-signal events (solve firehose stays out of realtime)", async () => {
+		await systemEventsDao.log({ eventType: "SOLVE_VERIFIED" })
+		await systemEventsDao.log({ eventType: "MISS_BATCH" })
+		await systemEventsDao.log({ eventType: "PAUSE_USED" })
+		expect(notifyAdmin).not.toHaveBeenCalled()
+	})
+
+	it("does NOT forward JOIN_REQUEST_SENT (it has a dedicated buttoned emit)", async () => {
+		await systemEventsDao.log({ eventType: "JOIN_REQUEST_SENT" })
+		expect(notifyAdmin).not.toHaveBeenCalled()
+	})
+})

--- a/src/server/system-events/system-events.dao.ts
+++ b/src/server/system-events/system-events.dao.ts
@@ -1,5 +1,6 @@
 import type { Prisma } from "@/generated/prisma/client"
-import type { SystemEventTargetType, SystemEventType } from "@/generated/prisma/enums"
+import { SystemEventTargetType, type SystemEventType } from "@/generated/prisma/enums"
+import { notifyAdmin } from "@/server/lib/bot"
 import { db } from "@/server/lib/db"
 
 export type SystemEventWriteInput = {
@@ -10,6 +11,36 @@ export type SystemEventWriteInput = {
 	targetType?: SystemEventTargetType | null
 	targetId?: string | null
 	metadata?: Prisma.JsonObject
+}
+
+// AgDR-0001 — realtime-classed events forwarded to husam-bot as `system.event`.
+// Everything else (SOLVE_VERIFIED, MISS_BATCH, PAUSE_USED, *_CHANGED, and
+// JOIN_REQUEST_SENT which has its own dedicated buttoned emit) is intentionally
+// NOT forwarded here — those are ignored or rolled into the daily digest.
+const REALTIME_EVENTS = new Set<SystemEventType>([
+	"GROUP_LEFT",
+	"MEMBER_REMOVED",
+	"GROUP_JOINED",
+	"JOIN_REQUEST_APPROVED",
+	"JOIN_REQUEST_REJECTED",
+])
+
+// Best-effort human label for the event's target (group slug for GROUP targets).
+const resolveTargetLabel = async (
+	input: SystemEventWriteInput
+): Promise<string | undefined> => {
+	if (input.targetType === SystemEventTargetType.GROUP && input.targetId) {
+		try {
+			const g = await db.group.findUnique({
+				where: { id: input.targetId },
+				select: { slug: true },
+			})
+			return g ? `@${g.slug}` : undefined
+		} catch {
+			return undefined
+		}
+	}
+	return undefined
 }
 
 export const systemEventsDao = {
@@ -25,6 +56,20 @@ export const systemEventsDao = {
 				metadata: (input.metadata ?? {}) as Prisma.InputJsonValue,
 			},
 		})
+
+		// Forward realtime-classed events to the admin bot after the row is
+		// committed. Best-effort: notifyAdmin swallows+logs its own failures.
+		if (REALTIME_EVENTS.has(input.eventType)) {
+			const targetLabel = await resolveTargetLabel(input)
+			await notifyAdmin("system.event", {
+				type: input.eventType,
+				actorName: input.actorName ?? undefined,
+				actorUsername: input.actorUsername ?? undefined,
+				targetType: input.targetType ?? undefined,
+				targetLabel,
+				at: new Date().toISOString(),
+			})
+		}
 	},
 
 	purgeOlderThan: async (before: Date): Promise<number> => {

--- a/src/server/trigger/assign-daily-problem.ts
+++ b/src/server/trigger/assign-daily-problem.ts
@@ -55,11 +55,13 @@ export const assignDailyProblemTask = schedules.task({
 		}
 
 		const stats = await problemsDao.getDailySolveStats(date)
-		notifyAdmin("digest.daily", {
+		await notifyAdmin("digest.daily", {
 			date: dateKey,
 			totalSolves: stats.totalSolves,
 			activeUsers: stats.activeUsers,
 			newUsers: stats.newUsers,
+			pausesUsed: stats.pausesUsed,
+			handleChanges: stats.handleChanges,
 		})
 
 		logger.log("Done", {

--- a/src/server/trigger/expire-admin-pro-grants.ts
+++ b/src/server/trigger/expire-admin-pro-grants.ts
@@ -45,6 +45,14 @@ export const expireAdminProGrantsTask = schedules.task({
 			count: expired.length,
 			usernames: expired.map((u) => u.username).filter(Boolean),
 		})
+
+		await notifyAdmin("pro.expired", {
+			count: expired.length,
+			username: expired.length === 1 ? (expired[0]?.username ?? undefined) : undefined,
+			source: "admin_grant",
+			expiredAt: new Date().toISOString(),
+		})
+
 		return { expired: expired.length }
 	},
 })

--- a/src/server/trigger/send-weekly-digest.ts
+++ b/src/server/trigger/send-weekly-digest.ts
@@ -1,0 +1,56 @@
+import { logger, schedules } from "@trigger.dev/sdk/v3"
+
+import { SolveStatus } from "@/generated/prisma/enums"
+import { notifyAdmin } from "@/server/lib/bot"
+import { db } from "@/server/lib/db"
+
+const WEEK_MS = 7 * 86_400_000
+
+export const sendWeeklyDigestTask = schedules.task({
+	id: "send-weekly-digest",
+	cron: "0 9 * * 1", // Mondays 09:00 UTC
+	maxDuration: 120,
+	catchError: async ({ task, error, retryAt }) => {
+		if (!retryAt) {
+			await notifyAdmin("job.failed", {
+				jobName: task,
+				error: error instanceof Error ? error.message : String(error),
+				failedAt: new Date().toISOString(),
+			})
+		}
+	},
+	run: async () => {
+		const now = new Date()
+		const weekStart = new Date(now.getTime() - WEEK_MS)
+		const prevStart = new Date(now.getTime() - 2 * WEEK_MS)
+
+		const [users, proUsers, newUsers, solves, solvesPrev] = await Promise.all([
+			db.user.count(),
+			db.user.count({ where: { isPro: true } }),
+			db.user.count({ where: { createdAt: { gte: weekStart } } }),
+			db.userSolve.count({
+				where: { status: SolveStatus.SOLVED, createdAt: { gte: weekStart } },
+			}),
+			db.userSolve.count({
+				where: {
+					status: SolveStatus.SOLVED,
+					createdAt: { gte: prevStart, lt: weekStart },
+				},
+			}),
+		])
+
+		await notifyAdmin("digest.weekly", {
+			weekStart: weekStart.toISOString().slice(0, 10),
+			weekEnd: now.toISOString().slice(0, 10),
+			users,
+			usersDelta: newUsers, // weekly growth
+			solves,
+			solvesDelta: solves - solvesPrev,
+			proUsers,
+			newUsers,
+		})
+
+		logger.log("Weekly digest sent", { users, solves, newUsers })
+		return { users, solves, newUsers }
+	},
+})


### PR DESCRIPTION
## Summary
- **Reliable `notifyAdmin`** — it was a fire-and-forget `fetch(...).catch(()=>{})`; on serverless request handlers that promise can be dropped when the function freezes after the response. Now `async`, awaited at the 5 request-path emit sites (`join.requested`, `feedback.submitted` ×2, `user.created`, `purchase.pro`), and it **logs non-2xx/errors** so a secret mismatch or bad payload is visible instead of silently swallowed.
- **Central event forwarder (AgDR-0001)** — `systemEventsDao.log()` now routes realtime-classed `SystemEventType` events to the admin bot as a generic `system.event` (churn: `GROUP_LEFT`/`MEMBER_REMOVED`; membership: `GROUP_JOINED`/`JOIN_REQUEST_APPROVED`/`JOIN_REQUEST_REJECTED`). One integration point + a tunable routing table; low-signal events (`SOLVE_VERIFIED`, `MISS_BATCH`, `PAUSE_USED`, `*_CHANGED`) are intentionally excluded, and `JOIN_REQUEST_SENT` keeps its dedicated buttoned emit.
- **`pro.expired` emit** — `expire-admin-pro-grants` now notifies when Pro grants lapse (revenue-loss signal), batched to one message per run.
- **Weekly digest** — new Trigger.dev task, Mondays 09:00 UTC, with WoW solve delta + weekly growth.
- **Daily digest enriched** — pause-used + handle-change roll-up counts (computed in `getDailySolveStats`, one day-boundary source of truth).
- **Watchdog data** — `/internal/bot` now exposes `dailyProblem.assignedForToday` and `signups48h` so husam-bot's watchdog cron can detect a silently-skipped scheduler and engagement cliffs.

## Testing
1. `bun run typecheck` ✓ · `bunx biome ci .` ✓ · `bun run test` ✓ (46, incl. new `system-events.dao.test.ts`) · `bun run build` ✓
2. New test covers the forwarder: realtime events forward with a resolved group label; low-signal events and `JOIN_REQUEST_SENT` do not.
3. No DB migration required — all reads use existing tables.

Refs #236

## Glossary
| Term | Definition |
|------|------------|
| `notifyAdmin` | Server→bot POST to husam-bot `/api/notify` announcing an admin event. |
| Central forwarder | Single hook in `systemEventsDao.log()` that routes events to the bot per a `SystemEventType → policy` table (AgDR-0001). |
| `system.event` | Generic bot payload carrying an event type + actor/target, rendered per-type by the bot. |
| Realtime-classed | Events that warrant an instant ping vs digest roll-up vs ignore. |
| Watchdog | husam-bot cron doing absence-detection against `/internal/bot`. |