### PR TITLE
fix(#244): solve-verification concurrency fix + improve batch (9 changes)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ UPSTASH_REDIS_REST_TOKEN="your-token-here"
 # Generate a 32+ char secret: openssl rand -base64 32
 BETTER_AUTH_SECRET="replace-with-a-32-char-random-string"
 BETTER_AUTH_URL="https://pstrack.localhost"
+BETTER_AUTH_API_KEY="changeme"
 
 # OAuth providers
 # Google: https://console.cloud.google.com/apis/credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,32 @@ jobs:
   test:
     name: Vitest
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: pstrack
+          POSTGRES_PASSWORD: pstrack
+          POSTGRES_DB: pstrack
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5433:5432
+    env:
+      DATABASE_URL: postgresql://pstrack:pstrack@127.0.0.1:5433/pstrack?schema=public
+      DIRECT_URL: postgresql://pstrack:pstrack@127.0.0.1:5433/pstrack?schema=public
+      TEST_DATABASE_URL: postgresql://pstrack:pstrack@127.0.0.1:5433/pstrack?schema=public
+      # Skip t3-env validation so unit tests don't need every secret; the real DB
+      # connection via TEST_DATABASE_URL provides the actual connectivity check.
+      SKIP_ENV_VALIDATION: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
+      - name: Apply migrations to test DB
+        run: bunx prisma migrate deploy
       - run: bun run test
 
   build:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ PStrack is a competitive programming accountability platform. Users join groups,
 | Action | Outcome                                            |
 | ------ | -------------------------------------------------- |
 | Solve  | +10 pts, +5 if first in group, streak continues    |
-| Pause  | Streak preserved, no points lost, consumes 1 pause |
+| Pause  | Streak preserved, −5 pts, consumes 1 pause |
 | Miss   | -3 pts, streak resets                              |
 
 ## Points & Gamification
@@ -192,7 +192,7 @@ if (dbUser?.role !== "admin") return error(403, { error: "Admin access required"
 |---|---|---|
 | `assign-daily-problem` | `0 0 * * *` | Picks the next NeetCode 250 problem per group's roadmap position; creates `DailyProblem` rows; sends daily digest emails |
 | `verify-submission` | On solve | Polls LeetCode/Codeforces for an accepted submission matching the problem + timestamp; awards points/bonuses, updates streak, evaluates badges |
-| `mark-missed` | `0 0 * * *` | For every `UserSolve` from yesterday without a terminal status: sets `MISSED`, applies −5, breaks streak, clawbacks same-day bonuses |
+| `mark-missed` | `0 0 * * *` | For every `UserSolve` from yesterday without a terminal status: sets `MISSED`, applies −3, breaks streak, and claws back same-day/streak bonuses |
 | `expire-join-requests` | Every hour | Marks `GroupJoinRequest` rows older than 1 day with status `PENDING` as `EXPIRED` |
 | `reset-monthly-pauses` | `0 0 1 * *` | Resets `User.pausesUsedThisMonth = 0` |
 | `reset-monthly-counters` | `0 0 1 * *` | Resets `User.verificationFailuresThisMonth = 0` |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,7 +8,7 @@ The source of truth for tokens is `src/styles.css`. This document explains what'
 
 ## 1. Color Tokens
 
-All colors are **semantic CSS variables in OKLCH**, defined in `src/styles.css` under `:root` (light) and `.dark` (dark). Tailwind v3 `@theme inline` directives expose them as utility classes (`bg-primary`, `text-muted-foreground`, etc.).
+All colors are **semantic CSS variables in OKLCH**, defined in `src/styles.css` under `:root` (light) and `.dark` (dark). Tailwind v4 `@theme inline` directives expose them as utility classes (`bg-primary`, `text-muted-foreground`, etc.).
 
 ### Surface & content
 
@@ -98,7 +98,7 @@ Base: `--radius: 0.625rem` (~10px). Scale multiplies that base:
 
 ## 5. Tailwind & Class Composition
 
-- **Tailwind v3** with `@theme inline` - the variables in `styles.css` are the configuration. There is no `tailwind.config.{js,ts}` to edit.
+- **Tailwind v4** with `@theme inline` - the variables in `styles.css` are the configuration. There is no `tailwind.config.{js,ts}` to edit.
 - **Class composition uses `cn()`** from `@/lib/utils`:
 
   ```tsx

--- a/docs/agdr/AgDR-0002-migration-points-history-unique-solve-reason.md
+++ b/docs/agdr/AgDR-0002-migration-points-history-unique-solve-reason.md
@@ -1,0 +1,72 @@
+# Migration: unique index on PointsHistory (userSolveId, reason)
+
+> In the context of fixing the solve-verification double-award race (plan 001), facing the fact that `applyPointsDelta` inserts a `PointsHistory` row unconditionally and no database constraint prevents a duplicate award, I decided to execute a **schema** migration adding `@@unique([userSolveId, reason])` to `PointsHistory`, to achieve database-level idempotency of point application per (solve, reason), accepting a one-time index build and a required pre-apply duplicate check on production.
+
+**Migration type**: schema (additive unique index)
+**Affected tables / entities**: `PointsHistory`
+**Estimated downtime**: none — an additive index; Prisma builds it non-concurrently, so on a large prod table it briefly locks writes to `PointsHistory`. See Testing/Observability for the concurrent-index note.
+**Data volume**: `PointsHistory` grows with every point change (one+ rows per solve/pause/miss/admin action) — could be large in prod; unknown exact count.
+**Target environment(s)**: dev/local now → staging → prod
+
+## Context
+
+The solve-verification flow (`verifyAndMarkSolved` in `src/server/problems/problems.dao.ts`) reads solved-status and the first-solver count *outside* the awarding transaction, and `applyPointsDeltaInTx` (`src/server/points/points.dao.ts`) does an unconditional `tx.pointsHistory.create(...)`. Two near-simultaneous solve submissions for the same user can therefore each insert a `DAILY_SOLVE` ledger row — doubling points. `PointsHistory` currently has only two non-unique indexes (`[userId, createdAt]`, `[userId, groupId, reason]`) and no uniqueness guard.
+
+Plan 001 fixes the application logic (re-check inside the transaction + atomic first-solver claim). This migration is the **database-level backstop**: with a unique index on `(userSolveId, reason)`, a duplicate `DAILY_SOLVE` insert for the same `userSolve` raises a constraint violation instead of silently double-awarding. `userSolveId` is nullable, and Postgres treats NULLs as distinct in unique indexes, so ledger rows not tied to a solve (join bonus, admin adjustments) are unaffected.
+
+## Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **`@@unique([userSolveId, reason])` on PointsHistory** | DB-enforced idempotency; NULL-userSolveId rows unaffected; cheap; reversible | Fails to apply if duplicate rows already exist (must dedupe first); non-concurrent build briefly locks writes |
+| Application-only guard (no DB constraint) | No migration, no index build | No protection against true-simultaneous transactions that both pass the in-tx re-read before either commits |
+| Composite PK / redesign of the ledger | Strongest integrity | Large blast radius on an append-only audit table; overkill for this fix |
+
+## Decision
+
+Chosen: **`@@unique([userSolveId, reason])`**, because it is the minimal, reversible, DB-level guarantee that pairs with plan 001's application-level fix to close the race completely, without disturbing the immutable append-only ledger design or the null-userSolveId rows.
+
+## Rollback Plan
+
+1. `DROP INDEX "PointsHistory_userSolveId_reason_key";` (name per the generated migration) — reverses the migration with no data change.
+2. Revert the `@@unique` line in `prisma/schema.prisma` and delete the migration directory, or `prisma migrate resolve --rolled-back <migration>` in prod.
+3. No data transformation is applied, so rollback is a pure index drop — safe at any time.
+
+**Rollback tested against**: unit fixture / local Postgres (the index is created and can be dropped locally). Not yet tested against a copy of prod — **do a copy-of-prod dry run before the prod apply** because of the duplicate-row risk below.
+**Rollback window**: unbounded — dropping the index never loses data.
+
+## Cross-Service Consumers
+
+- **none** — `PointsHistory` is an internal ledger written only by pstrack's own DAO layer (`applyPointsDelta`) and read by leaderboard/points queries within the same app. No external service reads or writes it.
+
+Deploy-order constraint:
+
+- **none** — the app code tolerates the index existing before or after deploy (the constraint only ever fires on a duplicate insert, which the plan-001 code no longer attempts).
+
+## Testing Plan
+
+- **Dev smoke**: `make up` (local Postgres) then `bun run db:migrate --name points_history_unique_solve_reason`; confirm the generated `migration.sql` contains `CREATE UNIQUE INDEX ... ON "PointsHistory"("userSolveId", "reason")` and that it applies cleanly to the (empty) local DB.
+- **Staging verify**: before applying, run the duplicate check —
+  `SELECT "userSolveId", reason, COUNT(*) FROM "PointsHistory" WHERE "userSolveId" IS NOT NULL GROUP BY 1,2 HAVING COUNT(*) > 1;`
+  Expect zero rows. If non-empty, the pre-fix bug already produced duplicates: dedupe (keep the earliest `createdAt` per pair, delete the extras) before applying, and reconcile the affected users' `totalPoints`.
+- **Prod**: repeat the duplicate check on a copy of prod first. Consider `CREATE UNIQUE INDEX CONCURRENTLY` (hand-written migration) instead of Prisma's default non-concurrent build to avoid a write lock on a large `PointsHistory`.
+- **Regression**: the plan-002 integration harness will add a two-concurrent-solves test asserting exactly one `DAILY_SOLVE` + one `FIRST_IN_GROUP` row.
+
+## Observability
+
+- **During apply**: watch the `bunx prisma migrate deploy` step in the CI deploy job (`.github/workflows/ci.yml`) — a failure here almost certainly means pre-existing duplicate rows.
+- **Post-apply**: no `PointsHistory` uniqueness-violation errors in Sentry under normal solve traffic (the plan-001 code should never trigger the constraint); `User.totalPoints` for a sampled user equals the sum of their ledger deltas.
+- **Alerts armed**: Sentry error-rate on the solve endpoint (`POST /problems/today/solve`) — a spike post-deploy would indicate the constraint firing on a legitimate path (should not happen).
+
+## Consequences
+
+- Point application becomes idempotent at the database level per `(userSolveId, reason)` — the double-award race cannot silently double-count even under true concurrency.
+- Any future feature that legitimately needs two ledger rows of the same reason for one solve would be blocked by this constraint and require revisiting it.
+- Prod apply now carries a mandatory pre-check/dedupe step (documented above) — a deliberate cost that surfaces latent duplicate data from the pre-fix bug.
+
+## Artifacts
+
+- Ticket: husamql3/pstrack#244 — https://github.com/husamql3/pstrack/issues/244
+- Commits / PRs: plan 001 on branch `advisor/execute-001-009`
+- Staging-run log: TBD
+- Post-apply dashboard snapshot: TBD

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,5 +7,7 @@ pre-commit:
 
 pre-push:
   commands:
+    typecheck:
+      run: bun run typecheck
     build:
       run: bun run build

--- a/prisma/migrations/20260707000001_points_history_unique_solve_reason/migration.sql
+++ b/prisma/migrations/20260707000001_points_history_unique_solve_reason/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "PointsHistory_userSolveId_reason_key" ON "PointsHistory"("userSolveId", "reason");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -302,6 +302,7 @@ model PointsHistory {
   userSolve UserSolve? @relation(fields: [userSolveId], references: [id])
   group     Group?     @relation(fields: [groupId], references: [id])
 
+  @@unique([userSolveId, reason])
   @@index([userId, createdAt])
   @@index([userId, groupId, reason])
 }

--- a/src/features/leaderboard/components/leaderboard-page.tsx
+++ b/src/features/leaderboard/components/leaderboard-page.tsx
@@ -1,4 +1,4 @@
-import { IconTrophy } from "@tabler/icons-react"
+import { IconLock, IconTrophy } from "@tabler/icons-react"
 import { Link, useNavigate, useSearch } from "@tanstack/react-router"
 import { useCallback, useTransition } from "react"
 
@@ -95,24 +95,23 @@ const GroupSelector = ({
 }
 
 // ─── Pro gate ─────────────────────────────────────────────────────────────────
-// TODO: re-enable when global leaderboard is restricted to Pro users
 
-// const ProGate = () => (
-// 	<div className="flex flex-col items-center gap-4 rounded-xl border border-border bg-background p-12 text-center">
-// 		<div className="flex size-12 items-center justify-center rounded-full bg-muted">
-// 			<IconLock className="size-5 text-muted-foreground" />
-// 		</div>
-// 		<div>
-// 			<p className="font-semibold text-base">Global Leaderboard is Pro only</p>
-// 			<p className="mt-1 text-muted-foreground text-sm">
-// 				Upgrade to Pro to see the top 100 solvers worldwide.
-// 			</p>
-// 		</div>
-// 		<Button asChild size="sm">
-// 			<Link to="/settings/account">Upgrade to Pro</Link>
-// 		</Button>
-// 	</div>
-// )
+const ProGate = () => (
+	<div className="flex flex-col items-center gap-4 rounded-xl border border-border bg-background p-12 text-center">
+		<div className="flex size-12 items-center justify-center rounded-full bg-muted">
+			<IconLock className="size-5 text-muted-foreground" />
+		</div>
+		<div>
+			<p className="font-semibold text-base">Global Leaderboard is Pro only</p>
+			<p className="mt-1 text-muted-foreground text-sm">
+				Upgrade to Pro to see the top 100 solvers worldwide.
+			</p>
+		</div>
+		<Button asChild size="sm">
+			<Link to="/settings/account">Upgrade to Pro</Link>
+		</Button>
+	</div>
+)
 
 // ─── No group state ───────────────────────────────────────────────────────────
 
@@ -168,17 +167,16 @@ const GroupLeaderboardSection = ({
 
 const GlobalLeaderboardSection = ({
 	period,
-	// TODO: re-enable isPro gate when we want to restrict global leaderboard to Pro users
-	// isPro,
+	isPro,
 	viewerUserId,
 }: {
 	period: LeaderboardPeriod
 	isPro: boolean
 	viewerUserId: string | null | undefined
 }) => {
-	const { data, isLoading } = useGlobalLeaderboard(period, true)
+	const { data, isLoading } = useGlobalLeaderboard(period, isPro)
 
-	// if (!isPro) return <ProGate />
+	if (!isPro) return <ProGate />
 
 	return (
 		<LeaderboardTable

--- a/src/server/groups/groups.notifications.ts
+++ b/src/server/groups/groups.notifications.ts
@@ -9,7 +9,10 @@ import { db } from "@/server/lib/db"
 import { sendEmail } from "@/server/lib/email"
 import { captureServerException } from "@/server/lib/sentry"
 
-const BASE_URL = env.BETTER_AUTH_URL.replace(/\/$/, "")
+// BETTER_AUTH_URL carries a schema default, but SKIP_ENV_VALIDATION (used by the
+// CI test job) bypasses zod defaults — fall back so importing this module, which
+// happens transitively in tests, never throws on an undefined value.
+const BASE_URL = (env.BETTER_AUTH_URL ?? "https://pstrack.localhost").replace(/\/$/, "")
 const groupName = (slug: string) => `@${slug}`
 const groupUrl = (groupId: string) => `${BASE_URL}/groups/${groupId}`
 const browseUrl = () => `${BASE_URL}/groups`

--- a/src/server/leaderboard/leaderboard.controller.test.ts
+++ b/src/server/leaderboard/leaderboard.controller.test.ts
@@ -1,0 +1,75 @@
+// @ts-nocheck
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+// Mock auth so session.ts can load without env vars
+vi.mock("@/server/lib/auth", () => ({
+	auth: {
+		api: {
+			getSession: vi.fn(),
+		},
+	},
+}))
+
+// Mock the DB
+vi.mock("@/server/lib/db", () => ({
+	db: {
+		user: {
+			findUnique: vi.fn(),
+		},
+	},
+}))
+
+import { auth } from "@/server/lib/auth"
+import { db } from "@/server/lib/db"
+import { requirePro } from "@/server/lib/session"
+
+const fakeRequest = new Request("https://example.com/")
+
+describe("requirePro", () => {
+	afterEach(() => vi.clearAllMocks())
+
+	it("returns 401 when there is no session", async () => {
+		auth.api.getSession.mockResolvedValue(null)
+
+		const result = await requirePro(fakeRequest)
+
+		expect(result.user).toBeNull()
+		expect(result.response).toBeDefined()
+		// Elysia's status() returns a Response-like; check it came back at all
+		expect(db.user.findUnique).not.toHaveBeenCalled()
+	})
+
+	it("returns 403 when the user is not Pro (isPro:false)", async () => {
+		auth.api.getSession.mockResolvedValue({
+			user: { id: "user-free", email: "free@example.com" },
+			session: {},
+		})
+		db.user.findUnique.mockResolvedValue({ isPro: false })
+
+		const result = await requirePro(fakeRequest)
+
+		expect(result.user).toBeNull()
+		expect(result.response).toBeDefined()
+		expect(db.user.findUnique).toHaveBeenCalledWith({
+			where: { id: "user-free" },
+			select: { isPro: true },
+		})
+	})
+
+	it("returns null response (pass-through) when the user is Pro", async () => {
+		auth.api.getSession.mockResolvedValue({
+			user: { id: "user-pro", email: "pro@example.com" },
+			session: {},
+		})
+		db.user.findUnique.mockResolvedValue({ isPro: true })
+
+		const result = await requirePro(fakeRequest)
+
+		expect(result.user).toEqual({ id: "user-pro", email: "pro@example.com" })
+		expect(result.response).toBeNull()
+		expect(db.user.findUnique).toHaveBeenCalledWith({
+			where: { id: "user-pro" },
+			select: { isPro: true },
+		})
+	})
+})

--- a/src/server/leaderboard/leaderboard.controller.ts
+++ b/src/server/leaderboard/leaderboard.controller.ts
@@ -1,6 +1,6 @@
 import { Elysia, status } from "elysia"
 
-import { getSessionUser, requireSessionUser } from "@/server/lib/session"
+import { getSessionUser, requirePro, requireSessionUser } from "@/server/lib/session"
 import { leaderboardDao } from "./leaderboard.dao"
 import { leaderboardModel } from "./leaderboard.model"
 import type { LeaderboardPeriod } from "./leaderboard.type"
@@ -14,7 +14,10 @@ export const leaderboardController = new Elysia({
 	.use(leaderboardModel)
 	.get(
 		"/global",
-		async ({ query }) => {
+		async ({ query, request }) => {
+			const { user, response } = await requirePro(request)
+			if (!user) return response
+
 			const period = (query.period ?? DEFAULT_PERIOD) as LeaderboardPeriod
 			return leaderboardDao.getGlobalLeaderboard(period)
 		},

--- a/src/server/leaderboard/leaderboard.dao.test.ts
+++ b/src/server/leaderboard/leaderboard.dao.test.ts
@@ -1,0 +1,125 @@
+// @ts-nocheck
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/server/lib/db", () => ({
+	db: {
+		group: { findUnique: vi.fn() },
+		groupMember: { findMany: vi.fn() },
+		pointsHistory: { groupBy: vi.fn() },
+	},
+}))
+
+import { db } from "@/server/lib/db"
+import { leaderboardDao } from "./leaderboard.dao"
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const makeUser = (id: string, totalPoints = 0) => ({
+	id,
+	username: `user-${id}`,
+	name: `User ${id}`,
+	isPro: false,
+	currentStreak: 0,
+	totalPoints,
+})
+
+const makeGroup = (id = "group-1") => ({
+	id,
+	slug: `slug-${id}`,
+	_count: { members: 3 },
+})
+
+describe("leaderboardDao.getGroupLeaderboard", () => {
+	afterEach(() => vi.clearAllMocks())
+
+	describe("week period (non-alltime)", () => {
+		it("issues exactly one groupBy — not one aggregate per member", async () => {
+			const members = [
+				{ user: makeUser("u1", 100) },
+				{ user: makeUser("u2", 200) },
+				{ user: makeUser("u3", 300) },
+			]
+
+			db.group.findUnique.mockResolvedValue(makeGroup())
+			db.groupMember.findMany.mockResolvedValue(members)
+			// u3 has earned 50 pts this week; u1 and u2 have no windowed history
+			db.pointsHistory.groupBy.mockResolvedValue([{ userId: "u3", _sum: { delta: 50 } }])
+
+			await leaderboardDao.getGroupLeaderboard("group-1", "week")
+
+			// One groupBy call, never aggregate
+			expect(db.pointsHistory.groupBy).toHaveBeenCalledOnce()
+		})
+
+		it("a member absent from the groupBy result gets periodPoints: 0", async () => {
+			const members = [
+				{ user: makeUser("u1", 100) },
+				{ user: makeUser("u2", 200) },
+				{ user: makeUser("u3", 300) },
+			]
+
+			db.group.findUnique.mockResolvedValue(makeGroup())
+			db.groupMember.findMany.mockResolvedValue(members)
+			// Only u3 appears in the windowed result
+			db.pointsHistory.groupBy.mockResolvedValue([{ userId: "u3", _sum: { delta: 50 } }])
+
+			const result = await leaderboardDao.getGroupLeaderboard("group-1", "week")
+
+			const byUserId = Object.fromEntries(
+				result.entries.map((e) => [e.userId, e.periodPoints])
+			)
+			expect(byUserId.u1).toBe(0) // absent → 0
+			expect(byUserId.u2).toBe(0) // absent → 0
+			expect(byUserId.u3).toBe(50) // present → summed delta
+		})
+
+		it("passes all member userIds as an IN filter to the single groupBy call", async () => {
+			const members = [
+				{ user: makeUser("u1") },
+				{ user: makeUser("u2") },
+				{ user: makeUser("u3") },
+			]
+
+			db.group.findUnique.mockResolvedValue(makeGroup())
+			db.groupMember.findMany.mockResolvedValue(members)
+			db.pointsHistory.groupBy.mockResolvedValue([])
+
+			await leaderboardDao.getGroupLeaderboard("group-1", "week")
+
+			const [callArgs] = db.pointsHistory.groupBy.mock.calls
+			expect(callArgs[0].where.userId).toEqual({ in: ["u1", "u2", "u3"] })
+		})
+	})
+
+	describe("alltime period", () => {
+		it("uses totalPoints from the denormalized cache and issues no groupBy", async () => {
+			const members = [{ user: makeUser("u1", 100) }, { user: makeUser("u2", 200) }]
+
+			db.group.findUnique.mockResolvedValue(makeGroup())
+			db.groupMember.findMany.mockResolvedValue(members)
+
+			const result = await leaderboardDao.getGroupLeaderboard("group-1", "alltime")
+
+			// No groupBy issued at all
+			expect(db.pointsHistory.groupBy).not.toHaveBeenCalled()
+
+			// periodPoints comes from totalPoints (the denormalized cache)
+			const byUserId = Object.fromEntries(
+				result.entries.map((e) => [e.userId, e.periodPoints])
+			)
+			expect(byUserId.u1).toBe(100)
+			expect(byUserId.u2).toBe(200)
+		})
+	})
+
+	describe("group not found", () => {
+		it("returns null when the group does not exist", async () => {
+			db.group.findUnique.mockResolvedValue(null)
+
+			const result = await leaderboardDao.getGroupLeaderboard("nonexistent", "week")
+
+			expect(result).toBeNull()
+			expect(db.pointsHistory.groupBy).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/src/server/leaderboard/leaderboard.dao.ts
+++ b/src/server/leaderboard/leaderboard.dao.ts
@@ -81,29 +81,29 @@ export const leaderboardDao = {
 
 		const start = periodStart(period)
 
-		const rows = await Promise.all(
-			members.map(async ({ user }) => {
-				let periodPoints: number
-
-				if (period === "alltime" || !start) {
-					// Use the denormalized total directly for all-time
-					periodPoints = user.totalPoints
-				} else {
-					// groupId is null on solve points — sum by userId + period only
-					const agg = await db.pointsHistory.aggregate({
-						where: {
-							userId: user.id,
-							reason: { in: EARN_REASONS },
-							createdAt: { gte: start },
-						},
-						_sum: { delta: true },
-					})
-					periodPoints = agg._sum.delta ?? 0
-				}
-
-				return { userId: user.id, ...user, periodPoints }
+		let periodByUser: Map<string, number> | null = null
+		if (period !== "alltime" && start) {
+			const userIds = members.map((m) => m.user.id)
+			const agg = await db.pointsHistory.groupBy({
+				by: ["userId"],
+				where: {
+					userId: { in: userIds },
+					reason: { in: EARN_REASONS },
+					createdAt: { gte: start },
+				},
+				_sum: { delta: true },
 			})
-		)
+			periodByUser = new Map(agg.map((r) => [r.userId, r._sum.delta ?? 0]))
+		}
+
+		const rows = members.map(({ user }) => ({
+			userId: user.id,
+			...user,
+			periodPoints:
+				period === "alltime" || !periodByUser
+					? user.totalPoints
+					: (periodByUser.get(user.id) ?? 0),
+		}))
 
 		return {
 			groupId: group.id,

--- a/src/server/lib/email.ts
+++ b/src/server/lib/email.ts
@@ -3,7 +3,27 @@ import { type CreateEmailOptions, Resend } from "resend"
 import { env } from "@/env"
 import { logger } from "@/server/lib/logger"
 
-export const resend = new Resend(env.RESEND_API_KEY)
+let client: Resend | null = null
+
+/**
+ * Construct the Resend client lazily on first use. Building it eagerly at module
+ * load throws ("Missing API key") whenever RESEND_API_KEY is absent — e.g. CI
+ * test runs that set SKIP_ENV_VALIDATION and don't provide email secrets. That
+ * would crash any module (or test suite) that merely imports this file, even if
+ * it never sends an email. Deferring construction keeps the module import-safe.
+ */
+const getClient = (): Resend => {
+	if (!client) client = new Resend(env.RESEND_API_KEY)
+	return client
+}
+
+/**
+ * Proxy over the lazily-created client, preserving the full call surface
+ * (`resend.emails.send(...)`, `resend.batch.send(...)`) for existing consumers.
+ */
+export const resend: Resend = new Proxy({} as Resend, {
+	get: (_target, prop) => Reflect.get(getClient(), prop),
+})
 
 export const sendEmail = async (payload: CreateEmailOptions) => {
 	const result = await resend.emails.send(payload)

--- a/src/server/lib/session.ts
+++ b/src/server/lib/session.ts
@@ -65,3 +65,22 @@ export const requirePlatformAdmin = async (request: Request) => {
 
 	return { user, response: null }
 }
+
+export const requirePro = async (request: Request) => {
+	const { user, response } = await requireSessionUser(request)
+	if (!user) return { user: null, response }
+
+	const dbUser = await db.user.findUnique({
+		where: { id: user.id },
+		select: { isPro: true },
+	})
+
+	if (!dbUser?.isPro) {
+		return {
+			user: null,
+			response: status(403, { error: "Pro required" }),
+		}
+	}
+
+	return { user, response: null }
+}

--- a/src/server/problems/daily-loop.integration.test.ts
+++ b/src/server/problems/daily-loop.integration.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Integration tests for the core daily loop.
+ *
+ * Everything hits the real test DB (see src/test/db.ts for the client).
+ * The ONLY thing mocked is the network call to LeetCode's GraphQL API
+ * (the `fetch` inside `verifyLeetCodeSubmission`), because we cannot
+ * make real outbound calls in CI.
+ *
+ * resetDb() is called in beforeEach via src/test/setup.ts.
+ */
+
+// @ts-nocheck — suppress strict-null / implicit-any for vi.spyOn globals
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { PointReason, SolveStatus } from "@/generated/prisma/enums"
+import {
+	FIRST_IN_GROUP_BONUS,
+	MISSED_PENALTY,
+	SOLVE_POINTS,
+} from "@/server/points/points.type"
+import { problemsDao } from "@/server/problems/problems.dao"
+import {
+	addMember,
+	createDailyProblem,
+	createGroup,
+	createProblem,
+	createUser,
+	testDb,
+} from "@/test/db"
+
+// ---------------------------------------------------------------------------
+// Helper: mock the LeetCode fetch globally
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+	vi.stubGlobal("fetch", mockFetch)
+})
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+/**
+ * Build a fetch mock that returns a successful LeetCode submission
+ * for the given slug, submitted `msSinceAssigned` ms after assignedDate.
+ */
+const mockLeetCodeMatch = (slug: string, submittedAtMs: number) => {
+	mockFetch.mockResolvedValue({
+		json: async () => ({
+			data: {
+				recentAcSubmissionList: [
+					{
+						titleSlug: slug,
+						timestamp: String(Math.floor(submittedAtMs / 1000)),
+					},
+				],
+			},
+		}),
+	})
+}
+
+const _mockLeetCodeNoMatch = () => {
+	mockFetch.mockResolvedValue({
+		json: async () => ({ data: { recentAcSubmissionList: [] } }),
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Seed helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Seed: active+started group, one member with a leetcodeHandle, one
+ * DailyProblem for `assignedDate`, with a RoadmapCatalog + RoadmapProblem
+ * so withRoadmapMetadata resolves cleanly.
+ */
+const seedHappyPath = async (assignedDate: Date) => {
+	const user = await createUser({ leetcodeHandle: "testhandle" })
+	const group = await createGroup({ roadmap: "NC250", isActive: true, isStarted: true })
+	await addMember(group.id, user.id)
+
+	const problem = await createProblem({
+		slug: "two-sum",
+		difficulty: "MEDIUM",
+		neetcode250: true,
+	})
+
+	// RoadmapCatalog is created by createGroup → createRoadmapCatalog("NC250").
+	// Add a RoadmapProblem so withRoadmapMetadata finds it.
+	const catalog = await testDb.roadmapCatalog.findUniqueOrThrow({
+		where: { key: "NC250" },
+	})
+	await testDb.roadmapProblem.create({
+		data: {
+			roadmapId: catalog.id,
+			problemId: problem.id,
+			position: 1,
+			topic: problem.topic,
+		},
+	})
+
+	const dailyProblem = await createDailyProblem({
+		groupId: group.id,
+		problemId: problem.id,
+		assignedDate,
+	})
+
+	return { user, group, problem, dailyProblem }
+}
+
+// ---------------------------------------------------------------------------
+// Test: happy-path solve
+// ---------------------------------------------------------------------------
+
+describe("verifyAndMarkSolved — happy path", () => {
+	it("creates a SOLVED UserSolve, DAILY_SOLVE + FIRST_IN_GROUP ledger rows, updates totalPoints and streak", async () => {
+		const today = new Date(
+			Date.UTC(
+				new Date().getUTCFullYear(),
+				new Date().getUTCMonth(),
+				new Date().getUTCDate()
+			)
+		)
+		const { user, problem } = await seedHappyPath(today)
+
+		// Mock: submission found, submitted 1 hour after midnight (within early-bird window)
+		const submittedAtMs = today.getTime() + 1 * 60 * 60 * 1000
+		mockLeetCodeMatch(problem.slug, submittedAtMs)
+
+		const result = await problemsDao.verifyAndMarkSolved(user.id)
+
+		// --- top-level result shape
+		expect(result.error).toBeNull()
+		expect(result.newStreak).toBe(1)
+
+		// --- UserSolve row
+		const solves = await testDb.userSolve.findMany({ where: { userId: user.id } })
+		expect(solves).toHaveLength(1)
+		const solve = solves[0]
+		expect(solve.status).toBe(SolveStatus.SOLVED)
+		expect(solve.isFirstInGroup).toBe(true)
+
+		// --- PointsHistory rows: DAILY_SOLVE, FIRST_IN_GROUP, EARLY_BIRD (submission < 12h)
+		const ledger = await testDb.pointsHistory.findMany({
+			where: { userId: user.id },
+			orderBy: { createdAt: "asc" },
+		})
+
+		const reasons = ledger.map((r) => r.reason)
+		expect(reasons).toContain(PointReason.DAILY_SOLVE)
+		expect(reasons).toContain(PointReason.FIRST_IN_GROUP)
+		expect(reasons).toContain(PointReason.EARLY_BIRD)
+
+		// No duplicates — each (userSolveId, reason) is unique in the ledger
+		const keys = ledger.map((r) => `${r.userSolveId}:${r.reason}`)
+		expect(new Set(keys).size).toBe(keys.length)
+
+		// --- Points amounts
+		const dailySolveDelta = ledger.find(
+			(r) => r.reason === PointReason.DAILY_SOLVE
+		)?.delta
+		expect(dailySolveDelta).toBe(SOLVE_POINTS.MEDIUM) // MEDIUM = 10
+
+		const firstInGroupDelta = ledger.find(
+			(r) => r.reason === PointReason.FIRST_IN_GROUP
+		)?.delta
+		expect(firstInGroupDelta).toBe(FIRST_IN_GROUP_BONUS) // +10
+
+		// --- User denormalized cache
+		const updatedUser = await testDb.user.findUniqueOrThrow({ where: { id: user.id } })
+		const expectedTotal = ledger.reduce((sum, r) => sum + r.delta, 0)
+		expect(updatedUser.totalPoints).toBe(expectedTotal)
+		expect(updatedUser.currentStreak).toBe(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Test: no-duplicate guard
+// ---------------------------------------------------------------------------
+
+describe("verifyAndMarkSolved — idempotency", () => {
+	it("calling twice produces exactly one DAILY_SOLVE and one FIRST_IN_GROUP row", async () => {
+		const today = new Date(
+			Date.UTC(
+				new Date().getUTCFullYear(),
+				new Date().getUTCMonth(),
+				new Date().getUTCDate()
+			)
+		)
+		const { user, problem } = await seedHappyPath(today)
+
+		const submittedAtMs = today.getTime() + 2 * 60 * 60 * 1000
+		mockLeetCodeMatch(problem.slug, submittedAtMs)
+
+		await problemsDao.verifyAndMarkSolved(user.id)
+
+		// Second call — mock still returns the same submission
+		mockLeetCodeMatch(problem.slug, submittedAtMs)
+		await problemsDao.verifyAndMarkSolved(user.id)
+
+		const dailySolveRows = await testDb.pointsHistory.findMany({
+			where: { userId: user.id, reason: PointReason.DAILY_SOLVE },
+		})
+		expect(dailySolveRows).toHaveLength(1)
+
+		const firstRows = await testDb.pointsHistory.findMany({
+			where: { userId: user.id, reason: PointReason.FIRST_IN_GROUP },
+		})
+		expect(firstRows).toHaveLength(1)
+	})
+})
+
+// ---------------------------------------------------------------------------
+// Test: mark-missed
+// ---------------------------------------------------------------------------
+
+describe("markMissedForDate", () => {
+	it("creates a MISSED UserSolve, writes a MISSED_DAY ledger row of -MISSED_PENALTY, and resets streak", async () => {
+		const yesterday = new Date(
+			Date.UTC(
+				new Date().getUTCFullYear(),
+				new Date().getUTCMonth(),
+				new Date().getUTCDate() - 1
+			)
+		)
+
+		// Seed a member who joined before yesterday (joinedAt default is now,
+		// so we override it to be safely before the reference date)
+		const user = await createUser({ leetcodeHandle: "missedhandle", currentStreak: 3 })
+		const group = await createGroup({ roadmap: "NC250", isActive: true, isStarted: true })
+
+		// Override joinedAt to be before yesterday so markMissedForDate picks it up
+		const member = await addMember(group.id, user.id)
+		await testDb.groupMember.update({
+			where: { id: member.id },
+			data: { joinedAt: new Date(yesterday.getTime() - 2 * 24 * 60 * 60 * 1000) },
+		})
+
+		// Give user a non-zero streak so we can confirm it resets
+		await testDb.user.update({
+			where: { id: user.id },
+			data: {
+				currentStreak: 3,
+				currentStreakStartedAt: new Date(yesterday.getTime() - 2 * 24 * 60 * 60 * 1000),
+			},
+		})
+
+		const problem = await createProblem({
+			slug: "missed-problem",
+			difficulty: "EASY",
+			neetcode250: true,
+		})
+		const catalog = await testDb.roadmapCatalog.findUniqueOrThrow({
+			where: { key: "NC250" },
+		})
+		await testDb.roadmapProblem.upsert({
+			where: { roadmapId_problemId: { roadmapId: catalog.id, problemId: problem.id } },
+			create: {
+				roadmapId: catalog.id,
+				problemId: problem.id,
+				position: 2,
+				topic: problem.topic,
+			},
+			update: {},
+		})
+
+		await createDailyProblem({
+			groupId: group.id,
+			problemId: problem.id,
+			assignedDate: yesterday,
+		})
+
+		// Act
+		const result = await problemsDao.markMissedForDate(yesterday, {
+			evaluateWarnings: false,
+		})
+
+		// --- outcome shape
+		expect(result.missed).toBe(1)
+
+		// --- UserSolve is MISSED
+		const solves = await testDb.userSolve.findMany({ where: { userId: user.id } })
+		expect(solves).toHaveLength(1)
+		expect(solves[0].status).toBe(SolveStatus.MISSED)
+
+		// --- PointsHistory contains a MISSED_DAY entry with -MISSED_PENALTY
+		const ledger = await testDb.pointsHistory.findMany({ where: { userId: user.id } })
+		const missedRow = ledger.find((r) => r.reason === PointReason.MISSED_DAY)
+		expect(missedRow).toBeDefined()
+		expect(missedRow?.delta).toBe(-MISSED_PENALTY)
+
+		// --- Streak reset
+		const updatedUser = await testDb.user.findUniqueOrThrow({ where: { id: user.id } })
+		expect(updatedUser.currentStreak).toBe(0)
+		expect(updatedUser.currentStreakStartedAt).toBeNull()
+	})
+})

--- a/src/server/problems/problems.dao.test.ts
+++ b/src/server/problems/problems.dao.test.ts
@@ -21,6 +21,7 @@ const tx = {
 		create: vi.fn(),
 		findFirst: vi.fn(),
 		update: vi.fn(),
+		updateMany: vi.fn(),
 	},
 	problem: {
 		findFirst: vi.fn(),
@@ -31,6 +32,8 @@ const tx = {
 	userSolve: {
 		create: vi.fn(),
 		upsert: vi.fn(),
+		findUnique: vi.fn(),
+		update: vi.fn(),
 	},
 }
 
@@ -231,7 +234,12 @@ describe("problemsDao", () => {
 	})
 
 	describe("verifyAndMarkSolved", () => {
-		it("awards solve points, first-in-group, early-bird, updates streaks, and evaluates badges when LeetCode verifies", async () => {
+		it("awards solve points, first-in-group (atomic claim), early-bird, updates streaks, and evaluates badges when LeetCode verifies", async () => {
+			// Changed from old test: removed db.userSolve.count mock (no longer used);
+			// isFirstInGroup now comes from atomic tx.dailyProblem.updateMany (count=1 = winner);
+			// isFirstInGroup no longer in upsert payload — set via separate tx.userSolve.update;
+			// tx.dailyProblem.update replaced with tx.dailyProblem.updateMany for atomic claim;
+			// tx.userSolve.findUnique returns null (not already solved) to pass the re-check.
 			const updatedToday = {
 				...readyToday,
 				solve: { id: "solve-1", status: SolveStatus.SOLVED, pointsEarned: 5 },
@@ -265,9 +273,10 @@ describe("problemsDao", () => {
 					}),
 				}))
 			)
-			db.userSolve.count.mockResolvedValue(0)
 			pointsDao.hasEverMissed.mockResolvedValue(false)
+			tx.userSolve.findUnique.mockResolvedValue(null) // not already solved
 			tx.userSolve.upsert.mockResolvedValue({ id: "solve-1" })
+			tx.dailyProblem.updateMany.mockResolvedValue({ count: 1 }) // winner of first-solver claim
 			pointsDao.applyPointsDelta.mockResolvedValue({
 				newTotal: 137,
 				crossedProThreshold: false,
@@ -291,6 +300,7 @@ describe("problemsDao", () => {
 					headers: { "Content-Type": "application/json" },
 				})
 			)
+			// upsert no longer includes isFirstInGroup — it is set separately after the atomic claim
 			expect(tx.userSolve.upsert).toHaveBeenCalledWith({
 				where: { userId_dailyProblemId: { userId: "user-1", dailyProblemId: "daily-1" } },
 				create: {
@@ -298,13 +308,11 @@ describe("problemsDao", () => {
 					dailyProblemId: "daily-1",
 					status: SolveStatus.SOLVED,
 					pointsEarned: 5,
-					isFirstInGroup: true,
 					verifiedAt: expect.any(Date),
 				},
 				update: {
 					status: SolveStatus.SOLVED,
 					pointsEarned: 5,
-					isFirstInGroup: true,
 					verifiedAt: expect.any(Date),
 				},
 				select: { id: true },
@@ -316,6 +324,11 @@ describe("problemsDao", () => {
 				PointReason.DAILY_SOLVE,
 				{ tx, userSolveId: "solve-1" }
 			)
+			// atomic claim won (count=1), so FIRST_IN_GROUP is awarded
+			expect(tx.dailyProblem.updateMany).toHaveBeenCalledWith({
+				where: { id: "daily-1", firstSolverId: null },
+				data: { firstSolverId: "user-1", firstSolveTime: expect.any(Date) },
+			})
 			expect(pointsDao.applyPointsDelta).toHaveBeenNthCalledWith(
 				2,
 				"user-1",
@@ -330,10 +343,6 @@ describe("problemsDao", () => {
 				PointReason.EARLY_BIRD,
 				{ tx, userSolveId: "solve-1" }
 			)
-			expect(tx.dailyProblem.update).toHaveBeenCalledWith({
-				where: { id: "daily-1" },
-				data: { firstSolverId: "user-1", firstSolveTime: expect.any(Date) },
-			})
 			expect(tx.user.update).toHaveBeenCalledWith({
 				where: { id: "user-1" },
 				data: {
@@ -430,6 +439,113 @@ describe("problemsDao", () => {
 			expect(pointsDao.applyPointsDelta).not.toHaveBeenCalled()
 			expect(tx.userSolve.upsert).not.toHaveBeenCalled()
 			expect(pointsDao.applyMissPenalty).not.toHaveBeenCalled()
+		})
+
+		it("first-solver loser (atomic claim count=0) does not award FIRST_IN_GROUP", async () => {
+			const updatedToday = {
+				...readyToday,
+				solve: { id: "solve-1", status: SolveStatus.SOLVED, pointsEarned: 5 },
+				groupSolvedCount: 1,
+				userStats: { currentStreak: 5, longestStreak: 8, totalPoints: 127 },
+			}
+			vi.spyOn(problemsDao, "getTodayForUser")
+				.mockResolvedValueOnce(readyToday)
+				.mockResolvedValueOnce(updatedToday)
+			db.user.findUniqueOrThrow.mockResolvedValue({
+				leetcodeHandle: "alice",
+				currentStreak: 4,
+				longestStreak: 8,
+				currentStreakStartedAt: new Date("2026-06-12T00:00:00.000Z"),
+				verificationFailuresThisMonth: 0,
+			})
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async () => ({
+					json: async () => ({
+						data: {
+							recentAcSubmissionList: [
+								{
+									titleSlug: "two-sum",
+									timestamp: String(
+										new Date("2026-06-16T02:00:00.000Z").getTime() / 1000
+									),
+								},
+							],
+						},
+					}),
+				}))
+			)
+			pointsDao.hasEverMissed.mockResolvedValue(false)
+			tx.userSolve.findUnique.mockResolvedValue(null) // not already solved
+			tx.userSolve.upsert.mockResolvedValue({ id: "solve-1" })
+			tx.dailyProblem.updateMany.mockResolvedValue({ count: 0 }) // loser — someone else already claimed
+			pointsDao.applyPointsDelta.mockResolvedValue({
+				newTotal: 127,
+				crossedProThreshold: false,
+			})
+			tx.groupMember.findUnique.mockResolvedValue({ id: "member-1" })
+			badgesDao.evaluateAndAward.mockResolvedValue([])
+
+			await problemsDao.verifyAndMarkSolved("user-1")
+
+			// FIRST_IN_GROUP must NOT be awarded when the atomic claim returns count=0
+			const firstInGroupCall = (
+				pointsDao.applyPointsDelta as ReturnType<typeof vi.fn>
+			).mock.calls.find((c) => c[2] === PointReason.FIRST_IN_GROUP)
+			expect(firstInGroupCall).toBeUndefined()
+			// DAILY_SOLVE is still awarded
+			expect(pointsDao.applyPointsDelta).toHaveBeenCalledWith(
+				"user-1",
+				5,
+				PointReason.DAILY_SOLVE,
+				{ tx, userSolveId: "solve-1" }
+			)
+		})
+
+		it("already-solved re-entry short-circuits: no upsert, no DAILY_SOLVE award", async () => {
+			const updatedToday = {
+				...readyToday,
+				solve: { id: "solve-1", status: SolveStatus.SOLVED, pointsEarned: 5 },
+				groupSolvedCount: 1,
+				userStats: { currentStreak: 5, longestStreak: 8, totalPoints: 137 },
+			}
+			vi.spyOn(problemsDao, "getTodayForUser")
+				.mockResolvedValueOnce(readyToday)
+				.mockResolvedValueOnce(updatedToday)
+			db.user.findUniqueOrThrow.mockResolvedValue({
+				leetcodeHandle: "alice",
+				currentStreak: 4,
+				longestStreak: 8,
+				currentStreakStartedAt: new Date("2026-06-12T00:00:00.000Z"),
+				verificationFailuresThisMonth: 0,
+			})
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async () => ({
+					json: async () => ({
+						data: {
+							recentAcSubmissionList: [
+								{
+									titleSlug: "two-sum",
+									timestamp: String(
+										new Date("2026-06-16T02:00:00.000Z").getTime() / 1000
+									),
+								},
+							],
+						},
+					}),
+				}))
+			)
+			pointsDao.hasEverMissed.mockResolvedValue(false)
+			// in-transaction re-check finds the solve already SOLVED → short-circuit
+			tx.userSolve.findUnique.mockResolvedValue({ status: SolveStatus.SOLVED })
+
+			await problemsDao.verifyAndMarkSolved("user-1")
+
+			// upsert must not be called — the transaction bails early
+			expect(tx.userSolve.upsert).not.toHaveBeenCalled()
+			// no points awarded
+			expect(pointsDao.applyPointsDelta).not.toHaveBeenCalled()
 		})
 	})
 

--- a/src/server/problems/problems.dao.ts
+++ b/src/server/problems/problems.dao.ts
@@ -25,7 +25,8 @@ import {
 	STREAK_MULTIPLIER_7,
 	STREAK_MULTIPLIER_30,
 } from "@/server/points/points.type"
-import { LEETCODE_STUDY_PLAN_ROADMAPS, NEETCODE_250_PROBLEMS } from "./problems.seed"
+import { syncRoadmapCatalog } from "./problems.roadmap"
+import { NEETCODE_250_PROBLEMS } from "./problems.seed"
 import {
 	type MarkSolvedResult,
 	type PauseTodayResult,
@@ -85,76 +86,6 @@ const startOfUtcDay = (d: Date) =>
 const pauseLimitFor = (user: { isPro: boolean }) => (user.isPro ? 4 : 2)
 const INACTIVITY_WARNING_MISSES = 5
 const BATCH_SIZE = 25
-const catalogIdFor = (key: string) => `roadmap_${key.toLowerCase()}`
-type LegacyRoadmapFlag = "neetcode250" | "neetcode150" | "blind75"
-
-type RoadmapCatalogSeed = Omit<
-	Prisma.RoadmapCatalogUncheckedCreateInput,
-	"id" | "key"
-> & {
-	id: string
-	key: RoadmapKey
-}
-
-const legacyRoadmapCatalogSeed: RoadmapCatalogSeed[] = [
-	{
-		id: "roadmap_nc250",
-		key: "NC250",
-		slug: "neetcode-250",
-		title: "NeetCode 250",
-		description: "Full 250-problem roadmap",
-		source: "NEETCODE",
-		sortOrder: 10,
-	},
-	{
-		id: "roadmap_nc150",
-		key: "NC150",
-		slug: "neetcode-150",
-		title: "NeetCode 150",
-		description: "Core 150 problems",
-		source: "NEETCODE",
-		sortOrder: 20,
-	},
-	{
-		id: "roadmap_blind75",
-		key: "BLIND75",
-		slug: "blind-75",
-		title: "Blind 75",
-		description: "Classic 75 problems",
-		source: "NEETCODE",
-		sortOrder: 30,
-	},
-]
-
-const leetcodeRoadmapCatalogSeed: RoadmapCatalogSeed[] = LEETCODE_STUDY_PLAN_ROADMAPS.map(
-	({ key, slug, title, description, source, sortOrder }) => ({
-		id: catalogIdFor(key),
-		key,
-		slug,
-		title,
-		description,
-		source,
-		sortOrder,
-	})
-)
-
-const roadmapCatalogSeed: RoadmapCatalogSeed[] = [
-	...legacyRoadmapCatalogSeed,
-	...leetcodeRoadmapCatalogSeed,
-]
-
-const legacyRoadmapFlag = (roadmap: RoadmapKey): LegacyRoadmapFlag | null => {
-	switch (roadmap) {
-		case "NC250":
-			return "neetcode250"
-		case "NC150":
-			return "neetcode150"
-		case "BLIND75":
-			return "blind75"
-		default:
-			return null
-	}
-}
 
 const dailyProblemFullSelect = {
 	id: true,
@@ -217,130 +148,6 @@ const findExistingDailyProblem = async (groupId: string, assignedDate: Date) =>
 			select: dailyProblemFullSelect,
 		})
 	)
-
-const seedLeetCodeStudyPlanProblems = async (tx: Tx) => {
-	const maxRoadmapIndex = await tx.problem.aggregate({
-		_max: { roadmapIndex: true },
-	})
-	let nextRoadmapIndex = (maxRoadmapIndex._max.roadmapIndex ?? 0) + 1
-	const seen = new Set<string>()
-
-	for (const roadmap of LEETCODE_STUDY_PLAN_ROADMAPS) {
-		for (const problem of roadmap.problems) {
-			if (seen.has(problem.slug)) continue
-			seen.add(problem.slug)
-
-			const existing = await tx.problem.findUnique({
-				where: { slug: problem.slug },
-				select: { id: true },
-			})
-
-			if (existing) {
-				await tx.problem.update({
-					where: { id: existing.id },
-					data: {
-						title: problem.title,
-						difficulty: problem.difficulty,
-						leetcodeId: problem.leetcodeId,
-						isPremium: problem.isPremium,
-					},
-				})
-				continue
-			}
-
-			await tx.problem.create({
-				data: {
-					slug: problem.slug,
-					title: problem.title,
-					difficulty: problem.difficulty,
-					topic: problem.topic,
-					roadmapIndex: nextRoadmapIndex,
-					leetcodeId: problem.leetcodeId,
-					isPremium: problem.isPremium,
-					source: "NEETCODE",
-				},
-			})
-			nextRoadmapIndex++
-		}
-	}
-}
-
-const syncLegacyRoadmapMemberships = async (tx: Tx) => {
-	for (const roadmap of legacyRoadmapCatalogSeed) {
-		const flag = legacyRoadmapFlag(roadmap.key)
-		if (!flag) continue
-
-		const problems = await tx.problem.findMany({
-			where: { [flag]: true },
-			orderBy: { roadmapIndex: "asc" },
-			select: { id: true, topic: true },
-		})
-
-		await tx.roadmapProblem.deleteMany({ where: { roadmapId: roadmap.id } })
-		await tx.roadmapProblem.createMany({
-			data: problems.map((problem, index) => ({
-				roadmapId: roadmap.id,
-				problemId: problem.id,
-				position: index + 1,
-				topic: problem.topic,
-			})),
-			skipDuplicates: true,
-		})
-	}
-}
-
-const syncLeetCodeStudyPlanMemberships = async (tx: Tx) => {
-	for (const roadmap of LEETCODE_STUDY_PLAN_ROADMAPS) {
-		const slugs = roadmap.problems.map((problem) => problem.slug)
-		const problems = await tx.problem.findMany({
-			where: { slug: { in: slugs } },
-			select: { id: true, slug: true },
-		})
-		const problemIdBySlug = new Map(problems.map((problem) => [problem.slug, problem.id]))
-		const data: Prisma.RoadmapProblemCreateManyInput[] = []
-
-		for (const problem of roadmap.problems) {
-			const problemId = problemIdBySlug.get(problem.slug)
-			if (!problemId) continue
-			data.push({
-				roadmapId: catalogIdFor(roadmap.key),
-				problemId,
-				position: problem.position,
-				topic: problem.topic,
-			})
-		}
-
-		if (data.length !== roadmap.problems.length) {
-			throw new Error(`Could not sync all problems for roadmap ${roadmap.key}`)
-		}
-
-		await tx.roadmapProblem.deleteMany({
-			where: { roadmapId: catalogIdFor(roadmap.key) },
-		})
-		await tx.roadmapProblem.createMany({ data, skipDuplicates: true })
-	}
-}
-
-const syncRoadmapCatalog = async (tx: Tx) => {
-	for (const roadmap of roadmapCatalogSeed) {
-		await tx.roadmapCatalog.upsert({
-			where: { key: roadmap.key },
-			create: roadmap,
-			update: {
-				slug: roadmap.slug,
-				title: roadmap.title,
-				description: roadmap.description,
-				source: roadmap.source,
-				sortOrder: roadmap.sortOrder,
-				isActive: true,
-			},
-		})
-	}
-
-	await seedLeetCodeStudyPlanProblems(tx)
-	await syncLegacyRoadmapMemberships(tx)
-	await syncLeetCodeStudyPlanMemberships(tx)
-}
 
 const assignNextProblemTx = async (
 	tx: Tx,

--- a/src/server/problems/problems.dao.ts
+++ b/src/server/problems/problems.dao.ts
@@ -84,6 +84,7 @@ const startOfUtcDay = (d: Date) =>
 
 const pauseLimitFor = (user: { isPro: boolean }) => (user.isPro ? 4 : 2)
 const INACTIVITY_WARNING_MISSES = 5
+const BATCH_SIZE = 25
 const catalogIdFor = (key: string) => `roadmap_${key.toLowerCase()}`
 type LegacyRoadmapFlag = "neetcode250" | "neetcode150" | "blind75"
 
@@ -586,13 +587,16 @@ export const problemsDao = {
 		let assigned = 0
 		let skipped = 0
 
-		await Promise.all(
-			groups.map(async (group) => {
-				const result = await ensureDailyProblem(group.id, date)
+		for (let i = 0; i < groups.length; i += BATCH_SIZE) {
+			const batch = groups.slice(i, i + BATCH_SIZE)
+			const results = await Promise.all(
+				batch.map((group) => ensureDailyProblem(group.id, date))
+			)
+			for (const result of results) {
 				if (result) assigned++
 				else skipped++
-			})
-		)
+			}
+		}
 
 		return { total: groups.length, assigned, skipped }
 	},

--- a/src/server/problems/problems.dao.ts
+++ b/src/server/problems/problems.dao.ts
@@ -1,5 +1,6 @@
 import type { Prisma } from "@/generated/prisma/client"
 import {
+	type BadgeType,
 	Difficulty,
 	GroupMemberRemovalReason,
 	GroupMemberStatus,
@@ -906,12 +907,9 @@ export const problemsDao = {
 			return { error: "NOT_VERIFIED", today }
 		}
 
-		const [existingSolvedCount, isComeback] = await Promise.all([
-			db.userSolve.count({ where: { dailyProblemId, status: SolveStatus.SOLVED } }),
-			user.currentStreak === 0 ? pointsDao.hasEverMissed(userId) : Promise.resolve(false),
-		])
+		const isComeback =
+			user.currentStreak === 0 ? await pointsDao.hasEverMissed(userId) : false
 
-		const isFirstInGroup = existingSolvedCount === 0
 		const baseSolvePoints =
 			problem.difficulty === Difficulty.HARD
 				? SOLVE_POINTS.HARD
@@ -936,6 +934,16 @@ export const problemsDao = {
 		const newLongest = Math.max(newStreak, user.longestStreak)
 
 		const { crossedProThreshold, newBadges } = await db.$transaction(async (tx) => {
+			const current = await tx.userSolve.findUnique({
+				where: { userId_dailyProblemId: { userId, dailyProblemId } },
+				select: { status: true },
+			})
+			// A concurrent request already finished this solve — do nothing, award nothing.
+			if (current?.status === SolveStatus.SOLVED) {
+				const empty: BadgeType[] = []
+				return { crossedProThreshold: false, newBadges: empty }
+			}
+
 			const upserted = await tx.userSolve.upsert({
 				where: { userId_dailyProblemId: { userId, dailyProblemId } },
 				create: {
@@ -943,13 +951,11 @@ export const problemsDao = {
 					dailyProblemId,
 					status: SolveStatus.SOLVED,
 					pointsEarned: baseSolvePoints,
-					isFirstInGroup,
 					verifiedAt: now,
 				},
 				update: {
 					status: SolveStatus.SOLVED,
 					pointsEarned: baseSolvePoints,
-					isFirstInGroup,
 					verifiedAt: now,
 				},
 				select: { id: true },
@@ -976,6 +982,14 @@ export const problemsDao = {
 				crossedPro ||= r1.crossedProThreshold
 			}
 
+			// Atomically claim first-solver: only ONE concurrent transaction can move
+			// firstSolverId from null → this user. updateMany returns count 1 for the winner, 0 for losers.
+			const claim = await tx.dailyProblem.updateMany({
+				where: { id: dailyProblemId, firstSolverId: null },
+				data: { firstSolverId: userId, firstSolveTime: now },
+			})
+			const isFirstInGroup = claim.count === 1
+
 			if (isFirstInGroup) {
 				const r2 = await pointsDao.applyPointsDelta(
 					userId,
@@ -984,9 +998,9 @@ export const problemsDao = {
 					opts
 				)
 				crossedPro ||= r2.crossedProThreshold
-				await tx.dailyProblem.update({
-					where: { id: dailyProblemId },
-					data: { firstSolverId: userId, firstSolveTime: now },
+				await tx.userSolve.update({
+					where: { id: upserted.id },
+					data: { isFirstInGroup: true },
 				})
 			}
 

--- a/src/server/problems/problems.notifications.ts
+++ b/src/server/problems/problems.notifications.ts
@@ -6,7 +6,10 @@ import { db } from "@/server/lib/db"
 import { sendEmail } from "@/server/lib/email"
 import { captureServerException } from "@/server/lib/sentry"
 
-const BASE_URL = env.BETTER_AUTH_URL.replace(/\/$/, "")
+// BETTER_AUTH_URL carries a schema default, but SKIP_ENV_VALIDATION (used by the
+// CI test job) bypasses zod defaults — fall back so importing this module, which
+// happens transitively in tests, never throws on an undefined value.
+const BASE_URL = (env.BETTER_AUTH_URL ?? "https://pstrack.localhost").replace(/\/$/, "")
 
 const STREAK_MILESTONES = [7, 30, 100] as const
 

--- a/src/server/problems/problems.roadmap.ts
+++ b/src/server/problems/problems.roadmap.ts
@@ -1,0 +1,200 @@
+import type { Prisma } from "@/generated/prisma/client"
+import { LEETCODE_STUDY_PLAN_ROADMAPS } from "./problems.seed"
+import type { RoadmapKey } from "./problems.type"
+
+type Tx = Prisma.TransactionClient
+type LegacyRoadmapFlag = "neetcode250" | "neetcode150" | "blind75"
+
+type RoadmapCatalogSeed = Omit<
+	Prisma.RoadmapCatalogUncheckedCreateInput,
+	"id" | "key"
+> & {
+	id: string
+	key: RoadmapKey
+}
+
+const catalogIdFor = (key: string) => `roadmap_${key.toLowerCase()}`
+
+const legacyRoadmapCatalogSeed: RoadmapCatalogSeed[] = [
+	{
+		id: "roadmap_nc250",
+		key: "NC250",
+		slug: "neetcode-250",
+		title: "NeetCode 250",
+		description: "Full 250-problem roadmap",
+		source: "NEETCODE",
+		sortOrder: 10,
+	},
+	{
+		id: "roadmap_nc150",
+		key: "NC150",
+		slug: "neetcode-150",
+		title: "NeetCode 150",
+		description: "Core 150 problems",
+		source: "NEETCODE",
+		sortOrder: 20,
+	},
+	{
+		id: "roadmap_blind75",
+		key: "BLIND75",
+		slug: "blind-75",
+		title: "Blind 75",
+		description: "Classic 75 problems",
+		source: "NEETCODE",
+		sortOrder: 30,
+	},
+]
+
+const leetcodeRoadmapCatalogSeed: RoadmapCatalogSeed[] = LEETCODE_STUDY_PLAN_ROADMAPS.map(
+	({ key, slug, title, description, source, sortOrder }) => ({
+		id: catalogIdFor(key),
+		key,
+		slug,
+		title,
+		description,
+		source,
+		sortOrder,
+	})
+)
+
+const roadmapCatalogSeed: RoadmapCatalogSeed[] = [
+	...legacyRoadmapCatalogSeed,
+	...leetcodeRoadmapCatalogSeed,
+]
+
+const legacyRoadmapFlag = (roadmap: RoadmapKey): LegacyRoadmapFlag | null => {
+	switch (roadmap) {
+		case "NC250":
+			return "neetcode250"
+		case "NC150":
+			return "neetcode150"
+		case "BLIND75":
+			return "blind75"
+		default:
+			return null
+	}
+}
+
+const seedLeetCodeStudyPlanProblems = async (tx: Tx) => {
+	const maxRoadmapIndex = await tx.problem.aggregate({
+		_max: { roadmapIndex: true },
+	})
+	let nextRoadmapIndex = (maxRoadmapIndex._max.roadmapIndex ?? 0) + 1
+	const seen = new Set<string>()
+
+	for (const roadmap of LEETCODE_STUDY_PLAN_ROADMAPS) {
+		for (const problem of roadmap.problems) {
+			if (seen.has(problem.slug)) continue
+			seen.add(problem.slug)
+
+			const existing = await tx.problem.findUnique({
+				where: { slug: problem.slug },
+				select: { id: true },
+			})
+
+			if (existing) {
+				await tx.problem.update({
+					where: { id: existing.id },
+					data: {
+						title: problem.title,
+						difficulty: problem.difficulty,
+						leetcodeId: problem.leetcodeId,
+						isPremium: problem.isPremium,
+					},
+				})
+				continue
+			}
+
+			await tx.problem.create({
+				data: {
+					slug: problem.slug,
+					title: problem.title,
+					difficulty: problem.difficulty,
+					topic: problem.topic,
+					roadmapIndex: nextRoadmapIndex,
+					leetcodeId: problem.leetcodeId,
+					isPremium: problem.isPremium,
+					source: "NEETCODE",
+				},
+			})
+			nextRoadmapIndex++
+		}
+	}
+}
+
+const syncLegacyRoadmapMemberships = async (tx: Tx) => {
+	for (const roadmap of legacyRoadmapCatalogSeed) {
+		const flag = legacyRoadmapFlag(roadmap.key)
+		if (!flag) continue
+
+		const problems = await tx.problem.findMany({
+			where: { [flag]: true },
+			orderBy: { roadmapIndex: "asc" },
+			select: { id: true, topic: true },
+		})
+
+		await tx.roadmapProblem.deleteMany({ where: { roadmapId: roadmap.id } })
+		await tx.roadmapProblem.createMany({
+			data: problems.map((problem, index) => ({
+				roadmapId: roadmap.id,
+				problemId: problem.id,
+				position: index + 1,
+				topic: problem.topic,
+			})),
+			skipDuplicates: true,
+		})
+	}
+}
+
+const syncLeetCodeStudyPlanMemberships = async (tx: Tx) => {
+	for (const roadmap of LEETCODE_STUDY_PLAN_ROADMAPS) {
+		const slugs = roadmap.problems.map((problem) => problem.slug)
+		const problems = await tx.problem.findMany({
+			where: { slug: { in: slugs } },
+			select: { id: true, slug: true },
+		})
+		const problemIdBySlug = new Map(problems.map((problem) => [problem.slug, problem.id]))
+		const data: Prisma.RoadmapProblemCreateManyInput[] = []
+
+		for (const problem of roadmap.problems) {
+			const problemId = problemIdBySlug.get(problem.slug)
+			if (!problemId) continue
+			data.push({
+				roadmapId: catalogIdFor(roadmap.key),
+				problemId,
+				position: problem.position,
+				topic: problem.topic,
+			})
+		}
+
+		if (data.length !== roadmap.problems.length) {
+			throw new Error(`Could not sync all problems for roadmap ${roadmap.key}`)
+		}
+
+		await tx.roadmapProblem.deleteMany({
+			where: { roadmapId: catalogIdFor(roadmap.key) },
+		})
+		await tx.roadmapProblem.createMany({ data, skipDuplicates: true })
+	}
+}
+
+export const syncRoadmapCatalog = async (tx: Tx) => {
+	for (const roadmap of roadmapCatalogSeed) {
+		await tx.roadmapCatalog.upsert({
+			where: { key: roadmap.key },
+			create: roadmap,
+			update: {
+				slug: roadmap.slug,
+				title: roadmap.title,
+				description: roadmap.description,
+				source: roadmap.source,
+				sortOrder: roadmap.sortOrder,
+				isActive: true,
+			},
+		})
+	}
+
+	await seedLeetCodeStudyPlanProblems(tx)
+	await syncLegacyRoadmapMemberships(tx)
+	await syncLeetCodeStudyPlanMemberships(tx)
+}

--- a/src/server/users/users.controller.ts
+++ b/src/server/users/users.controller.ts
@@ -34,7 +34,8 @@ export const usersController = new Elysia({ prefix: "/users", tags: ["Users"] })
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({
-						query: `query { matchedUser(username: "${body.handle}") { username } }`,
+						query: "query ($u: String!) { matchedUser(username: $u) { username } }",
+						variables: { u: body.handle },
 					}),
 				})
 				const json = (await res.json()) as {

--- a/src/test/db.ts
+++ b/src/test/db.ts
@@ -1,0 +1,190 @@
+/**
+ * Real-database test helpers for integration tests.
+ *
+ * Only imported by *.integration.test.ts files — never by unit tests.
+ * Uses TEST_DATABASE_URL (falls back to the local make-up DB) so CI can
+ * point at a dedicated Postgres service container.
+ */
+
+import { PrismaPg } from "@prisma/adapter-pg"
+
+import { PrismaClient } from "@/generated/prisma/client"
+import type { Difficulty, GroupType } from "@/generated/prisma/enums"
+
+const TEST_DATABASE_URL =
+	process.env.TEST_DATABASE_URL ??
+	"postgresql://pstrack:pstrack@127.0.0.1:5433/pstrack?schema=public"
+
+export const testDb = new PrismaClient({
+	adapter: new PrismaPg(TEST_DATABASE_URL),
+})
+
+/**
+ * Truncate all app tables in FK-safe order and restart identity sequences.
+ * Safe to call in beforeEach — keeps the schema intact.
+ */
+export const resetDb = async () => {
+	// Table names match the actual Postgres table names (Prisma uses PascalCase
+	// for models without @@map, lowercase for models with @@map).
+	await testDb.$executeRawUnsafe(`
+		TRUNCATE TABLE
+			"user_badge",
+			"PointsHistory",
+			"UserSolve",
+			"DailyProblem",
+			"RoadmapProblem",
+			"RoadmapCatalog",
+			"GroupMemberWarning",
+			"GroupJoinRequest",
+			"GroupMember",
+			"Group",
+			"Problem",
+			"feedback",
+			"system_event_log",
+			"admin_audit_log",
+			"feature_flag",
+			"system_config",
+			"verification",
+			"session",
+			"account",
+			"user"
+		RESTART IDENTITY CASCADE
+	`)
+}
+
+// ---------------------------------------------------------------------------
+// Fixture builders — thin wrappers that fill required fields with sensible defaults.
+// ---------------------------------------------------------------------------
+
+let _counter = 0
+const uid = () => `test-${++_counter}-${Date.now()}`
+// roadmapIndex must be @unique; use a large offset + counter so it doesn't
+// collide even across multiple beforeEach resets in a single test run.
+let _roadmapIdx = 900_000
+
+export const createUser = async (
+	overrides: Partial<{
+		id: string
+		name: string
+		email: string
+		username: string
+		leetcodeHandle: string
+		currentStreak: number
+		longestStreak: number
+		totalPoints: number
+		currentStreakStartedAt: Date | null
+	}> = {}
+) => {
+	const id = overrides.id ?? uid()
+	return testDb.user.create({
+		data: {
+			id,
+			name: overrides.name ?? `Test User ${id}`,
+			email: overrides.email ?? `test-${id}@example.com`,
+			emailVerified: true,
+			username: overrides.username ?? `user_${id}`,
+			leetcodeHandle: overrides.leetcodeHandle ?? null,
+			currentStreak: overrides.currentStreak ?? 0,
+			longestStreak: overrides.longestStreak ?? 0,
+			totalPoints: overrides.totalPoints ?? 0,
+			currentStreakStartedAt: overrides.currentStreakStartedAt ?? null,
+		},
+	})
+}
+
+export const createRoadmapCatalog = async (
+	overrides: Partial<{
+		key: string
+		slug: string
+		title: string
+	}> = {}
+) => {
+	const key = overrides.key ?? "NC250"
+	return testDb.roadmapCatalog.upsert({
+		where: { key },
+		create: {
+			key,
+			slug: overrides.slug ?? key.toLowerCase().replace(/_/g, "-"),
+			title: overrides.title ?? key,
+			description: `${key} roadmap`,
+			source: "NEETCODE",
+			sortOrder: 10,
+		},
+		update: {},
+	})
+}
+
+export const createGroup = async (
+	overrides: Partial<{
+		id: string
+		slug: string
+		type: GroupType
+		roadmap: string
+		creatorId: string
+		isActive: boolean
+		isStarted: boolean
+	}> = {}
+) => {
+	const id = overrides.id ?? uid()
+	const roadmap = overrides.roadmap ?? "NC250"
+
+	// Ensure roadmap catalog row exists (Group FK requires it)
+	await createRoadmapCatalog({ key: roadmap })
+
+	return testDb.group.create({
+		data: {
+			id,
+			slug: overrides.slug ?? `group-${id}`,
+			type: (overrides.type as GroupType) ?? "PUBLIC",
+			roadmap,
+			creatorId: overrides.creatorId ?? uid(),
+			isActive: overrides.isActive ?? true,
+			isStarted: overrides.isStarted ?? true,
+		},
+	})
+}
+
+export const addMember = async (groupId: string, userId: string) => {
+	return testDb.groupMember.create({
+		data: { groupId, userId },
+	})
+}
+
+export const createProblem = async (
+	overrides: Partial<{
+		id: string
+		slug: string
+		title: string
+		difficulty: Difficulty
+		topic: string
+		roadmapIndex: number
+		neetcode250: boolean
+	}> = {}
+) => {
+	const id = overrides.id ?? uid()
+	return testDb.problem.create({
+		data: {
+			id,
+			slug: overrides.slug ?? `problem-${id}`,
+			title: overrides.title ?? `Problem ${id}`,
+			difficulty: (overrides.difficulty as Difficulty) ?? "MEDIUM",
+			topic: overrides.topic ?? "Arrays & Hashing",
+			roadmapIndex: overrides.roadmapIndex ?? ++_roadmapIdx,
+			neetcode250: overrides.neetcode250 ?? true,
+		},
+	})
+}
+
+export const createDailyProblem = async ({
+	groupId,
+	problemId,
+	assignedDate,
+}: {
+	groupId: string
+	problemId: string
+	assignedDate: Date
+}) => {
+	return testDb.dailyProblem.create({
+		data: { groupId, problemId, assignedDate },
+	})
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,15 @@
+/**
+ * Per-suite reset wiring for integration tests.
+ *
+ * This file is only referenced by the "integration" vitest project (see
+ * vitest.config.ts). Unit tests use a separate project with no setupFiles, so
+ * they never touch this module and never need a real DB connection.
+ */
+
+import { beforeEach } from "vitest"
+
+import { resetDb } from "./db"
+
+beforeEach(async () => {
+	await resetDb()
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,29 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
 	plugins: [viteTsConfigPaths({ projects: ["./tsconfig.json"] })],
 	test: {
-		environment: "node",
+		projects: [
+			{
+				// Unit tests — all existing mock-based *.test.ts files.
+				// No real DB, no setup files; runs exactly as before.
+				plugins: [viteTsConfigPaths({ projects: ["./tsconfig.json"] })],
+				test: {
+					name: "unit",
+					environment: "node",
+					include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+					exclude: ["src/**/*.integration.test.ts"],
+				},
+			},
+			{
+				// Integration tests — *.integration.test.ts files only.
+				// resetDb() is called in beforeEach via the setup file.
+				plugins: [viteTsConfigPaths({ projects: ["./tsconfig.json"] })],
+				test: {
+					name: "integration",
+					environment: "node",
+					include: ["src/**/*.integration.test.ts"],
+					setupFiles: ["./src/test/setup.ts"],
+				},
+			},
+		],
 	},
 })


### PR DESCRIPTION
## Summary

A reviewed batch of nine improvements produced by an `/improve` audit (each landed as its own commit; every diff was re-verified against its done-criteria before inclusion). Highest-impact first:

- **Fixed the solve-verification double-award race** (`aae8008`) — `verifyAndMarkSolved` read solved-status and the first-solver count *outside* the awarding transaction, and `PointsHistory` had no uniqueness guard, so a double-submit could award `DAILY_SOLVE` twice and two users could both get the first-in-group bonus. Now: an in-transaction re-check short-circuits re-entry, an atomic `updateMany where firstSolverId: null` gates the bonus to a single winner, and a new `@@unique([userSolveId, reason])` constraint makes ledger writes idempotent at the DB level. Decision recorded in `docs/agdr/AgDR-0002-migration-points-history-unique-solve-reason.md`. **Closes #244** (the migration).
- **Gated the global leaderboard behind Pro** (`ab4c9e3`) — `/api/v3/leaderboard/global` had no auth and no `isPro` check despite being a documented Pro-only feature (revenue-gate bypass). Added a `requirePro` server helper (mirrors `requirePlatformAdmin`) and re-enabled the already-stubbed client `ProGate`.
- **Killed the group-leaderboard N+1** (`717f680`) — week/month boards issued one `pointsHistory.aggregate` per member; replaced with a single `groupBy` (the pattern the global board already used).
- **Parameterized the LeetCode handle GraphQL query** (`e062682`) — the handle was string-interpolated into the query; now passed as a GraphQL variable (the Codeforces sibling already escaped its input).
- **Bounded concurrency in the daily-problem assign job** (`89a7d72`) — the midnight cron fanned out an unbounded `Promise.all` over all groups; now batched (25) to protect the connection pool at scale.
- **Added a real-DB test harness + core-loop integration tests** (`cbf2817`) — the daily loop had only mock tests. New `unit`/`integration` vitest projects; the integration suite exercises solve → points/streak/first-in-group, an idempotency check (which also validates the race fix above), and mark-missed, all against a real Postgres.
- **Split the 1,254-line `problems.dao.ts`** (`f0511ba`) — extracted roadmap catalog seed/sync into `problems.roadmap.ts` (−193 lines), no behavior change, public `problemsDao` surface unchanged.
- **Corrected doc drift** (`00f550a`) — `AGENTS.md` said pauses cost nothing and mark-missed applied −5; code is −5 pause / −3 miss. `DESIGN.md` said Tailwind v3; it's v4.
- **Dev-tooling hygiene** (`90ed575`) — documented the required `BETTER_AUTH_API_KEY` in `.env.example`; added `typecheck` to the pre-push hook.

## Testing

1. `bun run typecheck` → clean
2. `bun run check` (Biome) → clean
3. `bun run test` → **66 pass** (63 unit + 3 real-DB integration)
4. `bun run build` → succeeds

CI now runs a Postgres service + `prisma migrate deploy` before the test job.

### ⚠️ Migration prod-apply note (see `docs/agdr/AgDR-0002-migration-points-history-unique-solve-reason.md`)
The `@@unique([userSolveId, reason])` index is applied locally. **Before prod**, run the duplicate pre-check — the pre-fix bug may have written duplicate rows, which would make the index build fail:

```sql
SELECT "userSolveId", reason, COUNT(*) FROM "PointsHistory"
WHERE "userSolveId" IS NOT NULL GROUP BY 1,2 HAVING COUNT(*) > 1;
```

If non-empty: dedupe (keep earliest per pair) + reconcile `totalPoints`, then apply.

Closes #244

## Glossary

| Term | Definition |
|------|------------|
| PointsHistory | Immutable append-only ledger; every point change writes a row. `User.totalPoints` is a denormalized cache of its sum. |
| First-in-group bonus | +10 awarded to the first member of a group to solve the daily problem; now claimed atomically so exactly one member wins. |
| Idempotent | Re-attempting the same operation causes no additional effect — here, a repeated solve produces no extra ledger rows. |
| N+1 | One query per row in a loop instead of a single batched query. |
| requirePro | Server-side guard returning 403 unless the session user's `isPro` is true (DB-checked). |
| Driver adapter (PrismaPg/PrismaNeon) | Prisma 7 connects via an adapter chosen by URL — local Postgres uses `PrismaPg`, Neon uses `PrismaNeon`. |
