### PR TITLE
ci(#265): auto-PR workflow for stage → main

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,70 @@
+name: Auto Create PR
+
+# Opens (or refreshes) a single stage → main "release" PR whenever `stage`
+# advances. main deploys to production, so this PR is the review + CI gate
+# before prod. See docs/agdr/AgDR-0003-auto-pr-stage-to-main.md.
+
+on:
+  push:
+    branches:
+      - stage
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: auto-pr-stage-to-main
+  cancel-in-progress: false
+
+jobs:
+  create-or-update-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for the changelog)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Open or update the stage → main PR
+        # PAT (not the default GITHUB_TOKEN) so the opened PR triggers ci.yml —
+        # GitHub deliberately will not run pull_request workflows on a PR opened
+        # by GITHUB_TOKEN.
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          BASE: main
+          HEAD: stage
+        run: |
+          set -euo pipefail
+
+          git fetch origin "$BASE" --quiet
+
+          # Empty-diff guard — nothing to ship if stage isn't ahead of main.
+          ahead=$(git rev-list --count "origin/${BASE}..HEAD")
+          if [ "$ahead" -eq 0 ]; then
+            echo "stage has no commits ahead of ${BASE} — nothing to PR. Skipping."
+            exit 0
+          fi
+
+          # Changelog body: exactly what is about to ship to production.
+          changelog=$(git log --oneline --no-merges "origin/${BASE}..HEAD")
+          {
+            printf '🤖 Automated PR from `%s` → `%s`.\n\n' "$HEAD" "$BASE"
+            printf '**%s commit(s) ready to ship:**\n\n' "$ahead"
+            printf '```\n%s\n```\n\n' "$changelog"
+            printf '_Opened/updated automatically on push to `%s`._\n' "$HEAD"
+          } > pr-body.md
+
+          # Reuse an existing open PR; otherwise create one.
+          existing=$(gh pr list --base "$BASE" --head "$HEAD" --state open \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh pr edit "$existing" --body-file pr-body.md
+            echo "Updated existing PR #${existing}"
+          else
+            gh pr create --base "$BASE" --head "$HEAD" \
+              --title "🎯 Auto PR: stage → main" \
+              --body-file pr-body.md
+            echo "Created new stage → main PR"
+          fi

--- a/docs/agdr/AgDR-0003-auto-pr-stage-to-main.md
+++ b/docs/agdr/AgDR-0003-auto-pr-stage-to-main.md
@@ -1,0 +1,38 @@
+# Auto-PR workflow: stage → main
+
+> In the context of pstrack's `stage → main` release flow, facing the toil of hand-opening a release PR every time `stage` advances, I decided to add a GitHub Actions workflow that auto-opens/updates the PR — authed with a PAT and built on the `gh` CLI — to achieve a single, CI-gated, reviewable prod gate, accepting a dependency on the `PAT_TOKEN` secret.
+
+## Context
+
+`main` deploys to production; work lands on `stage` first. pstrack's `ci.yml` runs only on `pull_request → main` / `push → main` — **nothing tests `stage`** — so the `stage → main` PR is the only place CI gates changes before prod. Opening that PR by hand each time is repetitive. db-studio already runs an equivalent `auto-pr.yml`; this ports the pattern to pstrack with a few enhancements.
+
+## Options Considered
+
+| Decision | Option | Pros | Cons |
+|----------|--------|------|------|
+| **Auth token** | **PAT (`secrets.PAT_TOKEN`)** ✓ | The auto-PR triggers `ci.yml` — the gate actually gates | Depends on a PAT secret + its scopes |
+| | Default `GITHUB_TOKEN` | Zero secrets | GitHub won't run `pull_request` workflows on a PR it opened → PR has **no checks** |
+| **Implementation** | **`gh` CLI** ✓ | No third-party action to trust/pin; create+update in one readable step | Slightly more shell |
+| | `repo-sync/pull-request@v2` + `actions/github-script` (db-studio's shape) | 1:1 parity | Third-party action gets a write-scoped PAT; more YAML |
+| **Trigger** | **`push: stage` only** ✓ | One code path; covers direct pushes and merges | — |
+| | `push` + `pull_request.closed` (db-studio) | "merged PR #N" flavour text | Redundant (a merge is a push); needs a merged-guard |
+| **PR body** | **Changelog of `main..stage`** ✓ | Shows exactly what ships to prod | — |
+| | Single triggering commit (db-studio) | Simpler | Hides the full release scope |
+
+Also: **empty-diff guard** (skip when `stage` isn't ahead of `main`, avoiding "No commits between…" errors) and **least-privilege perms** (`contents: read` + `pull-requests: write`, vs db-studio's `contents: write`).
+
+## Decision
+
+Chosen: **`gh`-CLI workflow, `push: stage` trigger, `PAT_TOKEN` auth, changelog body, empty-diff guard**, because it gives a genuinely CI-gated prod PR with the fewest external dependencies. The workflow file targets the `stage` branch (a `push:stage` workflow only runs from the copy present on `stage`).
+
+## Consequences
+
+- Every push to `stage` opens or refreshes one `🎯 Auto PR: stage → main`; pstrack CI runs on it via `PAT_TOKEN`.
+- `PAT_TOKEN` must keep `contents: read` + `pull-requests: write` on pstrack; if it lapses, the workflow fails loudly.
+- The bootstrap: merging *this* file into `stage` is itself a push to `stage`, so the first auto-PR appears immediately.
+- No third-party actions in this workflow; the `stage → main` PR is never auto-merged — merge still requires human review + approval.
+
+## Artifacts
+
+- `.github/workflows/auto-pr.yml`
+- Ticket husamql3/pstrack#265


### PR DESCRIPTION
## Summary
- **Adds `.github/workflows/auto-pr.yml`** — on every push to `stage`, it opens (or refreshes) a single `🎯 Auto PR: stage → main` release PR, so the CI-gated prod PR no longer has to be created by hand. Built on the **`gh` CLI** — no third-party action to trust or pin.
- **Authed via `secrets.PAT_TOKEN`** so the auto-PR actually triggers `ci.yml`. This matters: GitHub won't run `pull_request` workflows on a PR opened by the default `GITHUB_TOKEN`, so a default-token PR would show **zero checks** — defeating the purpose of a stage→main gate.
- **Push-only trigger, changelog body, empty-diff guard** — the PR body lists the commits in `origin/main..stage` (exactly what's shipping to prod), and a no-op push (stage not ahead of main) logs "nothing to PR" and creates nothing instead of erroring.
- **Least-privilege perms** — `contents: read` + `pull-requests: write` (db-studio's original used `contents: write`, which the gh-CLI approach doesn't need).
- Decisions recorded in **`docs/agdr/AgDR-0003-auto-pr-stage-to-main.md`**: PAT vs default token, `gh` CLI vs `repo-sync/pull-request`, push-only trigger.

## Why this PR targets `stage`, not `main`
A `push: stage` workflow only runs from the copy of the file that exists **on `stage`**. Merging this into `stage` is itself a push to `stage`, so the first auto-PR appears immediately and will carry this workflow (plus the 4 commits already on stage) into `main`.

## Testing
1. Merge to `stage` → observe the `Auto Create PR` workflow run and open `🎯 Auto PR: stage → main`.
2. Confirm that auto-PR shows pstrack CI checks running (proves `PAT_TOKEN` wiring) and its body lists the `origin/main..stage` commits.
3. Push to `stage` when it has no diff vs `main` → workflow logs "nothing to PR. Skipping." and creates no PR.

Refs #265

---

## Glossary
| Term | Definition |
|------|------------|
| Auto-PR | A workflow that programmatically opens/updates a PR instead of a human doing it. |
| `PAT_TOKEN` | Personal Access Token stored as a pstrack repo secret; used so the auto-PR triggers downstream CI — the default `GITHUB_TOKEN` cannot. |
| Empty-diff guard | A pre-check (`git rev-list --count origin/main..HEAD`) that skips PR creation when `stage` has no commits ahead of `main`. |
| Changelog body | The PR description generated from `git log origin/main..stage` — the exact set of commits about to reach production. |
