### PR TITLE
fix: redirect Pro checkout to Polar

### DIFF
--- a/src/features/settings/components/account/pro-plan-section.tsx
+++ b/src/features/settings/components/account/pro-plan-section.tsx
@@ -1,0 +1,64 @@
+import { sileo } from "sileo"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { authClient } from "@/lib/auth-client"
+import type { MeResponse } from "@/server/users/users.type"
+import { startProCheckout } from "../../lib/pro-checkout"
+import { SectionCard } from "../section-card"
+
+export const ProPlanSection = ({ me }: { me: MeResponse }) => {
+	const isPro = me.isPro
+
+	const handleUpgrade = async () => {
+		await sileo.promise(startProCheckout(authClient), {
+			loading: { title: "Redirecting to Polar..." },
+			success: { title: "Opening Polar checkout..." },
+			error: (err) => ({
+				title: "Could not start checkout",
+				description: err instanceof Error ? err.message : "Please try again.",
+			}),
+		})
+	}
+
+	return (
+		<SectionCard
+			title="PStrack Pro"
+			description={
+				isPro
+					? "Lifetime Pro is active on your account."
+					: "Upgrade once, keep Pro forever. No subscription, no renewals."
+			}
+			badge={isPro ? "Active" : "$14 lifetime"}
+		>
+			<div className="space-y-4">
+				<div className="grid gap-2 text-sm sm:grid-cols-2">
+					<PlanFeature>Join up to 5 groups</PlanFeature>
+					<PlanFeature>Groups up to 50 members</PlanFeature>
+					<PlanFeature>Private groups</PlanFeature>
+					<PlanFeature>4 pauses per month</PlanFeature>
+					<PlanFeature>Global leaderboard</PlanFeature>
+					<PlanFeature>Profile Pro badge</PlanFeature>
+				</div>
+				{isPro ? (
+					<div className="flex flex-wrap items-center gap-2 text-muted-foreground text-sm">
+						<Badge variant="secondary">Pro</Badge>
+						<span>
+							{me.proSource ? `Source: ${me.proSource}` : "Your account is Pro."}
+						</span>
+					</div>
+				) : (
+					<Button type="button" onClick={handleUpgrade}>
+						Upgrade with Polar
+					</Button>
+				)}
+			</div>
+		</SectionCard>
+	)
+}
+
+const PlanFeature = ({ children }: { children: string }) => (
+	<div className="rounded-lg border border-border bg-muted/30 px-3 py-2 text-muted-foreground">
+		{children}
+	</div>
+)

--- a/src/features/settings/lib/pro-checkout.test.ts
+++ b/src/features/settings/lib/pro-checkout.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { startProCheckout } from "./pro-checkout"
+
+describe("startProCheckout", () => {
+	it("creates a Polar checkout with the Pro slug and redirects the browser to the returned URL", async () => {
+		const checkout = vi.fn().mockResolvedValue({
+			data: { url: "https://sandbox.polar.sh/checkout/abc", redirect: true },
+			error: null,
+		})
+		const assignLocation = vi.fn()
+
+		await expect(startProCheckout({ checkout }, assignLocation)).resolves.toBe(
+			"https://sandbox.polar.sh/checkout/abc"
+		)
+
+		expect(checkout).toHaveBeenCalledWith({
+			slug: "pstrack",
+			successUrl: "/success?checkout_id={CHECKOUT_ID}",
+			returnUrl: "/settings/account",
+		})
+		expect(assignLocation).toHaveBeenCalledWith("https://sandbox.polar.sh/checkout/abc")
+	})
+
+	it("throws the checkout error instead of leaving the loading toast pending", async () => {
+		const checkout = vi.fn().mockResolvedValue({
+			data: null,
+			error: { message: "Checkout creation failed" },
+		})
+
+		await expect(startProCheckout({ checkout }, vi.fn())).rejects.toThrow(
+			"Checkout creation failed"
+		)
+	})
+
+	it("throws when Polar does not return a checkout URL", async () => {
+		const checkout = vi.fn().mockResolvedValue({ data: { redirect: true }, error: null })
+
+		await expect(startProCheckout({ checkout }, vi.fn())).rejects.toThrow(
+			"Polar did not return a checkout URL"
+		)
+	})
+})

--- a/src/features/settings/lib/pro-checkout.ts
+++ b/src/features/settings/lib/pro-checkout.ts
@@ -1,0 +1,36 @@
+type CheckoutResult = {
+	data?: {
+		url?: string
+		redirect?: boolean
+	} | null
+	error?: {
+		message?: string
+	} | null
+}
+
+type ProCheckoutClient = {
+	checkout: (data: {
+		slug: "pstrack"
+		successUrl: "/success?checkout_id={CHECKOUT_ID}"
+		returnUrl: "/settings/account"
+	}) => Promise<CheckoutResult>
+}
+
+const PRO_CHECKOUT_REQUEST = {
+	slug: "pstrack",
+	successUrl: "/success?checkout_id={CHECKOUT_ID}",
+	returnUrl: "/settings/account",
+} as const
+
+export const startProCheckout = async (
+	client: ProCheckoutClient,
+	assignLocation: (url: string) => void = (url) => window.location.assign(url)
+) => {
+	const { data, error } = await client.checkout(PRO_CHECKOUT_REQUEST)
+
+	if (error) throw new Error(error.message ?? "Could not start Polar checkout")
+	if (!data?.url) throw new Error("Polar did not return a checkout URL")
+
+	assignLocation(data.url)
+	return data.url
+}

--- a/src/routes/_authenticated/_app/settings/account.tsx
+++ b/src/routes/_authenticated/_app/settings/account.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router"
 
 import { DeleteAccountSection } from "@/features/settings/components/account/delete-account-section"
 import { EmailSection } from "@/features/settings/components/account/email-section"
+import { ProPlanSection } from "@/features/settings/components/account/pro-plan-section"
 import { ProvidersSection } from "@/features/settings/components/account/providers-section"
 import { SessionsSection } from "@/features/settings/components/account/sessions-section"
 import { SettingsSkeleton } from "@/features/settings/components/settings-skeleton"
@@ -18,6 +19,7 @@ function AccountPage() {
 
 	return (
 		<div className="flex flex-col gap-6">
+			<ProPlanSection me={me} />
 			<EmailSection me={me} />
 			<ProvidersSection />
 			<SessionsSection />


### PR DESCRIPTION
## Summary
- Add a Pro plan section on Account settings with an "Upgrade with Polar" button.
- Start the Better Auth Polar checkout using the configured `pstrack` slug and explicitly redirect the browser to the returned Polar checkout URL.
- Surface checkout errors so the loading toast does not hang forever.
- Keep successful payment Pro activation on the existing Polar `order.paid` webhook path and return to `/success?checkout_id={CHECKOUT_ID}`.

## Test Plan
- [x] `bun run check`
- [x] `bun run typecheck`
- [x] `bun run test -- src/features/settings/lib/pro-checkout.test.ts`
- [x] pre-push `bun run build` + `bun run typecheck`
- [ ] `bun run test` currently has unrelated failures in `src/server/problems/daily-loop.integration.test.ts` (missing user records / missed count assertion), outside this checkout change.
