### PR TITLE
feat(#238): list all pending join requests for the bot

### DIFF
--- a/src/server/internal/internal.controller.ts
+++ b/src/server/internal/internal.controller.ts
@@ -132,6 +132,22 @@ export const internalController = new Elysia({ prefix: "/internal" })
 		{ detail: { hide: true } }
 	)
 	.get(
+		"/bot/join-requests",
+		async ({ request }) => {
+			if (!requireBotAuth(request)) return status(401, { error: "Unauthorized" })
+
+			const requests = await groupsAdminDao.listAllPendingRequests()
+			return requests.map((r) => ({
+				requestId: r.id,
+				groupName: `@${r.group.slug}`,
+				userName: r.user.name ?? undefined,
+				userHandle: r.user.username ?? undefined,
+				requestedAt: r.createdAt.toISOString(),
+			}))
+		},
+		{ detail: { hide: true } }
+	)
+	.get(
 		"/bot",
 		async ({ request }) => {
 			const auth = request.headers.get("Authorization") ?? ""


### PR DESCRIPTION
## Summary
- **New `GET /internal/bot/join-requests`** (bot bearer auth) — returns every pending join request as `{ requestId, groupName, userName, userHandle, requestedAt }`, reusing the existing `groupsAdminDao.listAllPendingRequests()` query (no new DB access shape).
- Backs husam-bot's new `/requests` command, which lists the full pending backlog with per-request Accept/Reject/Move buttons (the buttons reuse the already-shipped `jr:A/R/T` callbacks against these `requestId`s).

## Testing
1. `bun run typecheck` ✓ · `bunx biome ci` ✓ · `bun run test` ✓ (46) · build unaffected (additive route).
2. `curl -H "Authorization: Bearer $BOT_NOTIFY_SECRET" $BASE/api/v3/internal/bot/join-requests` → JSON array of pending requests.
3. No DB migration.

Refs #238

## Glossary
| Term | Definition |
|------|------------|
| Pending join request | A `GroupJoinRequest` with status `PENDING` awaiting admin action. |
| Bot bearer auth | `Authorization: Bearer $BOT_NOTIFY_SECRET`, shared secret between pstrack and husam-bot. |
| `jr:A/R/T` | husam-bot callback prefixes for Accept / Reject / Transfer(move) on a request. |