### PR TITLE
[codex] Update Pro price references to $5

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -26,7 +26,7 @@ Pauses preserve streaks (a pause doesn't break the chain), but cost −5 points 
 
 ## Pro as a one-time purchase, not a subscription
 
-Reduces churn anxiety and support burden. Pro can also be earned by grinding to 3,000 points - this keeps non-paying users engaged and the Pro gate feel achievable. The threshold is calibrated (~7 months of consistent play at average earn velocity) so a $14 buyer's mental math always favors paying.
+Reduces churn anxiety and support burden. Pro can also be earned by grinding to 3,000 points - this keeps non-paying users engaged and the Pro gate feel achievable. The threshold is calibrated (~7 months of consistent play at average earn velocity) so a $5 buyer's mental math always favors paying.
 
 The purchase grant is an **explicit `onOrderPaid` webhook write** (`src/server/lib/pro.ts`), not something the Better Auth Polar plugin does automatically — an earlier assumption that it did is why paying briefly granted nothing. The webhook is the source of truth; `/success` just refetches. Refunds revoke Pro only when `proSource === POLAR_PURCHASE`.
 

--- a/docs/POINTS.md
+++ b/docs/POINTS.md
@@ -98,14 +98,14 @@ Pro is unlockable two ways:
 
 | Path | Cost |
 |---|---|
-| Polar purchase | $14 standard, $9 sale |
+| Polar purchase | $5 standard |
 | Points threshold | 3,000 points earned in-app |
 
-**Pro is permanent once unlocked**, by either path. There is no revocation - a user who reaches 3,000, gets Pro, then clawback drops them below 3,000 keeps Pro. Matches the lifetime promise of the $14 purchase.
+**Pro is permanent once unlocked**, by either path. There is no revocation - a user who reaches 3,000, gets Pro, then clawback drops them below 3,000 keeps Pro. Matches the lifetime promise of the $5 purchase.
 
 ### Why 3,000?
 
-Working from average earn velocity of ~14 points/day (mix of difficulty, with comeback and early-bird factored in), 3,000 points is roughly 7 months of consistent play. The threshold is deliberately set high enough that **a $14 buyer's mental math always favors paying** - 7 months of grinding to save $14 is irrational for anyone with disposable income. This protects revenue while still offering a legitimate free path for highly committed users.
+Working from average earn velocity of ~14 points/day (mix of difficulty, with comeback and early-bird factored in), 3,000 points is roughly 7 months of consistent play. The threshold is deliberately set high enough that **a $5 buyer's mental math always favors paying** - 7 months of grinding to save $5 is irrational for anyone with disposable income. This protects revenue while still offering a legitimate free path for highly committed users.
 
 ### Auto-Grant
 
@@ -242,7 +242,7 @@ Callers never compute new balances directly. The floor is enforced here and nowh
 
 - **Negative balance**: impossible by design. The floor lives in `applyPointsDelta`, not the UI.
 - **Clawback exceeds current balance**: balance clamps to 0; the "excess" is not stored anywhere. Pro threshold remains an absolute 3,000.
-- **Pro user who reaches 3,000 via points after already purchasing $14**: no-op. `isPro` is already true; `proSource` stays `POLAR_PURCHASE`.
+- **Pro user who reaches 3,000 via points after already purchasing $5**: no-op. `isPro` is already true; `proSource` stays `POLAR_PURCHASE`.
 - **First solve of a new streak**: `currentStreakStartedAt` is set to the solve's `createdAt`. Clawback uses `>=` comparison so this row's bonuses (if any) are included.
 - **Verification job retries**: only the *final* failure increments `verificationFailuresThisMonth`. Intermediate retries within the same Trigger.dev run don't count.
 - **Pause used on the same day as a previously-verified solve**: not allowed; UserSolve unique constraint `(userId, dailyProblemId)` prevents double-state.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,13 +25,13 @@ A competitive programming accountability platform. Users join groups, solve one 
 | Deployment | Vercel |
 | Email | Resend |
 | Background Jobs | Trigger.dev |
-| Payments | Polar ($14 one-time) |
+| Payments | Polar ($5 one-time) |
 | Error Tracking | Sentry |
 | Avatars | hashvatar (deterministic, no uploads) |
 
 ## Tiers
 
-| | Free | Pro ($14 one-time) |
+| | Free | Pro ($5 one-time) |
 |---|---|---|
 | Groups | Join 1 (max 30 members) | Join up to 5 (max 50 members) |
 | Create private groups | No | Yes |

--- a/docs/SEO-STRATEGY.md
+++ b/docs/SEO-STRATEGY.md
@@ -28,7 +28,7 @@ Three constraints shape this entire plan. Solve these before chasing rankings.
 |---|---|---|
 | **LeetCode.com** | The source of truth, has its own streaks/contests | Curated roadmap + groups + accountability — LC's UX is firehose, not guided |
 | **NeetCode.io** | The roadmap PStrack uses (NC250) | NeetCode has no streak/group/verification layer — PStrack is *the* social layer on his roadmap |
-| **AlgoExpert** ($99+/yr) | Paid course | PStrack is $14 lifetime + free tier; different price point, different value |
+| **AlgoExpert** ($99+/yr) | Paid course | PStrack is $5 lifetime + free tier; different price point, different value |
 | **Codewars** | Gamified katas | Different problem set; no interview prep focus |
 
 ### Keyword gap (opportunities)
@@ -71,7 +71,7 @@ Marketing site (SEO-critical, must be SSR) is **separate concern** from the app 
 **No blog. No comparison pages.** Organic footprint relies on:
 
 1. **SSR'd public pages** — `/groups`, `/problems`, `/$username` all render server-side so crawlers read real content.
-2. **Community seeding** — Reddit r/leetcode, HN Show HN, NeetCode Discord/subreddit. Primary acquisition channel for a $14 product with a tight dev niche.
+2. **Community seeding** — Reddit r/leetcode, HN Show HN, NeetCode Discord/subreddit. Primary acquisition channel for a $5 product with a tight dev niche.
 3. **MDX content pages** — `/about` and `/how-it-works` authored in markdown. Content is written in third-person where appropriate to be quotable by AI search.
 
 **Falsifiability**: if 90 days after public launch `leetcode accountability` and `leetcode study group` aren't on page 2 for their primary keyword, the SSR + community thesis is wrong — revisit a lightweight content strategy.
@@ -214,7 +214,7 @@ One safe template. Apply the quality gate.
 | Indexed pages | 8 | 30 | 100 | 300 |
 | AI citation count (manual checks) | 0 | 1 | 3 | 10 |
 | Signup conversion (organic → signup) | — | 3% | 4% | 5% |
-| Pro conversion (signup → $14) | — | 1% | 2% | 3% |
+| Pro conversion (signup → $5) | — | 1% | 2% | 3% |
 
 ---
 

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -134,8 +134,8 @@ Stay consistent with LeetCode — solve one problem a day, earn points, and comp
 
 ## Phase 7 — Freemium (Polar) · [#225](https://github.com/husamql3/pstrack/issues/225)
 
-- [x] Create Polar product ($14, one-time)
-- [ ] Set up sale pricing ($9) and promo codes in Polar dashboard
+- [x] Create Polar product ($5, one-time)
+- [ ] Set up promo codes in Polar dashboard
 - [x] Configure Better Auth Polar plugin (webhook handler, `isPro` sync)
 - [ ] Build billing settings page (`/settings/billing`) — Pro status, upgrade CTA (stub exists)
 - [ ] Add Pro gates in UI: group limits, global leaderboard, private group creation

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -15,7 +15,7 @@ PStrack is the accountability layer for the NeetCode 250 roadmap. It is not a re
 ## Pricing
 
 - Free tier: join 1 group of up to 30 members, 2 pauses/month, group leaderboard access.
-- Pro: $14 one-time lifetime purchase via Polar. Joins up to 5 groups of up to 50 members, can create private invite-only groups, 4 pauses/month, global leaderboard, and profile badge.
+- Pro: $5 one-time lifetime purchase via Polar. Joins up to 5 groups of up to 50 members, can create private invite-only groups, 4 pauses/month, global leaderboard, and profile badge.
 - No subscriptions. No paid recurring tiers.
 
 ## Groups
@@ -28,13 +28,13 @@ PStrack is the accountability layer for the NeetCode 250 roadmap. It is not a re
 
 - PStrack auto-verifies LeetCode submissions by polling the official LeetCode GraphQL API.
 - PStrack supports three roadmaps out of the box: NeetCode 250, NeetCode 150, and Blind 75.
-- PStrack is a $14 lifetime purchase — not a subscription — making it accessible to students and early-career developers.
+- PStrack is a $5 lifetime purchase — not a subscription — making it accessible to students and early-career developers.
 - PStrack uses deterministic hashvatar SVG avatars generated from username, not user-uploaded photos.
 
 ## Key URLs
 
 - [Homepage](https://pstrack.app/) — value proposition, tagline, and CTAs.
-- [About](https://pstrack.app/about) — how PStrack began, the design principles, and the $14 lifetime pricing rationale.
+- [About](https://pstrack.app/about) — how PStrack began, the design principles, and the $5 lifetime pricing rationale.
 - [Problems](https://pstrack.app/problems) — the NeetCode 250, NeetCode 150, and Blind 75 problem lists with progress tracking.
 - [Groups](https://pstrack.app/groups) — find or create a LeetCode study group.
 - [Badges](https://pstrack.app/badges) — streak, first-solver, and consistency badges earned for daily practice.

--- a/src/content/how-it-works.mdx
+++ b/src/content/how-it-works.mdx
@@ -28,6 +28,6 @@ Join a public group or create a private one. Group members share the same daily 
 
 ## Free vs Pro
 
-PStrack is free. The Pro tier is a **$14 one-time purchase** — no subscription, no annual renewal. Pro unlocks more groups, more pauses, private group creation, and the global leaderboard.
+PStrack is free. The Pro tier is a **$5 one-time purchase** — no subscription, no annual renewal. Pro unlocks more groups, more pauses, private group creation, and the global leaderboard.
 
 {/* TODO: Link to pricing page once it exists */}

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -3,9 +3,9 @@ import { createFileRoute } from "@tanstack/react-router"
 import { Header } from "@/features/home/header"
 import { createSeoHead, siteUrl } from "@/lib/seo"
 
-const ABOUT_TITLE = "How It Began — The Story Behind a $14 LeetCode Accountability Tool"
+const ABOUT_TITLE = "How It Began — The Story Behind a $5 LeetCode Accountability Tool"
 const ABOUT_DESCRIPTION =
-	"The story behind PStrack: why a $14 lifetime LeetCode accountability tool exists, what it's trying to fix about coding interview prep, and who built it."
+	"The story behind PStrack: why a $5 lifetime LeetCode accountability tool exists, what it's trying to fix about coding interview prep, and who built it."
 
 const aboutSchema = {
 	"@context": "https://schema.org",
@@ -78,8 +78,8 @@ function AboutPage() {
 						<p>[Story section 3 — design principles]</p>
 					</Section>
 
-					<Section title="Why $14, once">
-						{/* TODO: 120-180 words. The pricing decision. Why a one-time $14 instead
+					<Section title="Why $5, once">
+						{/* TODO: 120-180 words. The pricing decision. Why a one-time $5 instead
 						    of $9/mo or $99/yr. Who $99/yr is unaffordable for (students, early-
 						    career devs, anyone in a non-US market). The anti-subscription stance. */}
 						<p>[Story section 4 — pricing rationale]</p>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -8,7 +8,7 @@ import { createSeoHead, siteUrl } from "@/lib/seo"
 
 const HOME_TITLE = "LeetCode Accountability with Daily Problems & Study Groups"
 const HOME_DESCRIPTION =
-	"PStrack is the accountability layer for the NeetCode 250, NeetCode 150, and Blind 75 roadmaps. Solve one LeetCode problem a day, auto-verified against the LeetCode API, build streaks, and compete with study groups. Free tier; $14 lifetime Pro."
+	"PStrack is the accountability layer for the NeetCode 250, NeetCode 150, and Blind 75 roadmaps. Solve one LeetCode problem a day, auto-verified against the LeetCode API, build streaks, and compete with study groups. Free tier; $5 lifetime Pro."
 
 const homeSchema = {
 	"@context": "https://schema.org",
@@ -49,7 +49,7 @@ const homeSchema = {
 				{
 					"@type": "Offer",
 					name: "Pro (Lifetime)",
-					price: "14",
+					price: "5",
 					priceCurrency: "USD",
 					category: "OneTime",
 				},


### PR DESCRIPTION
## Summary

Updates PStrack Pro pricing references from $14 to $5 across app-facing SEO metadata, structured offer schema, MDX content, public llms.txt, and project docs.

Also removes the stale $9 sale-price task from the Polar timeline since the new standard price is $5.

## Validation

- bun run check
- pre-push hook: bun run build
- pre-push hook: bun run typecheck

## Notes

Unrelated local changes in settings files and vercel.json were left unstaged and are not included in this PR.