### PR TITLE
fix(db): dedup PointsHistory before unique (userSolveId, reason) index

### DIFF
--- a/prisma/migrations/20260707000001_points_history_unique_solve_reason/migration.sql
+++ b/prisma/migrations/20260707000001_points_history_unique_solve_reason/migration.sql
@@ -1,2 +1,29 @@
+-- Deduplicate PointsHistory rows that would violate the new
+-- (userSolveId, reason) uniqueness before creating the index.
+--
+-- These duplicates are double-award / double-penalty artifacts left over
+-- from the pre-fix verify-submission / mark-missed concurrency bug (#244):
+-- the same solve received two ledger rows for the same reason (e.g. two
+-- MISSED_DAY entries). Within a (userSolveId, reason) group the delta is
+-- identical, so keeping the earliest row and deleting the rest does not
+-- change any user's totalPoints. Rows with a NULL userSolveId (admin
+-- adjustments, streak bonuses not tied to a solve) are never touched —
+-- NULLs are treated as distinct by the unique index.
+DELETE FROM "PointsHistory"
+WHERE "id" IN (
+  SELECT "id"
+  FROM (
+    SELECT
+      "id",
+      ROW_NUMBER() OVER (
+        PARTITION BY "userSolveId", "reason"
+        ORDER BY "createdAt" ASC, "id" ASC
+      ) AS rn
+    FROM "PointsHistory"
+    WHERE "userSolveId" IS NOT NULL
+  ) ranked
+  WHERE ranked.rn > 1
+);
+
 -- CreateIndex
 CREATE UNIQUE INDEX "PointsHistory_userSolveId_reason_key" ON "PointsHistory"("userSolveId", "reason");


### PR DESCRIPTION
## Problem

The production deploy job failed at **Run database migrations** with `P3018` / Postgres `23505`:

```
could not create unique index "PointsHistory_userSolveId_reason_key"
Key ("userSolveId", reason)=(cmqyzi7su…, MISSED_DAY) is duplicated.
```

Migration `20260707000001_points_history_unique_solve_reason` (from #245) shipped as a bare `CREATE UNIQUE INDEX`. Production already held rows violating it — double-penalty artifacts from the pre-fix verify/mark-missed concurrency bug (#244), e.g. two `MISSED_DAY` ledger rows for one solve. Postgres can't build a unique index over duplicate data, so the migration was recorded **failed**, blocking it and every later migration.

## Fix

Prepend a dedup `DELETE` before creating the index:

- Keeps the **earliest** row per `(userSolveId, reason)`; later duplicates are removed.
- **No user's `totalPoints` changes** — duplicates in a group carry identical deltas, and `totalPoints` is an order-dependent running clamp (`Math.max(0, total+delta)`), not a plain ledger sum, so it is deliberately **not** recomputed.
- `NULL`-`userSolveId` rows (admin adjustments, streak bonuses) are untouched — NULLs are distinct in a unique index.

Verified end-to-end against Postgres 17: dedup removes exactly the right rows (later `MISSED_DAY`/`FIRST_IN_GROUP` dups gone, distinct `SOLVED` on the same solve kept, both NULL-solve rows survive) and the index then builds.

## Ops

The failed migration was already marked rolled-back against production (`prisma migrate resolve --rolled-back 20260707000001_points_history_unique_solve_reason`), so on merge `migrate deploy` re-runs the corrected SQL and continues through the remaining pending migrations.

> Note: editing an already-attempted migration changes its checksum — teammates whose local DB applied the original SQL will see a "migration modified" warning, cleared by `bun run db:reset`. Prod never applied it successfully.