### PR TITLE
Fix auth origin for www domain

### DIFF
--- a/src/server/lib/auth.ts
+++ b/src/server/lib/auth.ts
@@ -19,6 +19,7 @@ export const auth = betterAuth({
 	database: prismaAdapter(db, { provider: "postgresql" }),
 	secret: env.BETTER_AUTH_SECRET,
 	baseURL: env.BETTER_AUTH_URL,
+	trustedOrigins: [env.BETTER_AUTH_URL, "https://www.pstrack.app"],
 	basePath: "/api/v3/auth",
 	socialProviders: {
 		google: {


### PR DESCRIPTION
## Summary
- allow https://www.pstrack.app as a trusted Better Auth origin
- keep BETTER_AUTH_URL as the canonical apex domain

## Verification
- bun run typecheck