### PR TITLE
fix(deploy): add container HEALTHCHECK for zero-downtime Coolify deploys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,10 @@ ENV PORT=3000
 
 EXPOSE 3000
 
+# Lets Coolify gate the rolling swap on real readiness: it waits for the new
+# container to report healthy before routing traffic to it and stopping the old
+# one. Without this, Coolify falls back to stop-then-start (= downtime).
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:3000/api/v3/health || exit 1
+
 CMD ["node", ".output/server/index.mjs"]


### PR DESCRIPTION
## Problem

Every production deploy briefly takes the site down. CI pushes a new image to GHCR and triggers Coolify's `/api/v1/deploy`, but the `Dockerfile` has **no `HEALTHCHECK`**. Coolify can only do a rolling swap when it can observe the new container's health status — without one it falls back to **stop-old → start-new**, leaving a gap where the old image is gone but the new one isn't yet serving on `:3000`.

## Fix

Add a `HEALTHCHECK` to the `runtime-prebuilt` stage that probes the existing `/api/v3/health` endpoint (which also verifies DB connectivity) using the `curl` already installed in that stage.

```dockerfile
HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
    CMD curl -fsS http://localhost:3000/api/v3/health || exit 1
```

With rolling update enabled in Coolify, it now waits for `healthy` before cutting traffic over and stopping the old container.

## Follow-up (not code — Coolify UI)

- Enable **Rolling Update / Zero Downtime Deployment** on the app (General/Advanced).
- Confirm the **Health Check** tab points at `/api/v3/health` on port `3000` (keep it in sync with the Dockerfile `HEALTHCHECK`).
- Bump `--start-period` if cold start + first DB connect exceeds 30s.
- Verify the node server drains in-flight requests on `SIGTERM` so rolling swaps don't truncate responses.

## Test plan

- [ ] CI builds and publishes the image with the `HEALTHCHECK`.
- [ ] `docker inspect` on the running container shows `Health: healthy`.
- [ ] Deploy from `main` with rolling update on → no downtime window (site stays reachable throughout the swap).