### PR TITLE
feat(#241): Pro visual identity — animated badge + gold avatar treatment

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -151,6 +151,7 @@ import { motion } from "motion/react"
 - Use `motion` for layout transitions, hero/landing flourishes, and modal/sheet entrances if the shadcn primitive doesn't already animate.
 - Most shadcn primitives ship with their own CSS-driven animations via `tw-animate-css` - don't double-animate them with `motion`.
 - Keep durations short (150–300ms for UI; 400–600ms for hero moments). No infinite ambient loops outside the landing page.
+  - **Sanctioned exception:** the Pro badge (`src/components/ui/pro-badge.tsx`, `<ProBadge>`) runs a looping shine to signal Pro status. This is the one deliberate infinite ambient loop outside the landing page — CEO-directed for Pro identity (#241). Do not add others without the same explicit sign-off.
 - **Don't install `framer-motion`, `react-spring`, or `gsap`.** `motion` covers it.
 
 ---

--- a/src/components/ui/pro-badge.tsx
+++ b/src/components/ui/pro-badge.tsx
@@ -1,0 +1,36 @@
+import { IconStarFilled } from "@tabler/icons-react"
+import { motion } from "motion/react"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * Animated "PRO" badge — a luxe-style shine, hand-authored on `motion` + the
+ * `warning` design token (never a hardcoded gold, so theming + dark mode hold).
+ *
+ * The looping shine is a *sanctioned* exception to DESIGN.md §7 ("no infinite
+ * ambient loops outside the landing page") — CEO-directed for Pro identity (#241).
+ */
+export const ProBadge = ({ className }: { className?: string }) => (
+	<span
+		data-slot="pro-badge"
+		className={cn(
+			"relative inline-flex h-5 w-fit shrink-0 items-center gap-0.5 overflow-hidden rounded-4xl border border-warning/40 bg-warning/15 px-1.5 font-semibold text-[10px] text-warning-foreground uppercase leading-none tracking-wide",
+			className
+		)}
+	>
+		<motion.span
+			aria-hidden
+			className="pointer-events-none absolute inset-y-0 left-0 w-1/3 -skew-x-12 bg-gradient-to-r from-transparent via-warning/60 to-transparent"
+			initial={{ x: "-150%" }}
+			animate={{ x: "450%" }}
+			transition={{
+				duration: 1.6,
+				ease: "easeInOut",
+				repeat: Number.POSITIVE_INFINITY,
+				repeatDelay: 1.4,
+			}}
+		/>
+		<IconStarFilled className="relative size-2.5" />
+		<span className="relative">Pro</span>
+	</span>
+)

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -18,6 +18,7 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
+import { ProBadge } from "@/components/ui/pro-badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { HashAvatar } from "@/features/onboarding/components/hash-avatar"
 import { signOut, useSession } from "@/lib/auth-client"
@@ -78,7 +79,11 @@ export function UserMenu() {
 					{isPending ? (
 						<Skeleton className="size-4 shrink-0 rounded-full" />
 					) : (
-						<HashAvatar username={user?.username ?? initials} size={16} />
+						<HashAvatar
+							username={user?.username ?? initials}
+							size={16}
+							isPro={!!user?.isPro}
+						/>
 					)}
 					{isPending ? (
 						<Skeleton className="h-4 w-20" />
@@ -100,11 +105,18 @@ export function UserMenu() {
 						</>
 					) : (
 						<>
-							<HashAvatar username={user?.username ?? initials} size={32} />
+							<HashAvatar
+								username={user?.username ?? initials}
+								size={32}
+								isPro={!!user?.isPro}
+							/>
 							<div className="flex min-w-0 flex-col gap-0.5">
-								<span className="truncate font-medium text-foreground text-sm">
-									{user?.name ?? displayName}
-								</span>
+								<div className="flex min-w-0 items-center gap-1.5">
+									<span className="truncate font-medium text-foreground text-sm">
+										{user?.name ?? displayName}
+									</span>
+									{!!user?.isPro && <ProBadge />}
+								</div>
 								<span className="truncate text-muted-foreground text-xs">
 									{user?.email}
 								</span>

--- a/src/features/groups/components/group-problems-header-cell.tsx
+++ b/src/features/groups/components/group-problems-header-cell.tsx
@@ -15,7 +15,13 @@ export const GroupProblemsHeaderCell = ({
 	const inner = (
 		<>
 			<div className="relative">
-				<HashAvatar username={label} size={28} shape="circle" />
+				<HashAvatar
+					username={label}
+					size={28}
+					shape="circle"
+					isPro={member.isPro}
+					proStar={member.isPro}
+				/>
 			</div>
 			<div
 				className="grow text-center font-medium text-[11px] tracking-wide"

--- a/src/features/leaderboard/components/leaderboard-row.tsx
+++ b/src/features/leaderboard/components/leaderboard-row.tsx
@@ -1,6 +1,7 @@
 import { IconFlame } from "@tabler/icons-react"
 import { Link } from "@tanstack/react-router"
 
+import { ProBadge } from "@/components/ui/pro-badge"
 import { HashAvatar } from "@/features/onboarding/components/hash-avatar"
 import { cn } from "@/lib/utils"
 import type { LeaderboardEntry } from "@/server/leaderboard/leaderboard.type"
@@ -31,18 +32,14 @@ export const LeaderboardRow = ({
 
 			{/* Avatar */}
 			<div className="shrink-0">
-				<HashAvatar username={displayName} size={36} />
+				<HashAvatar username={displayName} size={36} isPro={entry.isPro} />
 			</div>
 
 			{/* Name + score bar */}
 			<div className="min-w-0 flex-1">
 				<div className="flex items-center gap-1.5">
 					<span className="truncate font-medium text-sm leading-none">{displayName}</span>
-					{entry.isPro && (
-						<span className="rounded bg-primary/15 px-1 py-0.5 font-mono text-[10px] text-primary leading-none">
-							pro
-						</span>
-					)}
+					{entry.isPro && <ProBadge />}
 					{isViewer && (
 						<span className="text-[10px] text-muted-foreground leading-none">(you)</span>
 					)}

--- a/src/features/onboarding/components/hash-avatar.tsx
+++ b/src/features/onboarding/components/hash-avatar.tsx
@@ -1,3 +1,4 @@
+import { IconStarFilled } from "@tabler/icons-react"
 import { renderHashvatar } from "hashvatar"
 import { useEffect, useRef } from "react"
 
@@ -7,10 +8,16 @@ export const HashAvatar = ({
 	username,
 	size = 80,
 	shape = "circle",
+	isPro = false,
+	proStar = false,
 }: {
 	username: string
 	size?: number
 	shape?: "circle" | "square"
+	/** Pro users get a gold ring around the avatar. */
+	isPro?: boolean
+	/** In list contexts, add a bottom-left gold star overlay (implies a Pro user). */
+	proStar?: boolean
 }) => {
 	const canvasRef = useRef<HTMLCanvasElement>(null)
 
@@ -25,24 +32,38 @@ export const HashAvatar = ({
 		return stop
 	}, [username, size])
 
-	if (!username) {
-		return (
-			<div
-				className={cn("bg-muted", shape === "circle" ? "rounded-full" : "rounded-xl")}
-				style={{ width: size, height: size }}
-			/>
-		)
-	}
+	const rounded = shape === "circle" ? "rounded-full" : "rounded-xl"
 
-	return (
+	const inner = !username ? (
+		<div className={cn("bg-muted", rounded)} style={{ width: size, height: size }} />
+	) : (
 		<div
-			className={cn(
-				"overflow-hidden",
-				shape === "circle" ? "rounded-full" : "rounded-xl"
-			)}
+			className={cn("overflow-hidden", rounded, isPro && "ring-2 ring-warning")}
 			style={{ width: size, height: size }}
 		>
 			<canvas ref={canvasRef} width={size} height={size} />
+		</div>
+	)
+
+	// Fast path: untouched behaviour for every existing (non-Pro) caller.
+	if (!isPro && !proStar) return inner
+
+	const starBox = Math.max(12, Math.round(size * 0.4))
+
+	return (
+		<div className="relative inline-flex shrink-0" style={{ width: size, height: size }}>
+			{inner}
+			{proStar && (
+				<span
+					className="absolute -bottom-0.5 left-0 z-10 inline-flex items-center justify-center rounded-full bg-warning text-warning-foreground ring-2 ring-background"
+					style={{ width: starBox, height: starBox }}
+				>
+					<IconStarFilled
+						style={{ width: starBox * 0.6, height: starBox * 0.6 }}
+						className="text-white"
+					/>
+				</span>
+			)}
 		</div>
 	)
 }

--- a/src/features/profile/components/public-profile.tsx
+++ b/src/features/profile/components/public-profile.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tabler/icons-react"
 import { format } from "date-fns"
 
+import { ProBadge } from "@/components/ui/pro-badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { HashAvatar } from "@/features/onboarding/components/hash-avatar"
 import { SolveHeatmap } from "@/features/profile/components/solve-heatmap"
@@ -55,12 +56,6 @@ const Stat = ({
 		<Icon className="size-4 text-muted-foreground" aria-hidden="true" />
 		<span className="truncate">{label}</span>
 	</a>
-)
-
-const ProChip = () => (
-	<span className="inline-flex items-center rounded-full border border-warning/30 bg-warning/5 px-2 py-0.5 font-mono font-semibold text-[10px] text-warning uppercase tracking-[0.18em]">
-		Pro
-	</span>
 )
 
 const BadgeMedal = ({
@@ -204,11 +199,11 @@ export const PublicProfile = ({ profile }: { profile: PublicProfileResponse }) =
 	if (profile.visibility === "PRIVATE") {
 		return (
 			<main className="mx-auto flex w-full max-w-md flex-col items-center gap-4 px-6 py-24 text-center">
-				<HashAvatar username={profile.username} size={80} />
+				<HashAvatar username={profile.username} size={80} isPro={profile.isPro} />
 				<div className="flex flex-col items-center gap-1">
 					<div className="flex items-center gap-2">
 						<h1 className="font-semibold text-xl">{profile.name}</h1>
-						{profile.isPro && <ProChip />}
+						{profile.isPro && <ProBadge />}
 					</div>
 					<p className="font-mono text-muted-foreground text-sm">@{profile.username}</p>
 				</div>
@@ -260,11 +255,11 @@ export const PublicProfile = ({ profile }: { profile: PublicProfileResponse }) =
 	return (
 		<main className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-6 py-16">
 			<header className="flex flex-col items-center gap-5 text-center sm:flex-row sm:items-start sm:text-left">
-				<HashAvatar username={username} size={96} />
+				<HashAvatar username={username} size={96} isPro={profile.isPro} />
 				<div className="flex min-w-0 flex-1 flex-col gap-1">
 					<div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
 						<h1 className="font-semibold text-2xl tracking-tight">{profile.name}</h1>
-						{profile.isPro && <ProChip />}
+						{profile.isPro && <ProBadge />}
 					</div>
 					<p className="font-mono text-muted-foreground text-sm">@{username}</p>
 					{profile.bio && <p className="mt-2 text-sm leading-relaxed">{profile.bio}</p>}


### PR DESCRIPTION
## Summary
- **Unified, animated Pro identity.** Adds a single `<ProBadge>` (`src/components/ui/pro-badge.tsx`) — a luxe-style gold "PRO" pill with a looping shine — replacing the three hand-rolled indicators that had drifted apart (the `ProChip` on profiles and the primary-colored pill in `leaderboard-row`). One component now means one consistent look everywhere.
- **Gold ring on Pro avatars, opt-in via a prop.** `HashAvatar` gains `isPro` (gold ring) and `proStar` (bottom-left star with a background, for dense list contexts). Both default off behind a fast path, so all ~9 existing avatar call sites are byte-for-byte unaffected — only Pro users render the treatment.
- **Wired across the app.** Ring + badge on the **leaderboard** and **public profile**; ring + bottom-left star in the **group-problems** board; ring on both avatars + badge in the **user menu** (gated on `session.user.isPro`, no extra query).
- **Token-based, no hardcoded gold.** Everything reuses the existing `warning` design token, so dark mode + theming keep working — no `bg-yellow-*`, no hex.
- **Documented motion exception.** The badge's shine is an *infinite ambient loop*, which `DESIGN.md §7` normally forbids outside the landing page. It's recorded there as a sanctioned, owner-directed exception so it isn't "fixed" later by mistake.

## Scope
Visual layer only. The rest of #241 — the `/pro` page, the `authClient.checkout` "Get Pro" CTA, and the "Upgrade" toast action — is intentionally deferred to a follow-up. Global-leaderboard gating stays out of scope (leaderboard remains open).

## Testing
1. `bun run dev`, sign in as a Pro user (or flip your `isPro`).
2. Check the **user menu** (nav button + dropdown), **leaderboard**, **public profile**, and a **group-problems** board — Pro users show the gold ring + animated badge; the group list also shows the bottom-left star.
3. Confirm a non-Pro user shows none of it, and verify both light and dark mode.

Verification: `typecheck` ✓ · `biome` ✓ · `build` ✓ · 75/75 unit tests ✓. (The 3 `daily-loop.integration.test.ts` failures are pre-existing — they need a migrated/seeded local test DB and are unrelated to this frontend-only change.)

Refs #241

---

## Glossary
| Term | Definition |
|------|------------|
| `ProBadge` | The new shared, animated gold "PRO" label component. Distinct from achievement "badges". |
| `isPro` prop | On `HashAvatar` — renders the gold ring. Sourced from the Better Auth session `additionalField`. |
| `proStar` prop | On `HashAvatar` — renders the bottom-left star overlay for list/dense contexts. |
| `warning` token | The existing design-system gold token (`--color-yellow-500`), reused as the Pro color. |
| Ambient loop | A continuously-repeating animation; normally disallowed off the landing page by `DESIGN.md §7`, exempted here for the Pro badge. |
