### PR TITLE
[codex] Fix profile navigation crash from leaderboard

### DIFF
--- a/src/routes/$username.tsx
+++ b/src/routes/$username.tsx
@@ -10,7 +10,9 @@ import { usePublicProfile } from "@/features/profile/hooks/use-public-profile"
 import { createSeoHead, siteUrl } from "@/lib/seo"
 
 export const Route = createFileRoute("/$username")({
-	ssr: true,
+	// Keep profile navigation in the client app to avoid mixed SSR/SPA reconciliation
+	// crashes when users click through from the leaderboard.
+	ssr: false,
 	component: PublicProfileRoute,
 	errorComponent: ({ error, reset }) => (
 		<RouteErrorFallback error={error} reset={reset} title="Could not load profile" />


### PR DESCRIPTION
## Summary

- Disable SSR for the public profile route so profile navigation stays in the client app when clicking from the SPA-only leaderboard.
- Keep the existing profile route error fallback for real profile load failures.

## Root cause

The leaderboard route is client-only, while `/$username` was SSR-enabled. The first client navigation from `/leaderboard` into `/$username` could hit a React DOM reconciliation race and bubble to the root error page (`removeChild` on a non-child node). Aligning the profile route with the client-rendered app path removes that mixed SSR/SPA transition.

Fixes #258

## Validation

- `bun run typecheck`
- `bun run check`
- `bun run test -- --project unit`
- `bun run build`
- Pre-commit Biome check passed
- Pre-push `build` and `typecheck` passed
- Local smoke: `http://127.0.0.1:3011/elmelegy` rendered the profile route with no root error, no route error, and no console errors.

## Notes

The full `bun run test` command still requires integration-test env vars in a fresh worktree; without `.env`, the DB integration suite fails during env validation before running. The unauthenticated smoke browser also cannot render signed-in leaderboard rows, so I could not honestly reproduce the exact row-click path locally.
