### PR TITLE
feat(#240): complete Polar purchase → Pro grant + /success page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,10 @@ EMAIL_FROM="PStrack <onboarding@resend.dev>"
 # Payments (Polar) — get an access token at https://polar.sh/dashboard
 POLAR_ACCESS_TOKEN=""
 POLAR_SUCCESS_URL="https://pstrack.localhost/success?checkout_id={CHECKOUT_ID}"
+# Polar webhook signing secret. REQUIRED to grant Pro on purchase — the order.paid
+# webhook is what sets User.isPro. Without it, webhooks are disabled and purchases
+# will NOT unlock Pro. Get it from the Polar dashboard → Webhooks.
+POLAR_WEBHOOK_SECRET=""
 
 # Error tracking (Sentry) — optional in development
 SENTRY_DSN=""

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,31 @@
+# PStrack
+
+Collaborative LeetCode progress tracking. Users solve daily problems in groups, earn points and streaks, and can unlock **Pro** for higher limits and premium features.
+
+## Language
+
+### Pro & entitlements
+
+**Pro**:
+An account entitlement unlocking higher limits and premium features. Permanent once obtained (`proExpiresAt = null`) — the one exception is an admin grant, which can be time-boxed and auto-expires.
+_Avoid_: premium (the word "premium" is reserved — see below), paid tier, subscription (Pro is a one-time lifetime unlock, not recurring).
+
+**Pro source**:
+How an account became Pro. One of: `POLAR_PURCHASE` (bought it), `POINTS_THRESHOLD` (crossed 3,000 points), `ADMIN_GRANT` (granted directly, optionally time-boxed), `INVITATION` (redeemed a Pro invitation — always lifetime).
+
+**Pro invitation**:
+An **admin-issued**, email-targeted, single-use claim link that grants **lifetime** Pro to the invited person when they accept (strict email match). Distinct from a **direct admin grant** (no claim step, granted immediately) and from a viral referral (pstrack has none — inviting to Pro is admin-only).
+_Avoid_: referral (this is not user-to-user), gift code / redeemable code (invitations are bound to one email, not a shareable code), coupon.
+
+**Pro badge**:
+The small visual label marking an account as Pro in lists, rows, and tables (leaderboard, group members, profile). A presentation concern only — the entitlement is `Pro`.
+_Avoid_: pro chip, pro pill, pro tag, pro marker (pick one name — it is the "Pro badge").
+
+### Gamification (not Pro)
+
+**Badge**:
+An earned **achievement** (gamification), shown on a user's profile; some are "Rare". A `UserBadge` links a user to a badge they earned. This is a distinct concept from the **Pro badge** — do not conflate.
+_Avoid_: using "badge" to mean the Pro indicator.
+
+**Premium** (problem):
+A `Problem` flagged `isPremium` — a LeetCode-premium problem that is skipped/excluded from a roadmap. Unrelated to **Pro**. The word "premium" belongs to LeetCode problems, not to the Pro entitlement.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -28,6 +28,8 @@ Pauses preserve streaks (a pause doesn't break the chain), but cost −5 points 
 
 Reduces churn anxiety and support burden. Pro can also be earned by grinding to 3,000 points - this keeps non-paying users engaged and the Pro gate feel achievable. The threshold is calibrated (~7 months of consistent play at average earn velocity) so a $14 buyer's mental math always favors paying.
 
+The purchase grant is an **explicit `onOrderPaid` webhook write** (`src/server/lib/pro.ts`), not something the Better Auth Polar plugin does automatically — an earlier assumption that it did is why paying briefly granted nothing. The webhook is the source of truth; `/success` just refetches. Refunds revoke Pro only when `proSource === POLAR_PURCHASE`.
+
 ## hashvatar for avatars
 
 Deterministic SVG generated from the username hash. No file uploads, no S3 bucket, no moderation pipeline. Avatars are always consistent and load instantly.

--- a/docs/FREEMIUM_MODEL.md
+++ b/docs/FREEMIUM_MODEL.md
@@ -19,14 +19,15 @@
 - Standard price: **$14**
 - Sale price: **$9**
 - Promo codes: supported natively in Polar dashboard
-- Integration: **Better Auth Polar plugin** - Pro status is tied directly to the auth session, no manual webhook handling required
+- Integration: **Better Auth Polar plugin** for checkout + webhook transport. NOTE: the plugin does **not** set `User.isPro` automatically — we handle that explicitly in the `onOrderPaid` webhook (`src/server/lib/pro.ts`). Requires `POLAR_WEBHOOK_SECRET`.
 
 ## How Pro Status Works
 
-1. User clicks "Upgrade to Pro" → redirected to Polar checkout
-2. On successful purchase, Polar fires webhook → Better Auth Polar plugin handles it
-3. `User.isPro` set to `true`
-4. Next session refresh picks up the updated Pro status automatically
+1. User clicks "Get Pro" → `authClient.checkout({ slug: "pstrack" })` → Polar checkout
+2. On successful purchase, Polar fires the `order.paid` webhook
+3. Our `onOrderPaid` handler maps the Polar customer → user (via `customer.externalId`, set to the user id on sign-up) and sets `isPro=true, proSource=POLAR_PURCHASE, proExpiresAt=null` (idempotent), then sends a confirmation email
+4. User is redirected to `/success`, which refetches the session + `me` query so Pro reflects immediately
+5. A refund fires `order.refunded` → Pro is revoked, but only when `proSource === POLAR_PURCHASE`
 
 ## Gating Logic
 

--- a/src/emails/pro-unlocked-by-purchase.tsx
+++ b/src/emails/pro-unlocked-by-purchase.tsx
@@ -1,0 +1,33 @@
+import { Button, Section, Text } from "@react-email/components"
+
+import { EmailLayout, s } from "./layout"
+
+interface ProUnlockedByPurchaseEmailProps {
+	name: string
+	dashboardUrl: string
+}
+
+export default function ProUnlockedByPurchaseEmail({
+	name,
+	dashboardUrl,
+}: ProUnlockedByPurchaseEmailProps) {
+	return (
+		<EmailLayout
+			preview="Your PStrack Pro is active"
+			note="You're receiving this because you purchased Pro on PStrack."
+			footerText="Thanks for the support."
+		>
+			<Text style={s.heading}>Pro unlocked.</Text>
+			<Text style={s.para}>
+				Hey {name} - your purchase is complete and Pro is active on your account. No
+				subscription, no renewals - it&apos;s yours permanently. Create groups, join up to
+				5, run groups of 50, and get 4 pauses a month.
+			</Text>
+			<Section style={s.ctaSection}>
+				<Button href={dashboardUrl} style={s.ctaGreen}>
+					Go to Dashboard
+				</Button>
+			</Section>
+		</EmailLayout>
+	)
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SuccessRouteImport } from './routes/success'
 import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
 import { Route as ProblemsRouteImport } from './routes/problems'
 import { Route as LoginRouteImport } from './routes/login'
@@ -52,6 +53,11 @@ import { Route as AdminAdminGroupsGroupIdSettingsRouteImport } from './routes/_a
 import { Route as AdminAdminGroupsGroupIdMembersRouteImport } from './routes/_admin/admin/groups/$groupId/members'
 import { Route as AdminAdminGroupsGroupIdJoinRequestsRouteImport } from './routes/_admin/admin/groups/$groupId/join-requests'
 
+const SuccessRoute = SuccessRouteImport.update({
+  id: '/success',
+  path: '/success',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
   id: '/sitemap.xml',
   path: '/sitemap.xml',
@@ -282,6 +288,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/problems': typeof ProblemsRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/success': typeof SuccessRoute
   '/api/$': typeof ApiSplatRoute
   '/groups/$groupId': typeof GroupsGroupIdRouteWithChildren
   '/admin/audit': typeof AdminAdminAuditRoute
@@ -322,6 +329,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/problems': typeof ProblemsRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/success': typeof SuccessRoute
   '/api/$': typeof ApiSplatRoute
   '/admin/audit': typeof AdminAdminAuditRoute
   '/admin/config': typeof AdminAdminConfigRoute
@@ -362,6 +370,7 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/problems': typeof ProblemsRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/success': typeof SuccessRoute
   '/_authenticated/_app': typeof AuthenticatedAppRouteWithChildren
   '/_authenticated/_onboarding': typeof AuthenticatedOnboardingRouteWithChildren
   '/api/$': typeof ApiSplatRoute
@@ -406,6 +415,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/problems'
     | '/sitemap.xml'
+    | '/success'
     | '/api/$'
     | '/groups/$groupId'
     | '/admin/audit'
@@ -446,6 +456,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/problems'
     | '/sitemap.xml'
+    | '/success'
     | '/api/$'
     | '/admin/audit'
     | '/admin/config'
@@ -485,6 +496,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/problems'
     | '/sitemap.xml'
+    | '/success'
     | '/_authenticated/_app'
     | '/_authenticated/_onboarding'
     | '/api/$'
@@ -530,12 +542,20 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   ProblemsRoute: typeof ProblemsRoute
   SitemapDotxmlRoute: typeof SitemapDotxmlRoute
+  SuccessRoute: typeof SuccessRoute
   ApiSplatRoute: typeof ApiSplatRoute
   GroupsGroupIdRoute: typeof GroupsGroupIdRouteWithChildren
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/success': {
+      id: '/success'
+      path: '/success'
+      fullPath: '/success'
+      preLoaderRoute: typeof SuccessRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/sitemap.xml': {
       id: '/sitemap.xml'
       path: '/sitemap.xml'
@@ -979,6 +999,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   ProblemsRoute: ProblemsRoute,
   SitemapDotxmlRoute: SitemapDotxmlRoute,
+  SuccessRoute: SuccessRoute,
   ApiSplatRoute: ApiSplatRoute,
   GroupsGroupIdRoute: GroupsGroupIdRouteWithChildren,
 }

--- a/src/routes/success.tsx
+++ b/src/routes/success.tsx
@@ -1,0 +1,48 @@
+import { IconCircleCheckFilled } from "@tabler/icons-react"
+import { useQueryClient } from "@tanstack/react-query"
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { useEffect } from "react"
+
+import { Button } from "@/components/ui/button"
+import { ME_QUERY_KEY } from "@/features/settings/hooks/use-me"
+import { authClient } from "@/lib/auth-client"
+
+type SuccessSearch = { checkout_id?: string }
+
+export const Route = createFileRoute("/success")({
+	validateSearch: (search: Record<string, unknown>): SuccessSearch => ({
+		checkout_id: typeof search.checkout_id === "string" ? search.checkout_id : undefined,
+	}),
+	component: SuccessPage,
+})
+
+function SuccessPage() {
+	const queryClient = useQueryClient()
+
+	// The webhook is the source of truth for the Pro grant; it may land a beat
+	// before or after this redirect. Force a fresh session + `me` so Pro shows up
+	// as soon as it's applied, without a manual reload.
+	useEffect(() => {
+		void authClient.getSession({ query: { disableCookieCache: true } })
+		void queryClient.invalidateQueries({ queryKey: ME_QUERY_KEY })
+	}, [queryClient])
+
+	return (
+		<div className="flex min-h-dvh items-center justify-center bg-background px-6">
+			<div className="flex max-w-md flex-col items-center gap-5 text-center">
+				<IconCircleCheckFilled className="size-14 text-warning" aria-hidden="true" />
+				<div>
+					<h1 className="font-semibold text-2xl tracking-tight">You're Pro 🎉</h1>
+					<p className="mt-2 text-muted-foreground text-sm">
+						Your purchase is complete and Pro is now active on your account — lifetime, no
+						renewals. Create groups, join up to 5, run groups of 50, and get 4 pauses a
+						month.
+					</p>
+				</div>
+				<Button asChild>
+					<Link to="/dashboard">Go to Dashboard</Link>
+				</Button>
+			</div>
+		</div>
+	)
+}

--- a/src/server/lib/auth.ts
+++ b/src/server/lib/auth.ts
@@ -12,6 +12,7 @@ import { sendEmail } from "@/server/lib/email"
 import { logger } from "@/server/lib/logger"
 import { sendMagicLinkEmail } from "@/server/lib/magic-link-email"
 import { polarClient } from "@/server/lib/polar"
+import { grantProFromPurchase, revokeProFromRefund } from "@/server/lib/pro"
 
 export const auth = betterAuth({
 	appName: "PStrack",
@@ -127,11 +128,31 @@ export const auth = betterAuth({
 							webhooks({
 								secret: env.POLAR_WEBHOOK_SECRET,
 								onOrderPaid: async (payload) => {
+									// Grant Pro FIRST (source of truth) — the Better Auth Polar
+									// plugin does NOT set isPro automatically. Then notify admin.
+									await grantProFromPurchase({
+										externalId: payload.data.customer.externalId,
+										email: payload.data.customer.email,
+									})
 									await notifyAdmin("purchase.pro", {
 										email: payload.data.customer.email ?? undefined,
 										plan: payload.data.product?.name ?? "Pro",
 										amount: payload.data.netAmount,
 										purchasedAt: new Date().toISOString(),
+									})
+								},
+								onOrderRefunded: async (payload) => {
+									// Lifetime Pro → a refund claws it back (only when the
+									// account's Pro came from a purchase).
+									await revokeProFromRefund({
+										externalId: payload.data.customer.externalId,
+										email: payload.data.customer.email,
+									})
+									await notifyAdmin("purchase.pro.refunded", {
+										email: payload.data.customer.email ?? undefined,
+										plan: payload.data.product?.name ?? "Pro",
+										amount: payload.data.netAmount,
+										refundedAt: new Date().toISOString(),
 									})
 								},
 							}),

--- a/src/server/lib/pro.test.ts
+++ b/src/server/lib/pro.test.ts
@@ -1,0 +1,165 @@
+// @ts-nocheck
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/env", () => ({
+	env: {
+		BETTER_AUTH_URL: "https://pstrack.localhost/",
+		EMAIL_FROM: "PStrack <pro@pstrack.localhost>",
+	},
+}))
+
+vi.mock("@/emails/pro-unlocked-by-purchase", () => ({
+	default: vi.fn((props) => ({ type: "ProUnlockedByPurchaseEmail", props })),
+}))
+
+vi.mock("@/server/lib/db", () => ({
+	db: {
+		user: {
+			findUnique: vi.fn(),
+			update: vi.fn(),
+		},
+	},
+}))
+
+vi.mock("@/server/lib/email", () => ({
+	sendEmail: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("@/server/lib/sentry", () => ({
+	captureServerException: vi.fn(),
+}))
+
+vi.mock("@/server/lib/logger", () => ({
+	logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+}))
+
+import { ProSource } from "@/generated/prisma/enums"
+import { db } from "@/server/lib/db"
+import { sendEmail } from "@/server/lib/email"
+import { logger } from "@/server/lib/logger"
+import { grantProFromPurchase, revokeProFromRefund } from "./pro"
+
+const baseUser = {
+	id: "u1",
+	email: "a@example.com",
+	emailVerified: true,
+	name: "Ada",
+	isPro: false,
+	proSource: null,
+}
+
+describe("grantProFromPurchase", () => {
+	afterEach(() => vi.clearAllMocks())
+
+	it("grants lifetime purchase Pro to a new buyer resolved via externalId and emails them", async () => {
+		db.user.findUnique.mockResolvedValueOnce({ ...baseUser })
+
+		await grantProFromPurchase({ externalId: "u1", email: "a@example.com" })
+
+		expect(db.user.update).toHaveBeenCalledWith({
+			where: { id: "u1" },
+			data: { isPro: true, proSource: ProSource.POLAR_PURCHASE, proExpiresAt: null },
+		})
+		expect(sendEmail).toHaveBeenCalledTimes(1)
+	})
+
+	it("is idempotent when the user already holds purchase-sourced Pro (no update, no email)", async () => {
+		db.user.findUnique.mockResolvedValueOnce({
+			...baseUser,
+			isPro: true,
+			proSource: ProSource.POLAR_PURCHASE,
+		})
+
+		await grantProFromPurchase({ externalId: "u1" })
+
+		expect(db.user.update).not.toHaveBeenCalled()
+		expect(sendEmail).not.toHaveBeenCalled()
+	})
+
+	it("does NOT overwrite an earned (points) source and sends no email when an existing Pro buys", async () => {
+		db.user.findUnique.mockResolvedValueOnce({
+			...baseUser,
+			isPro: true,
+			proSource: ProSource.POINTS_THRESHOLD,
+		})
+
+		await grantProFromPurchase({ externalId: "u1" })
+
+		// isPro stays true; proSource is preserved (NOT stamped POLAR_PURCHASE) so a
+		// later refund can't revoke independently-earned Pro.
+		expect(db.user.update).toHaveBeenCalledWith({
+			where: { id: "u1" },
+			data: { isPro: true },
+		})
+		expect(sendEmail).not.toHaveBeenCalled()
+	})
+
+	it("does not grant when no user resolves (logs, no update)", async () => {
+		db.user.findUnique.mockResolvedValue(null)
+
+		await grantProFromPurchase({ externalId: "ghost", email: "nobody@example.com" })
+
+		expect(db.user.update).not.toHaveBeenCalled()
+		expect(logger.error).toHaveBeenCalled()
+	})
+
+	it("rejects the email fallback for an unverified address", async () => {
+		// externalId absent → email branch; email exists but is unverified → no grant.
+		db.user.findUnique.mockResolvedValueOnce({ ...baseUser, emailVerified: false })
+
+		await grantProFromPurchase({ email: "a@example.com" })
+
+		expect(db.user.update).not.toHaveBeenCalled()
+	})
+
+	it("accepts the email fallback for a verified address and warns", async () => {
+		db.user.findUnique.mockResolvedValueOnce({ ...baseUser, emailVerified: true })
+
+		await grantProFromPurchase({ email: "a@example.com" })
+
+		expect(db.user.update).toHaveBeenCalledWith({
+			where: { id: "u1" },
+			data: { isPro: true, proSource: ProSource.POLAR_PURCHASE, proExpiresAt: null },
+		})
+		expect(logger.warn).toHaveBeenCalled()
+	})
+})
+
+describe("revokeProFromRefund", () => {
+	afterEach(() => vi.clearAllMocks())
+
+	it("revokes Pro when the account's Pro came from a purchase", async () => {
+		db.user.findUnique.mockResolvedValueOnce({
+			...baseUser,
+			isPro: true,
+			proSource: ProSource.POLAR_PURCHASE,
+		})
+
+		await revokeProFromRefund({ externalId: "u1" })
+
+		expect(db.user.update).toHaveBeenCalledWith({
+			where: { id: "u1" },
+			data: { isPro: false, proSource: null, proExpiresAt: null },
+		})
+	})
+
+	it("does NOT revoke Pro earned via points (protects earned Pro from refund griefing)", async () => {
+		db.user.findUnique.mockResolvedValueOnce({
+			...baseUser,
+			isPro: true,
+			proSource: ProSource.POINTS_THRESHOLD,
+		})
+
+		await revokeProFromRefund({ externalId: "u1" })
+
+		expect(db.user.update).not.toHaveBeenCalled()
+	})
+
+	it("is a no-op when no user resolves", async () => {
+		db.user.findUnique.mockResolvedValue(null)
+
+		await revokeProFromRefund({ externalId: "ghost" })
+
+		expect(db.user.update).not.toHaveBeenCalled()
+	})
+})

--- a/src/server/lib/pro.ts
+++ b/src/server/lib/pro.ts
@@ -8,6 +8,15 @@ import { captureServerException } from "@/server/lib/sentry"
 
 const BASE_URL = env.BETTER_AUTH_URL.replace(/\/$/, "")
 
+const USER_SELECT = {
+	id: true,
+	email: true,
+	emailVerified: true,
+	name: true,
+	isPro: true,
+	proSource: true,
+} as const
+
 /**
  * A Polar order/refund payload identifies the customer by `externalId` (set to
  * the pstrack user id on sign-up via `createCustomerOnSignUp`) with `email` as a
@@ -18,19 +27,38 @@ export type PolarCustomerRef = {
 	email?: string | null
 }
 
-const resolveUser = async (customer: PolarCustomerRef) => {
+type ResolvedUser = {
+	user: {
+		id: string
+		email: string
+		emailVerified: boolean
+		name: string
+		isPro: boolean
+		proSource: ProSource | null
+	}
+	via: "externalId" | "email"
+}
+
+/**
+ * Resolve a Polar customer back to a pstrack user. Prefer `externalId` (set
+ * server-side to the user id on sign-up — the trusted path). The `email`
+ * fallback is defence-in-depth-gated on `emailVerified` so an unverified
+ * address can never be used to steer a grant.
+ */
+const resolveUser = async (customer: PolarCustomerRef): Promise<ResolvedUser | null> => {
 	if (customer.externalId) {
 		const byId = await db.user.findUnique({
 			where: { id: customer.externalId },
-			select: { id: true, email: true, name: true, isPro: true, proSource: true },
+			select: USER_SELECT,
 		})
-		if (byId) return byId
+		if (byId) return { user: byId, via: "externalId" }
 	}
 	if (customer.email) {
-		return db.user.findUnique({
+		const byEmail = await db.user.findUnique({
 			where: { email: customer.email },
-			select: { id: true, email: true, name: true, isPro: true, proSource: true },
+			select: USER_SELECT,
 		})
+		if (byEmail?.emailVerified) return { user: byEmail, via: "email" }
 	}
 	return null
 }
@@ -41,16 +69,25 @@ const resolveUser = async (customer: PolarCustomerRef) => {
  * Pro, so we never double-send the confirmation email.
  */
 export const grantProFromPurchase = async (customer: PolarCustomerRef): Promise<void> => {
-	const user = await resolveUser(customer)
-	if (!user) {
+	const resolved = await resolveUser(customer)
+	if (!resolved) {
+		// Never log the raw email (PII). externalId is the user id, safe to log.
 		logger.error(
-			{ externalId: customer.externalId, email: customer.email },
+			{ externalId: customer.externalId ?? null, hasEmail: Boolean(customer.email) },
 			"polar order paid: could not resolve user — Pro NOT granted"
 		)
 		return
 	}
 
-	// Fully idempotent: already Pro from this exact source → nothing to do.
+	const { user, via } = resolved
+	if (via === "email") {
+		logger.warn(
+			{ userId: user.id },
+			"polar order paid: resolved user via email fallback, not externalId"
+		)
+	}
+
+	// Fully idempotent: already Pro from a purchase → nothing to do.
 	if (user.isPro && user.proSource === ProSource.POLAR_PURCHASE) return
 
 	const wasPro = user.isPro
@@ -59,13 +96,15 @@ export const grantProFromPurchase = async (customer: PolarCustomerRef): Promise<
 		where: { id: user.id },
 		data: {
 			isPro: true,
-			proSource: ProSource.POLAR_PURCHASE,
-			proExpiresAt: null,
+			// Preserve an independently-earned source (points / admin grant) so a
+			// later refund can't claw back Pro the user did NOT buy. Only stamp
+			// POLAR_PURCHASE (and clear expiry) when they weren't already Pro.
+			...(wasPro ? {} : { proSource: ProSource.POLAR_PURCHASE, proExpiresAt: null }),
 		},
 	})
 
-	// Only email someone who wasn't already Pro (e.g. a points/admin Pro who then
-	// buys just gets the source re-attributed, no "welcome to Pro" email).
+	// Only email someone who wasn't already Pro; an existing Pro who buys just
+	// funds the project — no "welcome to Pro" email.
 	if (!wasPro) {
 		sendEmail({
 			from: env.EMAIL_FROM,
@@ -81,12 +120,15 @@ export const grantProFromPurchase = async (customer: PolarCustomerRef): Promise<
 
 /**
  * Revoke Pro on a Polar refund — but ONLY when the account's Pro came from a
- * purchase. A user who also crossed the points threshold or holds an admin grant
- * keeps their Pro; we never claw back Pro they earned another way.
+ * purchase. A user who crossed the points threshold or holds an admin grant
+ * keeps their Pro; we never claw back Pro they earned another way. Combined with
+ * the source-preserving grant above, a points/admin Pro who also bought (and is
+ * therefore still `POINTS_THRESHOLD`/`ADMIN_GRANT`) is safe from refund revoke.
  */
 export const revokeProFromRefund = async (customer: PolarCustomerRef): Promise<void> => {
-	const user = await resolveUser(customer)
-	if (!user) return
+	const resolved = await resolveUser(customer)
+	if (!resolved) return
+	const { user } = resolved
 	if (user.proSource !== ProSource.POLAR_PURCHASE) return
 
 	await db.user.update({

--- a/src/server/lib/pro.ts
+++ b/src/server/lib/pro.ts
@@ -1,0 +1,97 @@
+import ProUnlockedByPurchaseEmail from "@/emails/pro-unlocked-by-purchase"
+import { env } from "@/env"
+import { ProSource } from "@/generated/prisma/enums"
+import { db } from "@/server/lib/db"
+import { sendEmail } from "@/server/lib/email"
+import { logger } from "@/server/lib/logger"
+import { captureServerException } from "@/server/lib/sentry"
+
+const BASE_URL = env.BETTER_AUTH_URL.replace(/\/$/, "")
+
+/**
+ * A Polar order/refund payload identifies the customer by `externalId` (set to
+ * the pstrack user id on sign-up via `createCustomerOnSignUp`) with `email` as a
+ * fallback. This is the ONLY mapping from a Polar customer back to a user.
+ */
+export type PolarCustomerRef = {
+	externalId?: string | null
+	email?: string | null
+}
+
+const resolveUser = async (customer: PolarCustomerRef) => {
+	if (customer.externalId) {
+		const byId = await db.user.findUnique({
+			where: { id: customer.externalId },
+			select: { id: true, email: true, name: true, isPro: true, proSource: true },
+		})
+		if (byId) return byId
+	}
+	if (customer.email) {
+		return db.user.findUnique({
+			where: { email: customer.email },
+			select: { id: true, email: true, name: true, isPro: true, proSource: true },
+		})
+	}
+	return null
+}
+
+/**
+ * Grant lifetime Pro from a completed Polar purchase. Idempotent: a redelivered
+ * `order.paid` webhook is a no-op once the user already holds purchase-sourced
+ * Pro, so we never double-send the confirmation email.
+ */
+export const grantProFromPurchase = async (customer: PolarCustomerRef): Promise<void> => {
+	const user = await resolveUser(customer)
+	if (!user) {
+		logger.error(
+			{ externalId: customer.externalId, email: customer.email },
+			"polar order paid: could not resolve user — Pro NOT granted"
+		)
+		return
+	}
+
+	// Fully idempotent: already Pro from this exact source → nothing to do.
+	if (user.isPro && user.proSource === ProSource.POLAR_PURCHASE) return
+
+	const wasPro = user.isPro
+
+	await db.user.update({
+		where: { id: user.id },
+		data: {
+			isPro: true,
+			proSource: ProSource.POLAR_PURCHASE,
+			proExpiresAt: null,
+		},
+	})
+
+	// Only email someone who wasn't already Pro (e.g. a points/admin Pro who then
+	// buys just gets the source re-attributed, no "welcome to Pro" email).
+	if (!wasPro) {
+		sendEmail({
+			from: env.EMAIL_FROM,
+			to: user.email,
+			subject: "Your PStrack Pro is active",
+			react: ProUnlockedByPurchaseEmail({
+				name: user.name,
+				dashboardUrl: `${BASE_URL}/dashboard`,
+			}),
+		}).catch((err) => captureServerException(err, { tag: "email:pro-unlocked-purchase" }))
+	}
+}
+
+/**
+ * Revoke Pro on a Polar refund — but ONLY when the account's Pro came from a
+ * purchase. A user who also crossed the points threshold or holds an admin grant
+ * keeps their Pro; we never claw back Pro they earned another way.
+ */
+export const revokeProFromRefund = async (customer: PolarCustomerRef): Promise<void> => {
+	const user = await resolveUser(customer)
+	if (!user) return
+	if (user.proSource !== ProSource.POLAR_PURCHASE) return
+
+	await db.user.update({
+		where: { id: user.id },
+		data: { isPro: false, proSource: null, proExpiresAt: null },
+	})
+	logger.info({ userId: user.id }, "polar refund: revoked purchase-sourced Pro")
+}


### PR DESCRIPTION
## Summary
- **Paying now actually grants Pro.** The Polar `onOrderPaid` webhook previously only pinged the admin bot; it now maps the Polar customer → pstrack user (via `customer.externalId`, set to the user id on sign-up, with an email fallback) and sets `isPro=true, proSource=POLAR_PURCHASE, proExpiresAt=null` — **idempotently**, so a redelivered webhook won't double-grant or double-email.
- **Refunds claw Pro back** — `onOrderRefunded` revokes Pro, but only when `proSource === POLAR_PURCHASE`, so a points/admin Pro who also bought is never wrongly downgraded.
- **New `/success` page** refetches the session + `me` query so Pro reflects immediately after checkout (no manual reload); the env `POLAR_SUCCESS_URL` finally resolves to a real route.
- **Confirmation email** on purchase (`pro-unlocked-by-purchase`, adapted from the points variant); `POLAR_WEBHOOK_SECRET` documented in `.env.example` (webhooks are gated on it).
- **Docs corrected:** `FREEMIUM_MODEL.md` claimed the Better Auth Polar plugin auto-grants Pro — it does not, and that false assumption was the root cause of paying granting nothing. `DECISIONS.md` now records the explicit-webhook design. Added `CONTEXT.md` domain glossary.

## Testing
1. Set `POLAR_WEBHOOK_SECRET` and point a Polar **sandbox** webhook at the Better Auth Polar route.
2. Complete a sandbox checkout for the `pstrack` product → confirm `User.isPro=true, proSource=POLAR_PURCHASE`, a confirmation email is sent, and `/success` shows Pro without a reload.
3. Redeliver the same `order.paid` webhook → **no** double-grant, **no** second email.
4. Refund the order in Polar → `onOrderRefunded` sets `isPro=false` (only when source was a purchase).
5. Automated: `bun run build && bun run typecheck && bun run test` — all green (62 tests, incl. 9 for pro.ts), lint clean.

Refs #240

> Per the SDLC QA gate, merging moves this to **QA** (verify the sandbox purchase path), not straight to Done.

## Glossary
| Term | Definition |
|------|------------|
| ProSource | How an account became Pro: `POLAR_PURCHASE` / `POINTS_THRESHOLD` / `ADMIN_GRANT` / `INVITATION`. |
| externalId | The Polar customer's external id — set to the pstrack user id on sign-up; the sole mapping from a Polar customer back to a user. |
| Idempotent | Re-delivering the same webhook produces no additional effect (no double-grant / double-email). |
| order.paid / order.refunded | Polar webhook events for a completed / refunded one-time purchase. |