### PR TITLE
feat(#255): Settings → Plan tab + fix hardcoded Polar product id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,11 @@ EMAIL_FROM="PStrack <onboarding@resend.dev>"
 
 # Payments (Polar) — get an access token at https://polar.sh/dashboard
 POLAR_ACCESS_TOKEN=""
+# Polar product UUID — ENVIRONMENT-SPECIFIC. Sandbox and production are separate
+# catalogs with different ids. Local/dev uses the SANDBOX product id (sandbox.polar.sh);
+# production uses the PRODUCTION id (polar.sh). Must target the same environment as
+# POLAR_ACCESS_TOKEN (the server flips to sandbox unless NODE_ENV=production).
+POLAR_PRODUCT_ID=""
 POLAR_SUCCESS_URL="https://pstrack.localhost/success?checkout_id={CHECKOUT_ID}"
 # Polar webhook signing secret. REQUIRED to grant Pro on purchase — the order.paid
 # webhook is what sets User.isPro. Without it, webhooks are disabled and purchases

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ PStrack is a competitive programming accountability platform. Users join groups,
 
 ## Tiers
 
-|                    | Free                    | Pro ($14 one-time)            |
+|                    | Free                    | Pro ($5 one-time)             |
 | ------------------ | ----------------------- | ----------------------------- |
 | Groups             | Join 1 (max 30 members) | Join up to 5 (max 50 members) |
 | Private groups     | No                      | Yes (creator perk)            |
@@ -37,7 +37,7 @@ PStrack is a competitive programming accountability platform. Users join groups,
 | Global leaderboard | No                      | Yes                           |
 | Profile badge      | No                      | Yes                           |
 
-Pro is a **lifetime one-time purchase** via Polar ($14 standard, $9 sale). No subscriptions.
+Pro is a **lifetime one-time purchase** via Polar ($5). No subscriptions.
 
 ## Commands
 

--- a/docs/FREEMIUM_MODEL.md
+++ b/docs/FREEMIUM_MODEL.md
@@ -4,7 +4,7 @@
 
 | | Free | Pro |
 |---|---|---|
-| Price | $0 | **$14 one-time** (sale: $9) |
+| Price | $0 | **$5 one-time** |
 | Groups joined | 1 | Up to 5 |
 | Group capacity | 30 members | 50 members (Pro-created groups) |
 | Create private groups | No | Yes |
@@ -16,8 +16,7 @@
 
 - Provider: **Polar**
 - Model: one-time purchase (lifetime Pro access)
-- Standard price: **$14**
-- Sale price: **$9**
+- Price: **$5**
 - Promo codes: supported natively in Polar dashboard
 - Integration: **Better Auth Polar plugin** for checkout + webhook transport. NOTE: the plugin does **not** set `User.isPro` automatically — we handle that explicitly in the `onOrderPaid` webhook (`src/server/lib/pro.ts`). Requires `POLAR_WEBHOOK_SECRET`.
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -41,6 +41,9 @@ export const env = createEnv({
 
 		// payments
 		POLAR_ACCESS_TOKEN: z.string().min(1),
+		// Environment-specific: Polar sandbox and production are separate catalogs
+		// with DIFFERENT product UUIDs. Must match the env POLAR_ACCESS_TOKEN targets.
+		POLAR_PRODUCT_ID: z.string().min(1),
 		POLAR_SUCCESS_URL: z.url(),
 		POLAR_WEBHOOK_SECRET: z.string().min(1).optional(),
 

--- a/src/features/leaderboard/components/leaderboard-page.tsx
+++ b/src/features/leaderboard/components/leaderboard-page.tsx
@@ -108,7 +108,7 @@ const ProGate = () => (
 			</p>
 		</div>
 		<Button asChild size="sm">
-			<Link to="/settings/account">Upgrade to Pro</Link>
+			<Link to="/settings/plan">Upgrade to Pro</Link>
 		</Button>
 	</div>
 )

--- a/src/features/settings/components/plan/plan-section.tsx
+++ b/src/features/settings/components/plan/plan-section.tsx
@@ -1,0 +1,68 @@
+import { IconCheck } from "@tabler/icons-react"
+
+import { SectionCard } from "@/features/settings/components/section-card"
+import {
+	PRO_FEATURES,
+	PRO_PRICE_CAPTION,
+	PRO_PRICE_LABEL,
+} from "@/features/settings/constants"
+import { ProSource } from "@/generated/prisma/enums"
+import { cn } from "@/lib/utils"
+import type { MeResponse } from "@/server/users/users.type"
+import { UpgradeButton } from "./upgrade-button"
+
+export const PlanSection = ({ me }: { me: MeResponse }) =>
+	me.isPro ? <CurrentProCard proSource={me.proSource} /> : <UpgradeCard />
+
+const CurrentProCard = ({ proSource }: { proSource: ProSource | null }) => (
+	<SectionCard
+		badge="Pro"
+		description="You have lifetime access to every Pro feature."
+		title="Pro plan"
+	>
+		<ul className="flex flex-col gap-2.5">
+			{PRO_FEATURES.map((feature) => (
+				<FeatureRow key={feature} label={feature} unlocked />
+			))}
+		</ul>
+		<p className="mt-5 text-muted-foreground text-sm">{proSourceNote(proSource)}</p>
+	</SectionCard>
+)
+
+const UpgradeCard = () => (
+	<SectionCard
+		description="A one-time purchase — no subscriptions, no renewals. Pro is yours for life."
+		title="Upgrade to Pro"
+	>
+		<div className="flex items-baseline gap-2">
+			<span className="font-semibold text-3xl tracking-tight">{PRO_PRICE_LABEL}</span>
+			<span className="text-muted-foreground text-sm">{PRO_PRICE_CAPTION}</span>
+		</div>
+		<ul className="mt-5 flex flex-col gap-2.5">
+			{PRO_FEATURES.map((feature) => (
+				<FeatureRow key={feature} label={feature} unlocked={false} />
+			))}
+		</ul>
+		<div className="mt-6">
+			<UpgradeButton />
+		</div>
+	</SectionCard>
+)
+
+const FeatureRow = ({ label, unlocked }: { label: string; unlocked: boolean }) => (
+	<li className="flex items-center gap-2.5 text-sm">
+		<IconCheck
+			aria-hidden="true"
+			className={cn("size-4 shrink-0", unlocked ? "text-success" : "text-primary")}
+		/>
+		<span>{label}</span>
+	</li>
+)
+
+const proSourceNote = (proSource: ProSource | null): string => {
+	if (proSource === ProSource.POLAR_PURCHASE)
+		return "Unlocked with your one-time purchase — thanks for supporting pstrack."
+	if (proSource === ProSource.POINTS_THRESHOLD)
+		return "Earned by reaching the points threshold. It's yours for life."
+	return "Lifetime access — no renewals, ever."
+}

--- a/src/features/settings/components/plan/upgrade-button.tsx
+++ b/src/features/settings/components/plan/upgrade-button.tsx
@@ -1,0 +1,38 @@
+import { IconArrowUpRight } from "@tabler/icons-react"
+import { useState } from "react"
+import { sileo } from "sileo"
+
+import { Button } from "@/components/ui/button"
+import { PRO_CHECKOUT_SLUG } from "@/features/settings/constants"
+import { authClient } from "@/lib/auth-client"
+
+// Kicks off the Better Auth Polar checkout for the Pro product. On success the
+// browser is redirected to Polar's hosted checkout, so there is no "done" state
+// to render — the button just stays disabled while we hand off.
+export const UpgradeButton = () => {
+	const [isRedirecting, setIsRedirecting] = useState(false)
+
+	const handleUpgrade = async () => {
+		setIsRedirecting(true)
+		try {
+			await sileo.promise(() => authClient.checkout({ slug: PRO_CHECKOUT_SLUG }), {
+				loading: { title: "Starting checkout…" },
+				success: { title: "Redirecting to Polar…" },
+				error: (err) => ({
+					title: "Couldn't start checkout",
+					description: err instanceof Error ? err.message : "Please try again.",
+				}),
+			})
+		} catch {
+			// sileo already surfaced the error toast — re-enable the button.
+			setIsRedirecting(false)
+		}
+	}
+
+	return (
+		<Button className="font-semibold" disabled={isRedirecting} onClick={handleUpgrade}>
+			{isRedirecting ? "Redirecting…" : "Upgrade to Pro"}
+			<IconArrowUpRight aria-hidden="true" />
+		</Button>
+	)
+}

--- a/src/features/settings/constants.ts
+++ b/src/features/settings/constants.ts
@@ -1,9 +1,29 @@
-import { IconBell, IconUser, IconUserCircle } from "@tabler/icons-react"
+import { IconBell, IconSparkles, IconUser, IconUserCircle } from "@tabler/icons-react"
 
 export const SETTINGS_NAV = [
 	{ to: "/settings/account", label: "Account", icon: IconUser },
 	{ to: "/settings/profile", label: "Profile", icon: IconUserCircle },
 	{ to: "/settings/notifications", label: "Notifications", icon: IconBell },
+	{ to: "/settings/plan", label: "Plan", icon: IconSparkles },
 ] as const
 
 export type SettingsNavItem = (typeof SETTINGS_NAV)[number]
+
+// ─── Pro plan ─────────────────────────────────────────────────────────────
+// Pro is a one-time LIFETIME unlock — not a subscription. See docs/FREEMIUM_MODEL.md.
+
+/** Displayed price. The amount actually charged is set on the Polar product. */
+export const PRO_PRICE_LABEL = "$5"
+export const PRO_PRICE_CAPTION = "one-time · lifetime"
+
+/** Polar product slug — must match the checkout() slug in src/server/lib/auth.ts. */
+export const PRO_CHECKOUT_SLUG = "pstrack"
+
+/** What upgrading unlocks — mirrors the tier table in AGENTS.md. */
+export const PRO_FEATURES = [
+	"Join up to 5 groups (Free: 1)",
+	"Create private, invite-only groups",
+	"4 pauses per month (Free: 2)",
+	"Global leaderboard — top 100 worldwide",
+	"Pro badge on your profile",
+] as const

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -43,6 +43,7 @@ import { Route as AuthenticatedAppSettingsIndexRouteImport } from './routes/_aut
 import { Route as AdminAdminUsersIndexRouteImport } from './routes/_admin/admin/users/index'
 import { Route as AdminAdminGroupsIndexRouteImport } from './routes/_admin/admin/groups/index'
 import { Route as AuthenticatedAppSettingsProfileRouteImport } from './routes/_authenticated/_app/settings/profile'
+import { Route as AuthenticatedAppSettingsPlanRouteImport } from './routes/_authenticated/_app/settings/plan'
 import { Route as AuthenticatedAppSettingsNotificationsRouteImport } from './routes/_authenticated/_app/settings/notifications'
 import { Route as AuthenticatedAppSettingsAccountRouteImport } from './routes/_authenticated/_app/settings/account'
 import { Route as AdminAdminUsersIdRouteImport } from './routes/_admin/admin/users/$id'
@@ -224,6 +225,12 @@ const AuthenticatedAppSettingsProfileRoute =
     path: '/profile',
     getParentRoute: () => AuthenticatedAppSettingsRoute,
   } as any)
+const AuthenticatedAppSettingsPlanRoute =
+  AuthenticatedAppSettingsPlanRouteImport.update({
+    id: '/plan',
+    path: '/plan',
+    getParentRoute: () => AuthenticatedAppSettingsRoute,
+  } as any)
 const AuthenticatedAppSettingsNotificationsRoute =
   AuthenticatedAppSettingsNotificationsRouteImport.update({
     id: '/notifications',
@@ -308,6 +315,7 @@ export interface FileRoutesByFullPath {
   '/admin/users/$id': typeof AdminAdminUsersIdRoute
   '/settings/account': typeof AuthenticatedAppSettingsAccountRoute
   '/settings/notifications': typeof AuthenticatedAppSettingsNotificationsRoute
+  '/settings/plan': typeof AuthenticatedAppSettingsPlanRoute
   '/settings/profile': typeof AuthenticatedAppSettingsProfileRoute
   '/admin/groups/': typeof AdminAdminGroupsIndexRoute
   '/admin/users/': typeof AdminAdminUsersIndexRoute
@@ -346,6 +354,7 @@ export interface FileRoutesByTo {
   '/admin/users/$id': typeof AdminAdminUsersIdRoute
   '/settings/account': typeof AuthenticatedAppSettingsAccountRoute
   '/settings/notifications': typeof AuthenticatedAppSettingsNotificationsRoute
+  '/settings/plan': typeof AuthenticatedAppSettingsPlanRoute
   '/settings/profile': typeof AuthenticatedAppSettingsProfileRoute
   '/admin/groups': typeof AdminAdminGroupsIndexRoute
   '/admin/users': typeof AdminAdminUsersIndexRoute
@@ -392,6 +401,7 @@ export interface FileRoutesById {
   '/_admin/admin/users/$id': typeof AdminAdminUsersIdRoute
   '/_authenticated/_app/settings/account': typeof AuthenticatedAppSettingsAccountRoute
   '/_authenticated/_app/settings/notifications': typeof AuthenticatedAppSettingsNotificationsRoute
+  '/_authenticated/_app/settings/plan': typeof AuthenticatedAppSettingsPlanRoute
   '/_authenticated/_app/settings/profile': typeof AuthenticatedAppSettingsProfileRoute
   '/_admin/admin/groups/': typeof AdminAdminGroupsIndexRoute
   '/_admin/admin/users/': typeof AdminAdminUsersIndexRoute
@@ -435,6 +445,7 @@ export interface FileRouteTypes {
     | '/admin/users/$id'
     | '/settings/account'
     | '/settings/notifications'
+    | '/settings/plan'
     | '/settings/profile'
     | '/admin/groups/'
     | '/admin/users/'
@@ -473,6 +484,7 @@ export interface FileRouteTypes {
     | '/admin/users/$id'
     | '/settings/account'
     | '/settings/notifications'
+    | '/settings/plan'
     | '/settings/profile'
     | '/admin/groups'
     | '/admin/users'
@@ -518,6 +530,7 @@ export interface FileRouteTypes {
     | '/_admin/admin/users/$id'
     | '/_authenticated/_app/settings/account'
     | '/_authenticated/_app/settings/notifications'
+    | '/_authenticated/_app/settings/plan'
     | '/_authenticated/_app/settings/profile'
     | '/_admin/admin/groups/'
     | '/_admin/admin/users/'
@@ -787,6 +800,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppSettingsProfileRouteImport
       parentRoute: typeof AuthenticatedAppSettingsRoute
     }
+    '/_authenticated/_app/settings/plan': {
+      id: '/_authenticated/_app/settings/plan'
+      path: '/plan'
+      fullPath: '/settings/plan'
+      preLoaderRoute: typeof AuthenticatedAppSettingsPlanRouteImport
+      parentRoute: typeof AuthenticatedAppSettingsRoute
+    }
     '/_authenticated/_app/settings/notifications': {
       id: '/_authenticated/_app/settings/notifications'
       path: '/notifications'
@@ -909,6 +929,7 @@ const AdminRouteWithChildren = AdminRoute._addFileChildren(AdminRouteChildren)
 interface AuthenticatedAppSettingsRouteChildren {
   AuthenticatedAppSettingsAccountRoute: typeof AuthenticatedAppSettingsAccountRoute
   AuthenticatedAppSettingsNotificationsRoute: typeof AuthenticatedAppSettingsNotificationsRoute
+  AuthenticatedAppSettingsPlanRoute: typeof AuthenticatedAppSettingsPlanRoute
   AuthenticatedAppSettingsProfileRoute: typeof AuthenticatedAppSettingsProfileRoute
   AuthenticatedAppSettingsIndexRoute: typeof AuthenticatedAppSettingsIndexRoute
 }
@@ -918,6 +939,7 @@ const AuthenticatedAppSettingsRouteChildren: AuthenticatedAppSettingsRouteChildr
     AuthenticatedAppSettingsAccountRoute: AuthenticatedAppSettingsAccountRoute,
     AuthenticatedAppSettingsNotificationsRoute:
       AuthenticatedAppSettingsNotificationsRoute,
+    AuthenticatedAppSettingsPlanRoute: AuthenticatedAppSettingsPlanRoute,
     AuthenticatedAppSettingsProfileRoute: AuthenticatedAppSettingsProfileRoute,
     AuthenticatedAppSettingsIndexRoute: AuthenticatedAppSettingsIndexRoute,
   }

--- a/src/routes/_authenticated/_app/settings/plan.tsx
+++ b/src/routes/_authenticated/_app/settings/plan.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { PlanSection } from "@/features/settings/components/plan/plan-section"
+import { SettingsSkeleton } from "@/features/settings/components/settings-skeleton"
+import { useMe } from "@/features/settings/hooks/use-me"
+
+export const Route = createFileRoute("/_authenticated/_app/settings/plan")({
+	component: PlanPage,
+})
+
+function PlanPage() {
+	const { data: me, isLoading } = useMe()
+
+	if (isLoading || !me) return <SettingsSkeleton rows={1} />
+
+	return (
+		<div className="flex flex-col gap-6">
+			<PlanSection me={me} />
+		</div>
+	)
+}

--- a/src/server/lib/auth.ts
+++ b/src/server/lib/auth.ts
@@ -116,7 +116,7 @@ export const auth = betterAuth({
 				checkout({
 					products: [
 						{
-							productId: "8b656c17-a416-4ef8-865a-a45a02ea7735",
+							productId: env.POLAR_PRODUCT_ID,
 							slug: "pstrack",
 						},
 					],


### PR DESCRIPTION
## Summary
- **Settings → Plan tab** — new `/settings/plan` route showing the current tier, the Pro feature list, and an **Upgrade to Pro** button that kicks off the Better Auth Polar checkout. Completes the GH-255 feature.
- **Fixed checkout 500 (`Product does not exist`)** — the checkout product id was hardcoded to a single UUID (`8b656c17-…`) while the Polar client's `server` flips between `sandbox`/`production` on `NODE_ENV`. Sandbox and production are separate catalogs with different product UUIDs, so the hardcoded id was invalid in whichever environment it wasn't created in — Polar rejected it and the plugin surfaced a generic 500. Now read from `env.POLAR_PRODUCT_ID` so the id moves per-environment alongside the token and server.
- **`POLAR_PRODUCT_ID` env var** — added to the env schema (`src/env.ts`) and documented in `.env.example` with the sandbox-vs-production gotcha spelled out, so the next person doesn't repeat it.

## Testing
1. Local: set a real **sandbox** `POLAR_ACCESS_TOKEN` + the **sandbox** `POLAR_PRODUCT_ID` in `.env`.
2. Visit `/settings/plan` → click **Upgrade to Pro** → browser redirects to Polar's hosted checkout (no 500).
3. Production: set the **production** product id + token in Vercel env → redeploy → checkout redirects instead of throwing.

Closes #255

---

## Glossary
| Term | Definition |
|------|------------|
| Polar | Payments platform used for the one-time Pro purchase. Sandbox (`sandbox.polar.sh`) and production (`polar.sh`) are fully separate environments with separate product catalogs and UUIDs. |
| `POLAR_PRODUCT_ID` | New env var holding the Polar product UUID to sell — environment-specific, must match the environment `POLAR_ACCESS_TOKEN` targets. |
| Better Auth Polar plugin | Mounts `/api/v3/auth/checkout`; on request it calls Polar `checkouts.create` with the configured product and redirects to the hosted checkout. |
| Lifetime Pro | pstrack's Pro tier — a one-time $5 purchase, not a subscription. |