### PR TITLE
[codex] Fix Prisma migrate diff workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -89,8 +89,7 @@ jobs:
         run: bunx prisma migrate deploy
 
       - name: Verify schema matches migrations
-        run: bunx prisma migrate diff --from-config-datasource --to-schema-datamodel prisma/schema.prisma --exit-code
-        continue-on-error: true
+        run: bunx prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma --exit-code
 
   build-and-push:
     name: Build and push image

--- a/prisma/migrations/20260708195000_add_group_started_audit_action/migration.sql
+++ b/prisma/migrations/20260708195000_add_group_started_audit_action/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "AdminAuditAction" ADD VALUE 'GROUP_STARTED';


### PR DESCRIPTION
Fixes #249.

## What changed
- Updated the Docker image workflow migration diff command from the removed `--to-schema-datamodel` flag to Prisma 7's `--to-schema` flag.
- Removed `continue-on-error` from the migration diff step so schema drift fails CI instead of being hidden.
- Added the missing `GROUP_STARTED` value migration for `AdminAuditAction`, which the restored diff check exposed.

## Why
The linked Actions job showed Prisma rejecting the removed flag. Once the flag was corrected, the validation found real schema drift between migrations and `schema.prisma`.

## Validation
- `bunx prisma validate`
- Isolated Postgres 17: `bunx prisma migrate deploy` then `bunx prisma migrate diff --from-config-datasource --to-schema prisma/schema.prisma --exit-code` -> `No difference detected.`
- Pre-push hook ran `bun run build` successfully.