### PR TITLE
test(stress): add concurrent reliability coverage

### DIFF
--- a/docs/STRESS_TESTING.md
+++ b/docs/STRESS_TESTING.md
@@ -1,0 +1,29 @@
+# Stress Testing
+
+PStrack has an in-process stress suite for deterministic reliability checks against
+the real integration test database.
+
+Run the fast subset:
+
+```sh
+bun run test:stress
+```
+
+Run a heavier manual or nightly pass:
+
+```sh
+PSTRACK_STRESS_REPETITIONS=20 bun run test:stress
+```
+
+The suite stresses every registered API route and every Trigger module through a
+manifest guard. New routes or jobs must be classified in
+`src/test/stress-manifest.ts`, then covered by a representative scenario.
+
+The API matrix uses deterministic session doubles so application routes can
+exercise authenticated and unauthenticated states. A separate Better Auth stress
+test calls the real auth handler concurrently for the session-read boundary.
+
+The primary failure signal is the post-run invariant audit in `src/test/stress.ts`.
+It checks for duplicate memberships, join requests, daily problems, solves, point
+ledger rows, badges, over-capacity groups, first-solver mismatches, and denormalized
+`User.totalPoints` drift.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"db:studio": "bunx db-studio@latest --database-url \"$DATABASE_URL\"",
 		"prisma:generate": "prisma generate",
 		"test": "vitest run",
+		"test:stress": "vitest run --project integration stress --no-file-parallelism",
 		"format": "biome check --write --unsafe .",
 		"check": "bun run biome check .",
 		"knip": "knip",

--- a/src/server/groups/groups.admin.dao.ts
+++ b/src/server/groups/groups.admin.dao.ts
@@ -196,11 +196,12 @@ export const groupsAdminDao = {
 		})
 		if (!existing) return { ok: false, error: "GROUP_NOT_FOUND" }
 
-		await db.$transaction(async (tx) => {
+		const deleted = await db.$transaction(async (tx) => {
 			await tx.dailyProblem.deleteMany({ where: { groupId } })
 			await tx.groupJoinRequest.deleteMany({ where: { groupId } })
 			await tx.groupMember.deleteMany({ where: { groupId } })
-			await tx.group.delete({ where: { id: groupId } })
+			const result = await tx.group.deleteMany({ where: { id: groupId } })
+			if (result.count === 0) return false
 			await adminAuditDao.log(
 				{
 					adminId,
@@ -210,8 +211,10 @@ export const groupsAdminDao = {
 				},
 				tx
 			)
+			return true
 		})
 
+		if (!deleted) return { ok: false, error: "GROUP_NOT_FOUND" }
 		return { ok: true, slug: existing.slug }
 	},
 

--- a/src/server/points/points.dao.test.ts
+++ b/src/server/points/points.dao.test.ts
@@ -13,13 +13,13 @@ import { db } from "@/server/lib/db"
 import { pointsDao } from "./points.dao"
 
 const tx = {
+	$queryRaw: vi.fn(),
 	pointsHistory: {
-		create: vi.fn(),
+		createMany: vi.fn(async () => ({ count: 1 })),
 		aggregate: vi.fn(),
 		findFirst: vi.fn(),
 	},
 	user: {
-		findUniqueOrThrow: vi.fn(),
 		update: vi.fn(),
 	},
 }
@@ -29,7 +29,7 @@ describe("pointsDao", () => {
 
 	describe("applyPointsDelta", () => {
 		it("writes an immutable ledger row and updates the cached total", async () => {
-			tx.user.findUniqueOrThrow.mockResolvedValue({ totalPoints: 12, isPro: false })
+			tx.$queryRaw.mockResolvedValue([{ totalPoints: 12, isPro: false }])
 
 			const result = await pointsDao.applyPointsDelta(
 				"user-1",
@@ -42,7 +42,7 @@ describe("pointsDao", () => {
 			)
 
 			expect(db.$transaction).toHaveBeenCalledOnce()
-			expect(tx.pointsHistory.create).toHaveBeenCalledWith({
+			expect(tx.pointsHistory.createMany).toHaveBeenCalledWith({
 				data: {
 					userId: "user-1",
 					delta: 10,
@@ -51,6 +51,7 @@ describe("pointsDao", () => {
 					userSolveId: "solve-1",
 					adminNote: null,
 				},
+				skipDuplicates: true,
 			})
 			expect(tx.user.update).toHaveBeenCalledWith({
 				where: { id: "user-1" },
@@ -60,7 +61,7 @@ describe("pointsDao", () => {
 		})
 
 		it("never lets a negative delta push total points below zero", async () => {
-			tx.user.findUniqueOrThrow.mockResolvedValue({ totalPoints: 2, isPro: false })
+			tx.$queryRaw.mockResolvedValue([{ totalPoints: 2, isPro: false }])
 
 			const result = await pointsDao.applyPointsDelta("user-1", -5, PointReason.PAUSE, {
 				tx,
@@ -74,7 +75,7 @@ describe("pointsDao", () => {
 		})
 
 		it("unlocks pro exactly when the user crosses the points threshold", async () => {
-			tx.user.findUniqueOrThrow.mockResolvedValue({ totalPoints: 2995, isPro: false })
+			tx.$queryRaw.mockResolvedValue([{ totalPoints: 2995, isPro: false }])
 
 			const result = await pointsDao.applyPointsDelta(
 				"user-1",
@@ -95,7 +96,7 @@ describe("pointsDao", () => {
 		})
 
 		it("does not overwrite pro source for users who are already pro", async () => {
-			tx.user.findUniqueOrThrow.mockResolvedValue({ totalPoints: 2995, isPro: true })
+			tx.$queryRaw.mockResolvedValue([{ totalPoints: 2995, isPro: true }])
 
 			const result = await pointsDao.applyPointsDelta(
 				"user-1",
@@ -115,9 +116,9 @@ describe("pointsDao", () => {
 	describe("applyMissPenalty", () => {
 		it("claws back streak bonuses before applying the missed-day penalty", async () => {
 			tx.pointsHistory.aggregate.mockResolvedValue({ _sum: { delta: 12 } })
-			tx.user.findUniqueOrThrow
-				.mockResolvedValueOnce({ totalPoints: 50, isPro: false })
-				.mockResolvedValueOnce({ totalPoints: 38, isPro: false })
+			tx.$queryRaw
+				.mockResolvedValueOnce([{ totalPoints: 50, isPro: false }])
+				.mockResolvedValueOnce([{ totalPoints: 38, isPro: false }])
 
 			await pointsDao.applyMissPenalty(tx, "user-1", {
 				userSolveId: "solve-1",
@@ -134,7 +135,7 @@ describe("pointsDao", () => {
 				},
 				_sum: { delta: true },
 			})
-			expect(tx.pointsHistory.create).toHaveBeenNthCalledWith(1, {
+			expect(tx.pointsHistory.createMany).toHaveBeenNthCalledWith(1, {
 				data: {
 					userId: "user-1",
 					delta: -12,
@@ -143,8 +144,9 @@ describe("pointsDao", () => {
 					userSolveId: "solve-1",
 					adminNote: null,
 				},
+				skipDuplicates: true,
 			})
-			expect(tx.pointsHistory.create).toHaveBeenNthCalledWith(2, {
+			expect(tx.pointsHistory.createMany).toHaveBeenNthCalledWith(2, {
 				data: {
 					userId: "user-1",
 					delta: -3,
@@ -153,6 +155,7 @@ describe("pointsDao", () => {
 					userSolveId: "solve-1",
 					adminNote: null,
 				},
+				skipDuplicates: true,
 			})
 			expect(tx.user.update).toHaveBeenLastCalledWith({
 				where: { id: "user-1" },
@@ -161,7 +164,7 @@ describe("pointsDao", () => {
 		})
 
 		it("applies only the missed-day penalty when there is no active streak", async () => {
-			tx.user.findUniqueOrThrow.mockResolvedValue({ totalPoints: 10, isPro: false })
+			tx.$queryRaw.mockResolvedValue([{ totalPoints: 10, isPro: false }])
 
 			await pointsDao.applyMissPenalty(tx, "user-1", {
 				userSolveId: "solve-1",
@@ -169,8 +172,8 @@ describe("pointsDao", () => {
 			})
 
 			expect(tx.pointsHistory.aggregate).not.toHaveBeenCalled()
-			expect(tx.pointsHistory.create).toHaveBeenCalledOnce()
-			expect(tx.pointsHistory.create).toHaveBeenCalledWith({
+			expect(tx.pointsHistory.createMany).toHaveBeenCalledOnce()
+			expect(tx.pointsHistory.createMany).toHaveBeenCalledWith({
 				data: {
 					userId: "user-1",
 					delta: -3,
@@ -179,6 +182,7 @@ describe("pointsDao", () => {
 					userSolveId: "solve-1",
 					adminNote: null,
 				},
+				skipDuplicates: true,
 			})
 			expect(tx.user.update).toHaveBeenLastCalledWith({
 				where: { id: "user-1" },

--- a/src/server/points/points.dao.ts
+++ b/src/server/points/points.dao.ts
@@ -12,6 +12,23 @@ type ApplyPointsOptions = {
 	tx?: Tx
 }
 
+type LockedUserPoints = {
+	totalPoints: number
+	isPro: boolean
+}
+
+const lockUserPoints = async (tx: Tx, userId: string): Promise<LockedUserPoints> => {
+	const rows = await tx.$queryRaw<LockedUserPoints[]>`
+		SELECT "totalPoints" AS "totalPoints", "isPro" AS "isPro"
+		FROM "user"
+		WHERE id = ${userId}
+		FOR NO KEY UPDATE
+	`
+	const user = rows[0]
+	if (!user) throw new Error(`User not found: ${userId}`)
+	return user
+}
+
 const applyPointsDeltaInTx = async (
 	tx: Tx,
 	userId: string,
@@ -19,7 +36,9 @@ const applyPointsDeltaInTx = async (
 	reason: PointReason,
 	opts: Omit<ApplyPointsOptions, "tx">
 ) => {
-	await tx.pointsHistory.create({
+	const user = await lockUserPoints(tx, userId)
+
+	const created = await tx.pointsHistory.createMany({
 		data: {
 			userId,
 			delta,
@@ -28,12 +47,12 @@ const applyPointsDeltaInTx = async (
 			userSolveId: opts.userSolveId ?? null,
 			adminNote: opts.adminNote ?? null,
 		},
+		skipDuplicates: true,
 	})
 
-	const user = await tx.user.findUniqueOrThrow({
-		where: { id: userId },
-		select: { totalPoints: true, isPro: true },
-	})
+	if (created.count === 0) {
+		return { newTotal: user.totalPoints, crossedProThreshold: false }
+	}
 
 	const newTotal = Math.max(0, user.totalPoints + delta)
 	const crossedProThreshold = !user.isPro && newTotal >= PRO_THRESHOLD

--- a/src/server/problems/problems.admin.dao.ts
+++ b/src/server/problems/problems.admin.dao.ts
@@ -46,6 +46,12 @@ const nextRoadmapIndex = async (): Promise<number> => {
 	return (max._max.roadmapIndex ?? 0) + 1
 }
 
+const isUniqueConstraintError = (err: unknown, field: string) =>
+	err instanceof Error &&
+	"code" in err &&
+	err.code === "P2002" &&
+	err.message.includes(field)
+
 const nextPositionForRoadmap = async (tx: Tx, roadmapId: string): Promise<number> => {
 	const max = await tx.roadmapProblem.aggregate({
 		where: { roadmapId },
@@ -152,36 +158,51 @@ export const problemsAdminDao = {
 		})
 		if (existing) return { ok: false, error: "SLUG_TAKEN" }
 
-		const idx = await nextRoadmapIndex()
+		let problem: AdminProblemListItem | null = null
+		for (let attempt = 0; attempt < 3; attempt++) {
+			const idx = await nextRoadmapIndex()
+			try {
+				problem = await db.$transaction(async (tx) => {
+					const created = await tx.problem.create({
+						data: {
+							slug: input.slug,
+							title: input.title,
+							difficulty: input.difficulty,
+							topic: input.topic,
+							leetcodeId: input.leetcodeId ?? null,
+							neetcode250: input.neetcode250 ?? false,
+							neetcode150: input.neetcode150 ?? false,
+							blind75: input.blind75 ?? false,
+							source: "CUSTOM",
+							roadmapIndex: idx,
+						},
+						select: adminProblemListSelect,
+					})
+					await syncProblemRoadmapMemberships(tx, created)
+					await adminAuditDao.log(
+						{
+							adminId,
+							action: "PROBLEM_CREATED",
+							target: { type: "PROBLEM", id: created.id },
+							metadata: { slug: created.slug },
+						},
+						tx
+					)
+					return created
+				})
+				break
+			} catch (err) {
+				if (isUniqueConstraintError(err, "slug")) {
+					return { ok: false, error: "SLUG_TAKEN" }
+				}
+				if (isUniqueConstraintError(err, "roadmapIndex") && attempt < 2) {
+					continue
+				}
+				throw err
+			}
+		}
 
-		const problem = await db.$transaction(async (tx) => {
-			const created = await tx.problem.create({
-				data: {
-					slug: input.slug,
-					title: input.title,
-					difficulty: input.difficulty,
-					topic: input.topic,
-					leetcodeId: input.leetcodeId ?? null,
-					neetcode250: input.neetcode250 ?? false,
-					neetcode150: input.neetcode150 ?? false,
-					blind75: input.blind75 ?? false,
-					source: "CUSTOM",
-					roadmapIndex: idx,
-				},
-				select: adminProblemListSelect,
-			})
-			await syncProblemRoadmapMemberships(tx, created)
-			await adminAuditDao.log(
-				{
-					adminId,
-					action: "PROBLEM_CREATED",
-					target: { type: "PROBLEM", id: created.id },
-					metadata: { slug: created.slug },
-				},
-				tx
-			)
-			return created
-		})
+		if (!problem) return { ok: false, error: "SLUG_TAKEN" }
 
 		return { ok: true, problem }
 	},
@@ -234,8 +255,9 @@ export const problemsAdminDao = {
 			return { ok: false, error: "HAS_DAILY_PROBLEMS" }
 		}
 
-		await db.$transaction(async (tx) => {
-			await tx.problem.delete({ where: { id } })
+		const deleted = await db.$transaction(async (tx) => {
+			const result = await tx.problem.deleteMany({ where: { id } })
+			if (result.count === 0) return false
 			await adminAuditDao.log(
 				{
 					adminId,
@@ -245,8 +267,10 @@ export const problemsAdminDao = {
 				},
 				tx
 			)
+			return true
 		})
 
+		if (!deleted) return { ok: false, error: "NOT_FOUND" }
 		return { ok: true }
 	},
 

--- a/src/server/problems/problems.dao.ts
+++ b/src/server/problems/problems.dao.ts
@@ -521,6 +521,8 @@ export const problemsDao = {
 		let skipped = 0
 
 		await db.$transaction(async (tx) => {
+			await tx.$executeRaw`SELECT pg_advisory_xact_lock(705414, 250)`
+
 			const customSlugs = new Set(
 				(
 					await tx.problem.findMany({

--- a/src/server/problems/problems.roadmap.ts
+++ b/src/server/problems/problems.roadmap.ts
@@ -122,10 +122,15 @@ const seedLeetCodeStudyPlanProblems = async (tx: Tx) => {
 	}
 }
 
-const syncLegacyRoadmapMemberships = async (tx: Tx) => {
+const syncLegacyRoadmapMemberships = async (
+	tx: Tx,
+	roadmapIdByKey: Map<RoadmapKey, string>
+) => {
 	for (const roadmap of legacyRoadmapCatalogSeed) {
 		const flag = legacyRoadmapFlag(roadmap.key)
 		if (!flag) continue
+		const roadmapId = roadmapIdByKey.get(roadmap.key)
+		if (!roadmapId) continue
 
 		const problems = await tx.problem.findMany({
 			where: { [flag]: true },
@@ -133,10 +138,10 @@ const syncLegacyRoadmapMemberships = async (tx: Tx) => {
 			select: { id: true, topic: true },
 		})
 
-		await tx.roadmapProblem.deleteMany({ where: { roadmapId: roadmap.id } })
+		await tx.roadmapProblem.deleteMany({ where: { roadmapId } })
 		await tx.roadmapProblem.createMany({
 			data: problems.map((problem, index) => ({
-				roadmapId: roadmap.id,
+				roadmapId,
 				problemId: problem.id,
 				position: index + 1,
 				topic: problem.topic,
@@ -146,8 +151,13 @@ const syncLegacyRoadmapMemberships = async (tx: Tx) => {
 	}
 }
 
-const syncLeetCodeStudyPlanMemberships = async (tx: Tx) => {
+const syncLeetCodeStudyPlanMemberships = async (
+	tx: Tx,
+	roadmapIdByKey: Map<RoadmapKey, string>
+) => {
 	for (const roadmap of LEETCODE_STUDY_PLAN_ROADMAPS) {
+		const roadmapId = roadmapIdByKey.get(roadmap.key)
+		if (!roadmapId) continue
 		const slugs = roadmap.problems.map((problem) => problem.slug)
 		const problems = await tx.problem.findMany({
 			where: { slug: { in: slugs } },
@@ -160,7 +170,7 @@ const syncLeetCodeStudyPlanMemberships = async (tx: Tx) => {
 			const problemId = problemIdBySlug.get(problem.slug)
 			if (!problemId) continue
 			data.push({
-				roadmapId: catalogIdFor(roadmap.key),
+				roadmapId,
 				problemId,
 				position: problem.position,
 				topic: problem.topic,
@@ -172,15 +182,17 @@ const syncLeetCodeStudyPlanMemberships = async (tx: Tx) => {
 		}
 
 		await tx.roadmapProblem.deleteMany({
-			where: { roadmapId: catalogIdFor(roadmap.key) },
+			where: { roadmapId },
 		})
 		await tx.roadmapProblem.createMany({ data, skipDuplicates: true })
 	}
 }
 
 export const syncRoadmapCatalog = async (tx: Tx) => {
+	const roadmapIdByKey = new Map<RoadmapKey, string>()
+
 	for (const roadmap of roadmapCatalogSeed) {
-		await tx.roadmapCatalog.upsert({
+		const catalog = await tx.roadmapCatalog.upsert({
 			where: { key: roadmap.key },
 			create: roadmap,
 			update: {
@@ -191,10 +203,12 @@ export const syncRoadmapCatalog = async (tx: Tx) => {
 				sortOrder: roadmap.sortOrder,
 				isActive: true,
 			},
+			select: { id: true },
 		})
+		roadmapIdByKey.set(roadmap.key, catalog.id)
 	}
 
 	await seedLeetCodeStudyPlanProblems(tx)
-	await syncLegacyRoadmapMemberships(tx)
-	await syncLeetCodeStudyPlanMemberships(tx)
+	await syncLegacyRoadmapMemberships(tx, roadmapIdByKey)
+	await syncLeetCodeStudyPlanMemberships(tx, roadmapIdByKey)
 }

--- a/src/server/stress/api.stress.integration.test.ts
+++ b/src/server/stress/api.stress.integration.test.ts
@@ -1,0 +1,1109 @@
+import { readFile } from "node:fs/promises"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const authMock = vi.hoisted(() => {
+	process.env.BOT_NOTIFY_SECRET = "stress-bot-secret"
+
+	return {
+		getSession: vi.fn(),
+		handler: vi.fn(async () => new Response("auth")),
+		listSessions: vi.fn(),
+		revokeOtherSessions: vi.fn(),
+		revokeSession: vi.fn(),
+	}
+})
+
+vi.mock("@/server/lib/auth", () => ({
+	auth: {
+		api: {
+			getSession: authMock.getSession,
+			listSessions: authMock.listSessions,
+			revokeOtherSessions: authMock.revokeOtherSessions,
+			revokeSession: authMock.revokeSession,
+		},
+		handler: authMock.handler,
+	},
+}))
+
+vi.mock("@/server/lib/axiom", () => ({
+	axiomLog: vi.fn(),
+}))
+
+vi.mock("@/server/lib/bot", () => ({
+	notifyAdmin: vi.fn(),
+}))
+
+vi.mock("@/server/lib/email", () => ({
+	sendEmail: vi.fn(async () => ({ id: "stress-email" })),
+}))
+
+vi.mock("@/server/lib/sentry", () => ({
+	captureServerException: vi.fn(),
+	initServerSentry: vi.fn(),
+	ServerSentry: { flush: vi.fn() },
+}))
+
+import { app } from "@/server/app"
+import {
+	addMember,
+	addRoadmapProblem,
+	createDailyProblem,
+	createGroup,
+	createProblem,
+	createUser,
+	testDb,
+} from "@/test/db"
+import {
+	expectAllowedResponse,
+	expectCoreStressInvariants,
+	expectNoRejectedStressWork,
+	runConcurrent,
+	stressRepetitions,
+} from "@/test/stress"
+import { STRESS_ENDPOINTS } from "@/test/stress-manifest"
+
+type StressSessionUser = {
+	id: string
+	email: string
+	name: string
+	username: string | null
+	isPro: boolean
+	role: string | null
+}
+
+type StressContext = {
+	admin: StressSessionUser
+	pro: StressSessionUser
+	user: StressSessionUser
+	pauseUser: StressSessionUser
+	outsider: StressSessionUser
+	target: StressSessionUser
+	removable: StressSessionUser
+	publicGroupId: string
+	privateGroupId: string
+	startableGroupId: string
+	deletableGroupId: string
+	inviteCode: string
+	joinRequestId: string
+	transferRequestId: string
+	feedbackId: string
+	problemId: string
+	deletableProblemId: string
+}
+
+type StressScenario = {
+	key: { method: string; path: string }
+	method: string
+	path: string
+	userId?: string
+	headers?: Record<string, string>
+	body?: unknown | ((index: number) => unknown)
+	allowedStatuses: number[]
+}
+
+const sessions = new Map<string, StressSessionUser>()
+let fontRegular: Buffer
+let fontBold: Buffer
+
+const startOfUtcDay = (date: Date) =>
+	new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+
+const toArrayBuffer = (buffer: Buffer) => Uint8Array.from(buffer).buffer
+
+const registerSession = (user: StressSessionUser) => {
+	sessions.set(user.id, user)
+	return user
+}
+
+const sessionUserFromDb = (user: Awaited<ReturnType<typeof createUser>>) =>
+	registerSession({
+		id: user.id,
+		email: user.email,
+		name: user.name,
+		username: user.username,
+		isPro: user.isPro,
+		role: user.role,
+	})
+
+const jsonResponse = (body: unknown, init?: ResponseInit) =>
+	new Response(JSON.stringify(body), {
+		...init,
+		headers: { "content-type": "application/json", ...init?.headers },
+	})
+
+const seedStressContext = async (): Promise<StressContext> => {
+	const today = startOfUtcDay(new Date())
+	const tomorrow = new Date(today.getTime() + 86_400_000)
+
+	const admin = sessionUserFromDb(
+		await createUser({
+			id: "stress-admin",
+			email: "stress-admin@example.com",
+			username: "stress_admin",
+			role: "admin",
+			isPro: true,
+			leetcodeHandle: "stressadmin",
+		})
+	)
+	const pro = sessionUserFromDb(
+		await createUser({
+			id: "stress-pro",
+			email: "stress-pro@example.com",
+			username: "stress_pro",
+			isPro: true,
+			leetcodeHandle: "stresspro",
+		})
+	)
+	const user = sessionUserFromDb(
+		await createUser({
+			id: "stress-user",
+			email: "stress-user@example.com",
+			username: "stress_user",
+			leetcodeHandle: "stressuser",
+			codeforcesHandle: "tourist",
+		})
+	)
+	const pauseUser = sessionUserFromDb(
+		await createUser({
+			id: "stress-pause",
+			email: "stress-pause@example.com",
+			username: "stress_pause",
+			leetcodeHandle: "stresspause",
+		})
+	)
+	const outsider = sessionUserFromDb(
+		await createUser({
+			id: "stress-outsider",
+			email: "stress-outsider@example.com",
+			username: "stress_outsider",
+			isPro: true,
+			leetcodeHandle: "stressoutsider",
+		})
+	)
+	const target = sessionUserFromDb(
+		await createUser({
+			id: "stress-target",
+			email: "stress-target@example.com",
+			username: "stress_target",
+			leetcodeHandle: "stresstarget",
+		})
+	)
+	const removable = sessionUserFromDb(
+		await createUser({
+			id: "stress-removable",
+			email: "stress-removable@example.com",
+			username: "stress_removable",
+			leetcodeHandle: "stressremovable",
+		})
+	)
+	const pendingUser = await createUser({
+		id: "stress-pending",
+		email: "stress-pending@example.com",
+		username: "stress_pending",
+	})
+	const transferUser = await createUser({
+		id: "stress-transfer",
+		email: "stress-transfer@example.com",
+		username: "stress_transfer",
+	})
+
+	const problem = await createProblem({
+		id: "stress-problem",
+		slug: "stress-two-sum",
+		title: "Stress Two Sum",
+		roadmapIndex: 10_001,
+		neetcode250: true,
+	})
+	await addRoadmapProblem({ problemId: problem.id, position: 1, topic: problem.topic })
+
+	const pauseProblem = await createProblem({
+		id: "stress-pause-problem",
+		slug: "stress-pause-problem",
+		title: "Stress Pause Problem",
+		roadmapIndex: 10_002,
+		neetcode250: true,
+	})
+	await addRoadmapProblem({
+		problemId: pauseProblem.id,
+		position: 2,
+		topic: pauseProblem.topic,
+	})
+
+	const deletableProblem = await createProblem({
+		id: "stress-deletable-problem",
+		slug: "stress-deletable-problem",
+		title: "Stress Deletable Problem",
+		roadmapIndex: 10_003,
+		neetcode250: true,
+	})
+	await addRoadmapProblem({
+		problemId: deletableProblem.id,
+		position: 3,
+		topic: deletableProblem.topic,
+	})
+
+	const publicGroup = await createGroup({
+		id: "stress-public-group",
+		slug: "stress-public-group",
+		creatorId: admin.id,
+		maxMembers: 50,
+		isStarted: true,
+	})
+	const pauseGroup = await createGroup({
+		id: "stress-pause-group",
+		slug: "stress-pause-group",
+		creatorId: admin.id,
+		maxMembers: 50,
+		isStarted: true,
+	})
+	const privateGroup = await createGroup({
+		id: "stress-private-group",
+		slug: "stress-private-group",
+		type: "PRIVATE",
+		creatorId: admin.id,
+		maxMembers: 50,
+		inviteCode: "stress-invite",
+		inviteExpiresAt: tomorrow,
+		isStarted: true,
+	})
+	const startableGroup = await createGroup({
+		id: "stress-startable-group",
+		slug: "stress-startable-group",
+		creatorId: admin.id,
+		maxMembers: 50,
+		isStarted: false,
+	})
+	const deletableGroup = await createGroup({
+		id: "stress-deletable-group",
+		slug: "stress-deletable-group",
+		creatorId: admin.id,
+		maxMembers: 50,
+		isStarted: false,
+	})
+
+	await Promise.all([
+		addMember(publicGroup.id, admin.id),
+		addMember(publicGroup.id, user.id),
+		addMember(publicGroup.id, removable.id),
+		addMember(pauseGroup.id, pauseUser.id),
+		addMember(privateGroup.id, admin.id),
+		addMember(privateGroup.id, target.id),
+	])
+
+	await Promise.all([
+		createDailyProblem({
+			groupId: publicGroup.id,
+			problemId: problem.id,
+			assignedDate: today,
+		}),
+		createDailyProblem({
+			groupId: pauseGroup.id,
+			problemId: pauseProblem.id,
+			assignedDate: today,
+		}),
+	])
+
+	const joinRequest = await testDb.groupJoinRequest.create({
+		data: {
+			groupId: publicGroup.id,
+			userId: pendingUser.id,
+			status: "PENDING",
+			expiresAt: tomorrow,
+		},
+	})
+	const transferRequest = await testDb.groupJoinRequest.create({
+		data: {
+			groupId: startableGroup.id,
+			userId: transferUser.id,
+			status: "PENDING",
+			expiresAt: tomorrow,
+		},
+	})
+
+	const feedback = await testDb.feedback.create({
+		data: {
+			userId: user.id,
+			groupId: publicGroup.id,
+			category: "BUG",
+			description: "Seed feedback",
+		},
+	})
+
+	await testDb.featureFlag.create({
+		data: {
+			key: "stress-existing-flag",
+			enabled: false,
+			description: "Existing stress flag",
+		},
+	})
+	await testDb.systemConfig.create({
+		data: {
+			key: "stress-existing-config",
+			value: { enabled: true },
+			description: "Existing stress config",
+		},
+	})
+
+	return {
+		admin,
+		pro,
+		user,
+		pauseUser,
+		outsider,
+		target,
+		removable,
+		publicGroupId: publicGroup.id,
+		privateGroupId: privateGroup.id,
+		startableGroupId: startableGroup.id,
+		deletableGroupId: deletableGroup.id,
+		inviteCode: "stress-invite",
+		joinRequestId: joinRequest.id,
+		transferRequestId: transferRequest.id,
+		feedbackId: feedback.id,
+		problemId: problem.id,
+		deletableProblemId: deletableProblem.id,
+	}
+}
+
+const createEndpointScenarios = (ctx: StressContext): StressScenario[] => [
+	{
+		key: { method: "ALL", path: "/api/v3/auth/*" },
+		method: "GET",
+		path: "/api/v3/auth/session",
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/health" },
+		method: "GET",
+		path: "/api/v3/health",
+		allowedStatuses: [200, 503],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/openapi" },
+		method: "GET",
+		path: "/api/v3/openapi",
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/openapi/json" },
+		method: "GET",
+		path: "/api/v3/openapi/json",
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/og/" },
+		method: "GET",
+		path: "/api/v3/og/?title=Stress%20Testing%20PStrack&subtitle=Invariant%20check",
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/magic-link" },
+		method: "GET",
+		path: "/api/v3/magic-link?token=%3C/script%3E&callbackURL=https://evil.example",
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/users/check-username" },
+		method: "POST",
+		path: "/api/v3/users/check-username",
+		body: { username: "stress_candidate" },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/users/validate-leetcode" },
+		method: "POST",
+		path: "/api/v3/users/validate-leetcode",
+		body: { handle: "stressuser" },
+		allowedStatuses: [200, 502],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/users/validate-codeforces" },
+		method: "POST",
+		path: "/api/v3/users/validate-codeforces",
+		body: { handle: "tourist" },
+		allowedStatuses: [200, 502],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/users/count" },
+		method: "GET",
+		path: "/api/v3/users/count",
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/users/me" },
+		method: "GET",
+		path: "/api/v3/users/me",
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "PATCH", path: "/api/v3/users/me/username" },
+		method: "PATCH",
+		path: "/api/v3/users/me/username",
+		userId: ctx.outsider.id,
+		body: { username: "stress_renamed" },
+		allowedStatuses: [200, 409, 429],
+	},
+	{
+		key: { method: "PATCH", path: "/api/v3/users/me/profile" },
+		method: "PATCH",
+		path: "/api/v3/users/me/profile",
+		userId: ctx.user.id,
+		body: { name: "Stress User", bio: "Under pressure", isPublic: true },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "PATCH", path: "/api/v3/users/me/handles" },
+		method: "PATCH",
+		path: "/api/v3/users/me/handles",
+		userId: ctx.user.id,
+		body: { leetcodeHandle: "stressuser", codeforcesHandle: "tourist" },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "PATCH", path: "/api/v3/users/me/notifications" },
+		method: "PATCH",
+		path: "/api/v3/users/me/notifications",
+		userId: ctx.user.id,
+		body: {
+			notifyDailyProblem: true,
+			notifyAchievements: false,
+			notifyGroupActivity: true,
+		},
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/users/me/sessions" },
+		method: "GET",
+		path: "/api/v3/users/me/sessions",
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "DELETE", path: "/api/v3/users/me/sessions/others" },
+		method: "DELETE",
+		path: "/api/v3/users/me/sessions/others",
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "DELETE", path: "/api/v3/users/me/sessions/:id" },
+		method: "DELETE",
+		path: "/api/v3/users/me/sessions/stress-session",
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/users/:username" },
+		method: "GET",
+		path: "/api/v3/users/stress_user",
+		userId: ctx.user.id,
+		allowedStatuses: [200, 404],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/users/:username/heatmap" },
+		method: "GET",
+		path: "/api/v3/users/stress_user/heatmap",
+		allowedStatuses: [200, 404],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/groups/join-by-invite" },
+		method: "POST",
+		path: "/api/v3/groups/join-by-invite",
+		userId: ctx.outsider.id,
+		body: { inviteCode: ctx.inviteCode },
+		allowedStatuses: [200, 403, 409],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/groups/" },
+		method: "GET",
+		path: "/api/v3/groups/",
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/groups/" },
+		method: "POST",
+		path: "/api/v3/groups/",
+		userId: ctx.pro.id,
+		body: {},
+		allowedStatuses: [200, 403],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/groups/:id" },
+		method: "GET",
+		path: `/api/v3/groups/${ctx.publicGroupId}`,
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/groups/:id/join" },
+		method: "POST",
+		path: `/api/v3/groups/${ctx.publicGroupId}/join`,
+		userId: ctx.target.id,
+		allowedStatuses: [200, 403, 409],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/groups/:id/leave" },
+		method: "POST",
+		path: `/api/v3/groups/${ctx.privateGroupId}/leave`,
+		userId: ctx.target.id,
+		allowedStatuses: [200, 400],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/groups/:id/members" },
+		method: "GET",
+		path: `/api/v3/groups/${ctx.publicGroupId}/members`,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/groups/:id/today-activity" },
+		method: "GET",
+		path: `/api/v3/groups/${ctx.publicGroupId}/today-activity`,
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/groups/:id/problems" },
+		method: "GET",
+		path: `/api/v3/groups/${ctx.publicGroupId}/problems?range=7d`,
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/problems/today" },
+		method: "GET",
+		path: "/api/v3/problems/today",
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/problems/roadmap" },
+		method: "GET",
+		path: "/api/v3/problems/roadmap?roadmap=NC250",
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/problems/today/solve" },
+		method: "POST",
+		path: "/api/v3/problems/today/solve",
+		userId: ctx.user.id,
+		allowedStatuses: [200, 409],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/problems/today/pause" },
+		method: "POST",
+		path: "/api/v3/problems/today/pause",
+		userId: ctx.pauseUser.id,
+		allowedStatuses: [200, 409],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/badges/me" },
+		method: "GET",
+		path: "/api/v3/badges/me",
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/feedbacks/prompt" },
+		method: "GET",
+		path: `/api/v3/feedbacks/prompt?groupId=${ctx.publicGroupId}`,
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/feedbacks/" },
+		method: "POST",
+		path: "/api/v3/feedbacks/",
+		userId: ctx.user.id,
+		body: {
+			groupId: ctx.publicGroupId,
+			category: "BUG",
+			description: "Stress feedback",
+		},
+		allowedStatuses: [200, 409],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/feedbacks/general" },
+		method: "POST",
+		path: "/api/v3/feedbacks/general",
+		userId: ctx.user.id,
+		body: { description: "General stress feedback" },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/feedbacks/" },
+		method: "GET",
+		path: "/api/v3/feedbacks/",
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "PATCH", path: "/api/v3/feedbacks/:id/reviewed" },
+		method: "PATCH",
+		path: `/api/v3/feedbacks/${ctx.feedbackId}/reviewed`,
+		userId: ctx.admin.id,
+		body: { reviewed: true },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "PATCH", path: "/api/v3/internal/bot/join-requests/:requestId" },
+		method: "PATCH",
+		path: `/api/v3/internal/bot/join-requests/${ctx.joinRequestId}`,
+		headers: { Authorization: "Bearer stress-bot-secret" },
+		body: { action: "APPROVED" },
+		allowedStatuses: [200, 409],
+	},
+	{
+		key: {
+			method: "POST",
+			path: "/api/v3/internal/bot/join-requests/:requestId/transfer",
+		},
+		method: "POST",
+		path: `/api/v3/internal/bot/join-requests/${ctx.transferRequestId}/transfer`,
+		headers: { Authorization: "Bearer stress-bot-secret" },
+		body: { targetGroupId: ctx.privateGroupId },
+		allowedStatuses: [200, 409],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/internal/bot/groups" },
+		method: "GET",
+		path: "/api/v3/internal/bot/groups",
+		headers: { Authorization: "Bearer stress-bot-secret" },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/internal/bot/join-requests" },
+		method: "GET",
+		path: "/api/v3/internal/bot/join-requests",
+		headers: { Authorization: "Bearer stress-bot-secret" },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/internal/bot" },
+		method: "GET",
+		path: "/api/v3/internal/bot",
+		headers: { Authorization: "Bearer stress-bot-secret" },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/leaderboard/global" },
+		method: "GET",
+		path: "/api/v3/leaderboard/global?period=week",
+		userId: ctx.pro.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/leaderboard/groups/:id" },
+		method: "GET",
+		path: `/api/v3/leaderboard/groups/${ctx.publicGroupId}?period=week`,
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/leaderboard/my-groups" },
+		method: "GET",
+		path: "/api/v3/leaderboard/my-groups",
+		userId: ctx.user.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/stats" },
+		method: "GET",
+		path: "/api/v3/admin/stats",
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/audit" },
+		method: "GET",
+		path: "/api/v3/admin/audit?limit=10",
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/feature-flags" },
+		method: "GET",
+		path: "/api/v3/admin/feature-flags",
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/admin/feature-flags" },
+		method: "POST",
+		path: "/api/v3/admin/feature-flags",
+		userId: ctx.admin.id,
+		body: { key: "stress-created-flag", enabled: true, description: "Stress" },
+		allowedStatuses: [200, 409],
+	},
+	{
+		key: { method: "PATCH", path: "/api/v3/admin/feature-flags/:key" },
+		method: "PATCH",
+		path: "/api/v3/admin/feature-flags/stress-existing-flag",
+		userId: ctx.admin.id,
+		body: { enabled: true },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/system-config" },
+		method: "GET",
+		path: "/api/v3/admin/system-config",
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "PUT", path: "/api/v3/admin/system-config" },
+		method: "PUT",
+		path: "/api/v3/admin/system-config",
+		userId: ctx.admin.id,
+		body: {
+			key: "stress-existing-config",
+			value: { enabled: true, updatedBy: "stress" },
+			description: "Stress config",
+		},
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/emails/templates" },
+		method: "GET",
+		path: "/api/v3/admin/emails/templates",
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/admin/emails/send" },
+		method: "POST",
+		path: "/api/v3/admin/emails/send",
+		userId: ctx.admin.id,
+		body: { template: "daily-problem", toUserId: ctx.user.id, props: {} },
+		allowedStatuses: [200, 400],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/users/" },
+		method: "GET",
+		path: "/api/v3/admin/users/?limit=10",
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/users/:id" },
+		method: "GET",
+		path: `/api/v3/admin/users/${ctx.user.id}`,
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/users/:id/points-history" },
+		method: "GET",
+		path: `/api/v3/admin/users/${ctx.user.id}/points-history?limit=10`,
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "PATCH", path: "/api/v3/admin/users/:id/ban" },
+		method: "PATCH",
+		path: `/api/v3/admin/users/${ctx.target.id}/ban`,
+		userId: ctx.admin.id,
+		body: { banned: true, reason: "Stress ban" },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/admin/users/:id/points" },
+		method: "POST",
+		path: `/api/v3/admin/users/${ctx.target.id}/points`,
+		userId: ctx.admin.id,
+		body: { delta: 1, reason: "Stress adjustment" },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/admin/users/:id/pro" },
+		method: "POST",
+		path: `/api/v3/admin/users/${ctx.target.id}/pro`,
+		userId: ctx.admin.id,
+		body: { grant: true, expiresAt: null, reason: "Stress grant" },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/admin/users/:id/impersonate-audit" },
+		method: "POST",
+		path: `/api/v3/admin/users/${ctx.target.id}/impersonate-audit`,
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: {
+			method: "POST",
+			path: "/api/v3/admin/users/:id/impersonate-end-audit",
+		},
+		method: "POST",
+		path: `/api/v3/admin/users/${ctx.target.id}/impersonate-end-audit`,
+		userId: ctx.admin.id,
+		body: { durationMs: 10 },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/admin/groups/" },
+		method: "POST",
+		path: "/api/v3/admin/groups/",
+		userId: ctx.admin.id,
+		body: { type: "PUBLIC", roadmap: "NC250", maxMembers: 30 },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/groups/" },
+		method: "GET",
+		path: "/api/v3/admin/groups/?limit=10",
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/groups/pending-requests" },
+		method: "GET",
+		path: "/api/v3/admin/groups/pending-requests",
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/groups/:id" },
+		method: "GET",
+		path: `/api/v3/admin/groups/${ctx.publicGroupId}`,
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/groups/:id/members" },
+		method: "GET",
+		path: `/api/v3/admin/groups/${ctx.publicGroupId}/members`,
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "DELETE", path: "/api/v3/admin/groups/:id/members/:userId" },
+		method: "DELETE",
+		path: `/api/v3/admin/groups/${ctx.publicGroupId}/members/${ctx.removable.id}`,
+		userId: ctx.admin.id,
+		allowedStatuses: [200, 404],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/groups/:id/join-requests" },
+		method: "GET",
+		path: `/api/v3/admin/groups/${ctx.publicGroupId}/join-requests`,
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: {
+			method: "PATCH",
+			path: "/api/v3/admin/groups/:id/join-requests/:requestId",
+		},
+		method: "PATCH",
+		path: `/api/v3/admin/groups/${ctx.publicGroupId}/join-requests/${ctx.joinRequestId}`,
+		userId: ctx.admin.id,
+		body: { action: "APPROVED" },
+		allowedStatuses: [200, 404, 409],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/admin/groups/:id/invite" },
+		method: "POST",
+		path: `/api/v3/admin/groups/${ctx.publicGroupId}/invite`,
+		userId: ctx.admin.id,
+		body: { expiresIn: "7d" },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "DELETE", path: "/api/v3/admin/groups/:id/invite" },
+		method: "DELETE",
+		path: `/api/v3/admin/groups/${ctx.publicGroupId}/invite`,
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "PATCH", path: "/api/v3/admin/groups/:id/start" },
+		method: "PATCH",
+		path: `/api/v3/admin/groups/${ctx.startableGroupId}/start`,
+		userId: ctx.admin.id,
+		allowedStatuses: [200, 409],
+	},
+	{
+		key: { method: "PATCH", path: "/api/v3/admin/groups/:id/freeze" },
+		method: "PATCH",
+		path: `/api/v3/admin/groups/${ctx.publicGroupId}/freeze`,
+		userId: ctx.admin.id,
+		body: { frozen: true },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "DELETE", path: "/api/v3/admin/groups/:id" },
+		method: "DELETE",
+		path: `/api/v3/admin/groups/${ctx.deletableGroupId}`,
+		userId: ctx.admin.id,
+		allowedStatuses: [200, 404],
+	},
+	{
+		key: { method: "GET", path: "/api/v3/admin/problems/" },
+		method: "GET",
+		path: "/api/v3/admin/problems/?limit=10",
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/admin/problems/" },
+		method: "POST",
+		path: "/api/v3/admin/problems/",
+		userId: ctx.admin.id,
+		body: (index: number) => ({
+			slug: `stress-created-problem-${index}`,
+			title: `Stress Created Problem ${index}`,
+			difficulty: "EASY",
+			topic: "Stress",
+			leetcodeId: null,
+			neetcode250: false,
+			neetcode150: false,
+			blind75: false,
+		}),
+		allowedStatuses: [200, 409],
+	},
+	{
+		key: { method: "PATCH", path: "/api/v3/admin/problems/:id" },
+		method: "PATCH",
+		path: `/api/v3/admin/problems/${ctx.problemId}`,
+		userId: ctx.admin.id,
+		body: { title: "Stress Two Sum Updated" },
+		allowedStatuses: [200],
+	},
+	{
+		key: { method: "DELETE", path: "/api/v3/admin/problems/:id" },
+		method: "DELETE",
+		path: `/api/v3/admin/problems/${ctx.deletableProblemId}`,
+		userId: ctx.admin.id,
+		allowedStatuses: [200, 404, 409],
+	},
+	{
+		key: { method: "POST", path: "/api/v3/admin/problems/seed" },
+		method: "POST",
+		path: "/api/v3/admin/problems/seed",
+		userId: ctx.admin.id,
+		allowedStatuses: [200],
+	},
+]
+
+const makeRequest = (scenario: StressScenario, index: number) => {
+	const headers = new Headers(scenario.headers ?? {})
+	if (scenario.userId) headers.set("x-test-user-id", scenario.userId)
+
+	let body: BodyInit | undefined
+	const rawBody =
+		typeof scenario.body === "function" ? scenario.body(index) : scenario.body
+	if (rawBody !== undefined) {
+		headers.set("content-type", "application/json")
+		body = JSON.stringify(rawBody)
+	}
+
+	return new Request(`https://stress.test${scenario.path}`, {
+		method: scenario.method,
+		headers,
+		body,
+	})
+}
+
+describe("API stress suite", () => {
+	beforeAll(async () => {
+		fontRegular = await readFile(
+			new URL("../../../public/fonts/geist-400.woff", import.meta.url)
+		)
+		fontBold = await readFile(
+			new URL("../../../public/fonts/geist-600.woff", import.meta.url)
+		)
+	})
+
+	beforeEach(() => {
+		sessions.clear()
+		authMock.handler.mockImplementation(async () => new Response("auth"))
+		authMock.getSession.mockImplementation(async ({ headers }) => {
+			const userId = headers.get("x-test-user-id")
+			const user = userId ? sessions.get(userId) : null
+			if (!user) return null
+
+			return {
+				user,
+				session: {
+					id: `session-${user.id}`,
+					token: `token-${user.id}`,
+					userId: user.id,
+					createdAt: new Date(),
+					updatedAt: new Date(),
+					expiresAt: new Date(Date.now() + 86_400_000),
+				},
+			}
+		})
+		authMock.listSessions.mockResolvedValue([
+			{
+				id: "stress-session",
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				expiresAt: new Date(Date.now() + 86_400_000),
+				ipAddress: "127.0.0.1",
+				userAgent: "stress",
+			},
+		])
+		authMock.revokeOtherSessions.mockResolvedValue({ success: true })
+		authMock.revokeSession.mockResolvedValue({ success: true })
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+				const url = String(input)
+				if (url.endsWith("/fonts/geist-400.woff")) {
+					return new Response(toArrayBuffer(fontRegular))
+				}
+				if (url.endsWith("/fonts/geist-600.woff")) {
+					return new Response(toArrayBuffer(fontBold))
+				}
+				if (url.includes("leetcode.com/graphql")) {
+					const body = init?.body ? JSON.parse(String(init.body)) : {}
+					if (String(body.query ?? "").includes("matchedUser")) {
+						return jsonResponse({ data: { matchedUser: { username: "stressuser" } } })
+					}
+					return jsonResponse({
+						data: {
+							recentAcSubmissionList: [
+								{
+									titleSlug: "stress-two-sum",
+									timestamp: String(Math.floor(Date.now() / 1000)),
+								},
+							],
+						},
+					})
+				}
+				if (url.includes("codeforces.com/api/user.info")) {
+					return jsonResponse({ status: "OK" })
+				}
+				return new Response("not found", { status: 404 })
+			})
+		)
+	})
+
+	it("keeps every endpoint inside its allowed response envelope under representative pressure", async () => {
+		const ctx = await seedStressContext()
+		const scenarios = createEndpointScenarios(ctx)
+		const expectedKeys = STRESS_ENDPOINTS.map(({ method, path }) => ({
+			method,
+			path,
+		}))
+		const actualKeys = scenarios.map((scenario) => scenario.key)
+
+		expect(actualKeys).toEqual(expectedKeys)
+
+		const repetitions = stressRepetitions(2)
+		for (const scenario of scenarios) {
+			const results = await runConcurrent(repetitions, async (index) => {
+				const response = await app.handle(makeRequest(scenario, index))
+				await expectAllowedResponse(response, scenario.allowedStatuses)
+			})
+			expectNoRejectedStressWork(results)
+		}
+
+		await expectCoreStressInvariants()
+	})
+})

--- a/src/server/stress/auth.stress.integration.test.ts
+++ b/src/server/stress/auth.stress.integration.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { auth } from "@/server/lib/auth"
+import {
+	expectNoRejectedStressWork,
+	runConcurrent,
+	stressRepetitions,
+} from "@/test/stress"
+
+describe("Better Auth stress suite", () => {
+	it("handles concurrent unauthenticated session reads consistently", async () => {
+		const repetitions = stressRepetitions(10)
+		const results = await runConcurrent(repetitions, async () => {
+			const response = await auth.handler(
+				new Request("https://pstrack.test/api/v3/auth/get-session")
+			)
+			return {
+				status: response.status,
+				body: await response.json(),
+			}
+		})
+
+		expectNoRejectedStressWork(results)
+		for (const result of results) {
+			if (result.status !== "fulfilled") continue
+			expect(result.value.status).toBe(200)
+			expect(result.value.body).toBeNull()
+		}
+	})
+})

--- a/src/server/stress/manifest.stress.integration.test.ts
+++ b/src/server/stress/manifest.stress.integration.test.ts
@@ -1,0 +1,49 @@
+import { readdir } from "node:fs/promises"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@/server/lib/auth", () => ({
+	auth: {
+		api: { getSession: vi.fn() },
+		handler: vi.fn(() => new Response("auth")),
+	},
+}))
+
+vi.mock("@/server/lib/sentry", () => ({
+	captureServerException: vi.fn(),
+	initServerSentry: vi.fn(),
+	ServerSentry: { flush: vi.fn() },
+}))
+
+import { app } from "@/server/app"
+import { STRESS_BACKGROUND_MODULES, STRESS_ENDPOINTS } from "@/test/stress-manifest"
+
+describe("stress manifest", () => {
+	it("classifies every registered API endpoint", () => {
+		const actual = app.routes.map((route) => ({
+			method: route.method,
+			path: route.path,
+		}))
+
+		const expected = STRESS_ENDPOINTS.map(({ method, path }) => ({ method, path }))
+
+		expect(actual).toEqual(expected)
+		expect(STRESS_ENDPOINTS.every((endpoint) => endpoint.dimensions.length > 0)).toBe(
+			true
+		)
+	})
+
+	it("classifies every Trigger module", async () => {
+		const entries = await readdir(new URL("../trigger", import.meta.url))
+		const actual = entries
+			.filter((entry) => entry.endsWith(".ts"))
+			.filter((entry) => !entry.endsWith(".test.ts"))
+			.sort()
+
+		const expected = STRESS_BACKGROUND_MODULES.map((module) => module.file).sort()
+
+		expect(actual).toEqual(expected)
+		expect(
+			STRESS_BACKGROUND_MODULES.every((module) => module.dimensions.length > 0)
+		).toBe(true)
+	})
+})

--- a/src/server/stress/trigger-modules.stress.integration.test.ts
+++ b/src/server/stress/trigger-modules.stress.integration.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const deliveryMocks = vi.hoisted(() => ({
+	notifyAdmin: vi.fn(async (_event: string, _payload: unknown) => {}),
+	resendBatchSend: vi.fn(
+		async (emails: unknown[], _options?: { idempotencyKey: string }) => ({
+			data: { data: emails.map(() => ({ id: "stress-email" })) },
+			error: null,
+		})
+	),
+}))
+
+vi.mock("@trigger.dev/sdk/v3", () => ({
+	logger: { log: vi.fn() },
+	schedules: {
+		task: vi.fn((config) => config),
+	},
+	task: vi.fn((config) => config),
+}))
+
+vi.mock("@/server/lib/bot", () => ({
+	notifyAdmin: deliveryMocks.notifyAdmin,
+}))
+
+vi.mock("@/server/lib/email", () => ({
+	resend: {
+		batch: {
+			send: deliveryMocks.resendBatchSend,
+		},
+	},
+	sendEmail: vi.fn(async () => ({ id: "stress-email" })),
+}))
+
+vi.mock("@/server/lib/redis", () => ({
+	createRedisKey: (...parts: string[]) => parts.join(":"),
+	redisExpire: vi.fn(async () => {}),
+	redisSAdd: vi.fn(async () => {}),
+	redisSIsMember: vi.fn(async () => false),
+}))
+
+vi.mock("@/server/lib/sentry", () => ({
+	captureServerException: vi.fn(),
+}))
+
+import { ProSource } from "@/generated/prisma/enums"
+import { assignDailyProblemTask } from "@/server/trigger/assign-daily-problem"
+import { expireAdminProGrantsTask } from "@/server/trigger/expire-admin-pro-grants"
+import { expireJoinRequestsTask } from "@/server/trigger/expire-join-requests"
+import { markMissedTask } from "@/server/trigger/mark-missed"
+import { purgeSystemEventsTask } from "@/server/trigger/purge-system-events"
+import { resetMonthlyCountersTask } from "@/server/trigger/reset-monthly-counters"
+import { resetTodayProblemsTask } from "@/server/trigger/reset-today-problems"
+import { sendDailyDigestBatchTask } from "@/server/trigger/send-daily-digest-batch"
+import { sendWeeklyDigestTask } from "@/server/trigger/send-weekly-digest"
+import {
+	addMember,
+	addRoadmapProblem,
+	createDailyProblem,
+	createGroup,
+	createProblem,
+	createUser,
+	testDb,
+} from "@/test/db"
+import {
+	expectCoreStressInvariants,
+	expectNoRejectedStressWork,
+	runConcurrent,
+	stressRepetitions,
+	withStressRetry,
+} from "@/test/stress"
+
+const startOfUtcDay = (date: Date) =>
+	new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+
+const runStressTask = async (
+	taskDefinition: object,
+	payload?: unknown
+): Promise<unknown> => {
+	const run: unknown = Reflect.get(taskDefinition, "run")
+	if (typeof run !== "function")
+		throw new Error("Stress task is missing its run function")
+
+	return Reflect.apply(run, taskDefinition, payload === undefined ? [] : [payload])
+}
+
+const seedTriggerState = async () => {
+	const today = startOfUtcDay(new Date())
+	const yesterday = new Date(today.getTime() - 86_400_000)
+	const tomorrow = new Date(today.getTime() + 86_400_000)
+
+	const admin = await createUser({
+		id: "stress-trigger-admin",
+		email: "stress-trigger-admin@example.com",
+		username: "stress_trigger_admin",
+		role: "admin",
+		isPro: true,
+	})
+	const user = await createUser({
+		id: "stress-trigger-user",
+		email: "stress-trigger-user@example.com",
+		username: "stress_trigger_user",
+		pausesUsedThisMonth: 2,
+		verificationFailuresThisMonth: 3,
+		currentStreak: 4,
+		currentStreakStartedAt: new Date(yesterday.getTime() - 3 * 86_400_000),
+	})
+	const expiredPro = await createUser({
+		id: "stress-expired-pro",
+		email: "stress-expired-pro@example.com",
+		username: "stress_expired_pro",
+		isPro: true,
+		proSource: ProSource.ADMIN_GRANT,
+	})
+	await testDb.user.update({
+		where: { id: expiredPro.id },
+		data: { proExpiresAt: new Date(Date.now() - 60_000) },
+	})
+	const requester = await createUser({
+		id: "stress-trigger-requester",
+		email: "stress-trigger-requester@example.com",
+		username: "stress_trigger_requester",
+	})
+
+	const group = await createGroup({
+		id: "stress-trigger-group",
+		slug: "stress-trigger-group",
+		creatorId: admin.id,
+		maxMembers: 50,
+		isStarted: true,
+	})
+	await addMember(group.id, user.id)
+	await testDb.groupMember.updateMany({
+		where: { groupId: group.id, userId: user.id },
+		data: { joinedAt: new Date(yesterday.getTime() - 86_400_000) },
+	})
+
+	const problem = await createProblem({
+		id: "stress-trigger-problem",
+		slug: "stress-trigger-problem",
+		title: "Stress Trigger Problem",
+		roadmapIndex: 20_001,
+	})
+	await addRoadmapProblem({ problemId: problem.id, position: 1, topic: problem.topic })
+	await createDailyProblem({
+		groupId: group.id,
+		problemId: problem.id,
+		assignedDate: yesterday,
+	})
+
+	await testDb.groupJoinRequest.create({
+		data: {
+			groupId: group.id,
+			userId: requester.id,
+			status: "PENDING",
+			expiresAt: new Date(Date.now() - 60_000),
+		},
+	})
+
+	await testDb.systemEventLog.create({
+		data: {
+			eventType: "GROUP_JOINED",
+			targetType: "GROUP",
+			targetId: group.id,
+			createdAt: new Date(Date.now() - 100 * 86_400_000),
+		},
+	})
+
+	return { today, tomorrow, groupId: group.id }
+}
+
+describe("Trigger module stress suite", () => {
+	beforeEach(() => {
+		deliveryMocks.notifyAdmin.mockClear()
+		deliveryMocks.resendBatchSend.mockClear()
+		Reflect.set(
+			sendDailyDigestBatchTask,
+			"batchTrigger",
+			vi.fn(async () => ({ batchId: "stress-digest-batch" }))
+		)
+	})
+
+	it("keeps scheduled modules idempotent under repeated runs", async () => {
+		const state = await seedTriggerState()
+		const repetitions = stressRepetitions(2)
+		const tasks = [
+			() => runStressTask(assignDailyProblemTask, { timestamp: state.today }),
+			() => runStressTask(markMissedTask, { timestamp: state.tomorrow }),
+			() => runStressTask(expireJoinRequestsTask),
+			() => runStressTask(resetMonthlyCountersTask),
+			() => runStressTask(expireAdminProGrantsTask),
+			() => runStressTask(purgeSystemEventsTask),
+			() => runStressTask(sendWeeklyDigestTask),
+		]
+		const work = tasks.flatMap((task) => Array.from({ length: repetitions }, () => task))
+
+		const results = await runConcurrent(work.length, async (index) =>
+			withStressRetry(() => work[index]())
+		)
+
+		expectNoRejectedStressWork(results)
+		await expectCoreStressInvariants()
+		const weeklyNotifications = deliveryMocks.notifyAdmin.mock.calls.filter(
+			([event]) => event === "digest.weekly"
+		)
+		expect(weeklyNotifications).toHaveLength(repetitions)
+	}, 20_000)
+
+	it("keeps destructive and delivery modules bounded under repeated runs", async () => {
+		await seedTriggerState()
+		const repetitions = stressRepetitions(2)
+		const digestPayload = {
+			dateKey: "2026-06-16",
+			batchIndex: 0,
+			recipients: [
+				{
+					email: "stress-trigger-user@example.com",
+					name: "Stress Trigger User",
+					groupSlug: "stress-trigger-group",
+					problemSlug: "stress-trigger-problem",
+					problemTitle: "Stress Trigger Problem",
+					difficulty: "EASY",
+					topic: "Stress",
+				},
+			],
+		}
+		const tasks = [
+			() => runStressTask(resetTodayProblemsTask),
+			() => runStressTask(sendDailyDigestBatchTask, digestPayload),
+		]
+		const work = tasks.flatMap((task) => Array.from({ length: repetitions }, () => task))
+
+		const results = await runConcurrent(work.length, async (index) =>
+			withStressRetry(() => work[index]())
+		)
+
+		expectNoRejectedStressWork(results)
+		await expectCoreStressInvariants()
+		expect(deliveryMocks.resendBatchSend).toHaveBeenCalledTimes(repetitions)
+		for (const [, options] of deliveryMocks.resendBatchSend.mock.calls) {
+			expect(options).toEqual({
+				idempotencyKey: "daily-digest:2026-06-16:0",
+			})
+		}
+	}, 20_000)
+})

--- a/src/test/db.ts
+++ b/src/test/db.ts
@@ -9,7 +9,7 @@
 import { PrismaPg } from "@prisma/adapter-pg"
 
 import { PrismaClient } from "@/generated/prisma/client"
-import type { Difficulty, GroupType } from "@/generated/prisma/enums"
+import type { Difficulty, GroupType, ProSource } from "@/generated/prisma/enums"
 
 const TEST_DATABASE_URL =
 	process.env.TEST_DATABASE_URL ??
@@ -69,10 +69,16 @@ export const createUser = async (
 		email: string
 		username: string
 		leetcodeHandle: string
+		codeforcesHandle: string | null
+		isPro: boolean
+		proSource: ProSource | null
+		role: string | null
 		currentStreak: number
 		longestStreak: number
 		totalPoints: number
 		currentStreakStartedAt: Date | null
+		pausesUsedThisMonth: number
+		verificationFailuresThisMonth: number
 	}> = {}
 ) => {
 	const id = overrides.id ?? uid()
@@ -84,10 +90,16 @@ export const createUser = async (
 			emailVerified: true,
 			username: overrides.username ?? `user_${id}`,
 			leetcodeHandle: overrides.leetcodeHandle ?? null,
+			codeforcesHandle: overrides.codeforcesHandle ?? null,
+			isPro: overrides.isPro ?? false,
+			proSource: overrides.proSource ?? null,
+			role: overrides.role ?? null,
 			currentStreak: overrides.currentStreak ?? 0,
 			longestStreak: overrides.longestStreak ?? 0,
 			totalPoints: overrides.totalPoints ?? 0,
 			currentStreakStartedAt: overrides.currentStreakStartedAt ?? null,
+			pausesUsedThisMonth: overrides.pausesUsedThisMonth ?? 0,
+			verificationFailuresThisMonth: overrides.verificationFailuresThisMonth ?? 0,
 		},
 	})
 }
@@ -121,8 +133,12 @@ export const createGroup = async (
 		type: GroupType
 		roadmap: string
 		creatorId: string
+		maxMembers: number
+		inviteCode: string | null
+		inviteExpiresAt: Date | null
 		isActive: boolean
 		isStarted: boolean
+		frozen: boolean
 	}> = {}
 ) => {
 	const id = overrides.id ?? uid()
@@ -138,8 +154,12 @@ export const createGroup = async (
 			type: (overrides.type as GroupType) ?? "PUBLIC",
 			roadmap,
 			creatorId: overrides.creatorId ?? uid(),
+			maxMembers: overrides.maxMembers ?? 30,
+			inviteCode: overrides.inviteCode ?? null,
+			inviteExpiresAt: overrides.inviteExpiresAt ?? null,
 			isActive: overrides.isActive ?? true,
 			isStarted: overrides.isStarted ?? true,
+			frozen: overrides.frozen ?? false,
 		},
 	})
 }
@@ -186,5 +206,27 @@ export const createDailyProblem = async ({
 }) => {
 	return testDb.dailyProblem.create({
 		data: { groupId, problemId, assignedDate },
+	})
+}
+
+export const addRoadmapProblem = async ({
+	roadmap = "NC250",
+	problemId,
+	position,
+	topic,
+}: {
+	roadmap?: string
+	problemId: string
+	position: number
+	topic?: string | null
+}) => {
+	const catalog = await createRoadmapCatalog({ key: roadmap })
+	return testDb.roadmapProblem.create({
+		data: {
+			roadmapId: catalog.id,
+			problemId,
+			position,
+			topic: topic ?? null,
+		},
 	})
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -8,7 +8,18 @@
 
 import { beforeEach } from "vitest"
 
-import { resetDb } from "./db"
+const TEST_DATABASE_URL =
+	process.env.TEST_DATABASE_URL ??
+	"postgresql://pstrack:pstrack@127.0.0.1:5433/pstrack?schema=public"
+
+process.env.DATABASE_URL = TEST_DATABASE_URL
+process.env.DIRECT_URL = TEST_DATABASE_URL
+process.env.NODE_ENV = "test"
+process.env.SKIP_ENV_VALIDATION = "1"
+process.env.BETTER_AUTH_URL ??= "https://pstrack.test"
+process.env.EMAIL_FROM ??= "PStrack <test@pstrack.test>"
+
+const { resetDb } = await import("./db")
 
 beforeEach(async () => {
 	await resetDb()

--- a/src/test/stress-manifest.ts
+++ b/src/test/stress-manifest.ts
@@ -1,0 +1,546 @@
+export type StressDimension =
+	| "auth"
+	| "authorization"
+	| "concurrency"
+	| "fuzz"
+	| "idempotency"
+	| "invariant"
+	| "load"
+	| "read"
+	| "side-effect"
+
+export type StressEndpoint = {
+	method: string
+	path: string
+	module: string
+	dimensions: StressDimension[]
+}
+
+export type StressBackgroundModule = {
+	file: string
+	module: string
+	dimensions: StressDimension[]
+}
+
+export const STRESS_ENDPOINTS: StressEndpoint[] = [
+	{ method: "ALL", path: "/api/v3/auth/*", module: "auth", dimensions: ["auth"] },
+	{
+		method: "GET",
+		path: "/api/v3/health",
+		module: "health",
+		dimensions: ["read", "load"],
+	},
+	{ method: "GET", path: "/api/v3/openapi", module: "docs", dimensions: ["read"] },
+	{ method: "GET", path: "/api/v3/openapi/json", module: "docs", dimensions: ["read"] },
+	{ method: "GET", path: "/api/v3/og/", module: "og", dimensions: ["read", "fuzz"] },
+	{
+		method: "GET",
+		path: "/api/v3/magic-link",
+		module: "auth",
+		dimensions: ["auth", "fuzz"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/users/check-username",
+		module: "users",
+		dimensions: ["fuzz", "load"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/users/validate-leetcode",
+		module: "users",
+		dimensions: ["fuzz", "load"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/users/validate-codeforces",
+		module: "users",
+		dimensions: ["fuzz", "load"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/users/count",
+		module: "users",
+		dimensions: ["read", "load"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/users/me",
+		module: "users",
+		dimensions: ["auth", "read"],
+	},
+	{
+		method: "PATCH",
+		path: "/api/v3/users/me/username",
+		module: "users",
+		dimensions: ["auth", "fuzz", "side-effect"],
+	},
+	{
+		method: "PATCH",
+		path: "/api/v3/users/me/profile",
+		module: "users",
+		dimensions: ["auth", "fuzz", "side-effect"],
+	},
+	{
+		method: "PATCH",
+		path: "/api/v3/users/me/handles",
+		module: "users",
+		dimensions: ["auth", "fuzz", "side-effect"],
+	},
+	{
+		method: "PATCH",
+		path: "/api/v3/users/me/notifications",
+		module: "users",
+		dimensions: ["auth", "side-effect"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/users/me/sessions",
+		module: "users",
+		dimensions: ["auth", "read"],
+	},
+	{
+		method: "DELETE",
+		path: "/api/v3/users/me/sessions/others",
+		module: "users",
+		dimensions: ["auth", "side-effect"],
+	},
+	{
+		method: "DELETE",
+		path: "/api/v3/users/me/sessions/:id",
+		module: "users",
+		dimensions: ["auth", "side-effect"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/users/:username",
+		module: "users",
+		dimensions: ["read", "fuzz"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/users/:username/heatmap",
+		module: "users",
+		dimensions: ["read", "fuzz"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/groups/join-by-invite",
+		module: "groups",
+		dimensions: ["auth", "concurrency", "invariant"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/groups/",
+		module: "groups",
+		dimensions: ["read", "load"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/groups/",
+		module: "groups",
+		dimensions: ["auth", "side-effect", "invariant"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/groups/:id",
+		module: "groups",
+		dimensions: ["read", "authorization"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/groups/:id/join",
+		module: "groups",
+		dimensions: ["auth", "concurrency", "invariant"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/groups/:id/leave",
+		module: "groups",
+		dimensions: ["auth", "idempotency", "invariant"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/groups/:id/members",
+		module: "groups",
+		dimensions: ["read", "load"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/groups/:id/today-activity",
+		module: "groups",
+		dimensions: ["auth", "authorization", "read"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/groups/:id/problems",
+		module: "groups",
+		dimensions: ["authorization", "read", "load"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/problems/today",
+		module: "problems",
+		dimensions: ["auth", "idempotency", "invariant"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/problems/roadmap",
+		module: "problems",
+		dimensions: ["read", "fuzz", "load"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/problems/today/solve",
+		module: "problems",
+		dimensions: ["auth", "concurrency", "idempotency", "invariant"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/problems/today/pause",
+		module: "problems",
+		dimensions: ["auth", "concurrency", "idempotency", "invariant"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/badges/me",
+		module: "badges",
+		dimensions: ["auth", "read", "invariant"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/feedbacks/prompt",
+		module: "feedback",
+		dimensions: ["auth", "read"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/feedbacks/",
+		module: "feedback",
+		dimensions: ["auth", "idempotency", "invariant"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/feedbacks/general",
+		module: "feedback",
+		dimensions: ["auth", "side-effect"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/feedbacks/",
+		module: "feedback",
+		dimensions: ["authorization", "read"],
+	},
+	{
+		method: "PATCH",
+		path: "/api/v3/feedbacks/:id/reviewed",
+		module: "feedback",
+		dimensions: ["authorization", "side-effect"],
+	},
+	{
+		method: "PATCH",
+		path: "/api/v3/internal/bot/join-requests/:requestId",
+		module: "internal",
+		dimensions: ["auth", "side-effect", "invariant"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/internal/bot/join-requests/:requestId/transfer",
+		module: "internal",
+		dimensions: ["auth", "side-effect", "invariant"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/internal/bot/groups",
+		module: "internal",
+		dimensions: ["auth", "read"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/internal/bot/join-requests",
+		module: "internal",
+		dimensions: ["auth", "read"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/internal/bot",
+		module: "internal",
+		dimensions: ["auth", "read"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/leaderboard/global",
+		module: "leaderboard",
+		dimensions: ["auth", "authorization", "read", "load"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/leaderboard/groups/:id",
+		module: "leaderboard",
+		dimensions: ["read", "load"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/leaderboard/my-groups",
+		module: "leaderboard",
+		dimensions: ["auth", "read"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/stats",
+		module: "admin",
+		dimensions: ["authorization", "read"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/audit",
+		module: "admin",
+		dimensions: ["authorization", "read", "fuzz"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/feature-flags",
+		module: "admin",
+		dimensions: ["authorization", "read"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/admin/feature-flags",
+		module: "admin",
+		dimensions: ["authorization", "side-effect", "idempotency"],
+	},
+	{
+		method: "PATCH",
+		path: "/api/v3/admin/feature-flags/:key",
+		module: "admin",
+		dimensions: ["authorization", "side-effect"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/system-config",
+		module: "admin",
+		dimensions: ["authorization", "read"],
+	},
+	{
+		method: "PUT",
+		path: "/api/v3/admin/system-config",
+		module: "admin",
+		dimensions: ["authorization", "side-effect", "idempotency"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/emails/templates",
+		module: "admin",
+		dimensions: ["authorization", "read"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/admin/emails/send",
+		module: "admin",
+		dimensions: ["authorization", "side-effect"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/users/",
+		module: "admin-users",
+		dimensions: ["authorization", "read", "fuzz"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/users/:id",
+		module: "admin-users",
+		dimensions: ["authorization", "read"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/users/:id/points-history",
+		module: "admin-users",
+		dimensions: ["authorization", "read"],
+	},
+	{
+		method: "PATCH",
+		path: "/api/v3/admin/users/:id/ban",
+		module: "admin-users",
+		dimensions: ["authorization", "side-effect"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/admin/users/:id/points",
+		module: "admin-users",
+		dimensions: ["authorization", "side-effect", "invariant"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/admin/users/:id/pro",
+		module: "admin-users",
+		dimensions: ["authorization", "side-effect"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/admin/users/:id/impersonate-audit",
+		module: "admin-users",
+		dimensions: ["authorization", "side-effect"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/admin/users/:id/impersonate-end-audit",
+		module: "admin-users",
+		dimensions: ["authorization", "side-effect"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/admin/groups/",
+		module: "admin-groups",
+		dimensions: ["authorization", "side-effect", "invariant"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/groups/",
+		module: "admin-groups",
+		dimensions: ["authorization", "read", "fuzz"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/groups/pending-requests",
+		module: "admin-groups",
+		dimensions: ["authorization", "read"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/groups/:id",
+		module: "admin-groups",
+		dimensions: ["authorization", "read"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/groups/:id/members",
+		module: "admin-groups",
+		dimensions: ["authorization", "read"],
+	},
+	{
+		method: "DELETE",
+		path: "/api/v3/admin/groups/:id/members/:userId",
+		module: "admin-groups",
+		dimensions: ["authorization", "side-effect", "invariant"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/groups/:id/join-requests",
+		module: "admin-groups",
+		dimensions: ["authorization", "read"],
+	},
+	{
+		method: "PATCH",
+		path: "/api/v3/admin/groups/:id/join-requests/:requestId",
+		module: "admin-groups",
+		dimensions: ["authorization", "side-effect", "invariant"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/admin/groups/:id/invite",
+		module: "admin-groups",
+		dimensions: ["authorization", "side-effect"],
+	},
+	{
+		method: "DELETE",
+		path: "/api/v3/admin/groups/:id/invite",
+		module: "admin-groups",
+		dimensions: ["authorization", "side-effect"],
+	},
+	{
+		method: "PATCH",
+		path: "/api/v3/admin/groups/:id/start",
+		module: "admin-groups",
+		dimensions: ["authorization", "side-effect", "idempotency"],
+	},
+	{
+		method: "PATCH",
+		path: "/api/v3/admin/groups/:id/freeze",
+		module: "admin-groups",
+		dimensions: ["authorization", "side-effect"],
+	},
+	{
+		method: "DELETE",
+		path: "/api/v3/admin/groups/:id",
+		module: "admin-groups",
+		dimensions: ["authorization", "side-effect", "invariant"],
+	},
+	{
+		method: "GET",
+		path: "/api/v3/admin/problems/",
+		module: "admin-problems",
+		dimensions: ["authorization", "read", "fuzz"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/admin/problems/",
+		module: "admin-problems",
+		dimensions: ["authorization", "side-effect", "idempotency"],
+	},
+	{
+		method: "PATCH",
+		path: "/api/v3/admin/problems/:id",
+		module: "admin-problems",
+		dimensions: ["authorization", "side-effect"],
+	},
+	{
+		method: "DELETE",
+		path: "/api/v3/admin/problems/:id",
+		module: "admin-problems",
+		dimensions: ["authorization", "side-effect", "invariant"],
+	},
+	{
+		method: "POST",
+		path: "/api/v3/admin/problems/seed",
+		module: "admin-problems",
+		dimensions: ["authorization", "side-effect", "idempotency"],
+	},
+]
+
+export const STRESS_BACKGROUND_MODULES: StressBackgroundModule[] = [
+	{
+		file: "assign-daily-problem.ts",
+		module: "trigger",
+		dimensions: ["idempotency", "invariant", "side-effect"],
+	},
+	{
+		file: "expire-admin-pro-grants.ts",
+		module: "trigger",
+		dimensions: ["idempotency", "side-effect"],
+	},
+	{
+		file: "expire-join-requests.ts",
+		module: "trigger",
+		dimensions: ["idempotency", "side-effect"],
+	},
+	{
+		file: "mark-missed.ts",
+		module: "trigger",
+		dimensions: ["idempotency", "invariant", "side-effect"],
+	},
+	{
+		file: "purge-system-events.ts",
+		module: "trigger",
+		dimensions: ["idempotency", "side-effect"],
+	},
+	{
+		file: "reset-monthly-counters.ts",
+		module: "trigger",
+		dimensions: ["idempotency", "side-effect"],
+	},
+	{
+		file: "reset-today-problems.ts",
+		module: "trigger",
+		dimensions: ["idempotency", "side-effect"],
+	},
+	{
+		file: "send-daily-digest-batch.ts",
+		module: "trigger",
+		dimensions: ["idempotency", "side-effect"],
+	},
+	{
+		file: "send-weekly-digest.ts",
+		module: "trigger",
+		dimensions: ["read", "side-effect"],
+	},
+]

--- a/src/test/stress.ts
+++ b/src/test/stress.ts
@@ -1,0 +1,219 @@
+import { expect } from "vitest"
+
+import { testDb } from "@/test/db"
+
+type DuplicateRow = {
+	key: string
+	count: bigint
+}
+
+type OverCapacityGroupRow = {
+	id: string
+	slug: string
+	maxMembers: number
+	activeMembers: bigint
+}
+
+type FirstSolverMismatchRow = {
+	id: string
+	firstSolverId: string | null
+}
+
+export const stressRepetitions = (fallback: number) => {
+	const raw = process.env.PSTRACK_STRESS_REPETITIONS
+	if (!raw) return fallback
+
+	const parsed = Number(raw)
+	if (!Number.isInteger(parsed) || parsed < 1) return fallback
+	return parsed
+}
+
+export const runConcurrent = async <T>(
+	count: number,
+	fn: (index: number) => Promise<T>
+) => {
+	return Promise.allSettled(Array.from({ length: count }, (_, index) => fn(index)))
+}
+
+const isTransientDbContention = (error: unknown) => {
+	const message = error instanceof Error ? error.message : String(error)
+	return (
+		message.includes("deadlock detected") ||
+		message.includes("could not serialize access") ||
+		message.includes("40P01") ||
+		message.includes("40001")
+	)
+}
+
+export const withStressRetry = async <T>(
+	fn: () => Promise<T>,
+	attempts = 3
+): Promise<T> => {
+	let lastError: unknown
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		try {
+			return await fn()
+		} catch (error) {
+			lastError = error
+			if (!isTransientDbContention(error) || attempt === attempts) break
+			await new Promise((resolve) => setTimeout(resolve, attempt * 25))
+		}
+	}
+	throw lastError
+}
+
+export const expectNoRejectedStressWork = <T>(results: PromiseSettledResult<T>[]) => {
+	const rejected = results.filter((result) => result.status === "rejected")
+	expect(rejected).toEqual([])
+}
+
+export const expectAllowedResponse = async (
+	response: Response,
+	allowedStatuses: number[]
+) => {
+	const body = await response.text()
+	expect(
+		allowedStatuses,
+		`${response.url} returned ${response.status}: ${body}`
+	).toContain(response.status)
+	expect(response.status, `${response.url} returned 5xx: ${body}`).toBeLessThan(500)
+}
+
+const addDuplicateViolation = (
+	violations: string[],
+	label: string,
+	rows: DuplicateRow[]
+) => {
+	for (const row of rows) {
+		violations.push(`${label} duplicate ${row.key} count=${row.count.toString()}`)
+	}
+}
+
+export const expectCoreStressInvariants = async () => {
+	const violations: string[] = []
+
+	const [
+		duplicateMembers,
+		duplicateJoinRequests,
+		duplicateDailyProblems,
+		duplicateSolves,
+		duplicatePointReasons,
+		duplicateBadges,
+		duplicateFirstSolves,
+		overCapacityGroups,
+		firstSolverMismatches,
+		users,
+		ledgerRows,
+	] = await Promise.all([
+		testDb.$queryRaw<DuplicateRow[]>`
+			SELECT "groupId" || ':' || "userId" AS key, COUNT(*) AS count
+			FROM "GroupMember"
+			GROUP BY "groupId", "userId"
+			HAVING COUNT(*) > 1
+		`,
+		testDb.$queryRaw<DuplicateRow[]>`
+			SELECT "groupId" || ':' || "userId" AS key, COUNT(*) AS count
+			FROM "GroupJoinRequest"
+			GROUP BY "groupId", "userId"
+			HAVING COUNT(*) > 1
+		`,
+		testDb.$queryRaw<DuplicateRow[]>`
+			SELECT "groupId" || ':' || "assignedDate" AS key, COUNT(*) AS count
+			FROM "DailyProblem"
+			GROUP BY "groupId", "assignedDate"
+			HAVING COUNT(*) > 1
+		`,
+		testDb.$queryRaw<DuplicateRow[]>`
+			SELECT "userId" || ':' || "dailyProblemId" AS key, COUNT(*) AS count
+			FROM "UserSolve"
+			GROUP BY "userId", "dailyProblemId"
+			HAVING COUNT(*) > 1
+		`,
+		testDb.$queryRaw<DuplicateRow[]>`
+			SELECT "userSolveId" || ':' || reason AS key, COUNT(*) AS count
+			FROM "PointsHistory"
+			WHERE "userSolveId" IS NOT NULL
+			GROUP BY "userSolveId", reason
+			HAVING COUNT(*) > 1
+		`,
+		testDb.$queryRaw<DuplicateRow[]>`
+			SELECT "userId" || ':' || type AS key, COUNT(*) AS count
+			FROM "user_badge"
+			GROUP BY "userId", type
+			HAVING COUNT(*) > 1
+		`,
+		testDb.$queryRaw<DuplicateRow[]>`
+			SELECT "dailyProblemId" AS key, COUNT(*) AS count
+			FROM "UserSolve"
+			WHERE "isFirstInGroup" = true
+			GROUP BY "dailyProblemId"
+			HAVING COUNT(*) > 1
+		`,
+		testDb.$queryRaw<OverCapacityGroupRow[]>`
+			SELECT g.id, g.slug, g."maxMembers", COUNT(m.id) AS "activeMembers"
+			FROM "Group" g
+			LEFT JOIN "GroupMember" m
+				ON m."groupId" = g.id AND m.status = 'ACTIVE'
+			GROUP BY g.id
+			HAVING COUNT(m.id) > g."maxMembers"
+		`,
+		testDb.$queryRaw<FirstSolverMismatchRow[]>`
+			SELECT dp.id, dp."firstSolverId"
+			FROM "DailyProblem" dp
+			WHERE dp."firstSolverId" IS NOT NULL
+				AND NOT EXISTS (
+					SELECT 1
+					FROM "UserSolve" us
+					WHERE us."dailyProblemId" = dp.id
+						AND us."userId" = dp."firstSolverId"
+						AND us."isFirstInGroup" = true
+						AND us.status = 'SOLVED'
+				)
+		`,
+		testDb.user.findMany({
+			select: { id: true, totalPoints: true },
+			orderBy: { id: "asc" },
+		}),
+		testDb.pointsHistory.findMany({
+			select: { id: true, userId: true, delta: true, createdAt: true },
+			orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+		}),
+	])
+
+	addDuplicateViolation(violations, "GroupMember", duplicateMembers)
+	addDuplicateViolation(violations, "GroupJoinRequest", duplicateJoinRequests)
+	addDuplicateViolation(violations, "DailyProblem", duplicateDailyProblems)
+	addDuplicateViolation(violations, "UserSolve", duplicateSolves)
+	addDuplicateViolation(violations, "PointsHistory", duplicatePointReasons)
+	addDuplicateViolation(violations, "UserBadge", duplicateBadges)
+	addDuplicateViolation(violations, "first solve", duplicateFirstSolves)
+
+	for (const row of overCapacityGroups) {
+		violations.push(
+			`Group ${row.slug} over capacity ${row.activeMembers.toString()}/${row.maxMembers}`
+		)
+	}
+
+	for (const row of firstSolverMismatches) {
+		violations.push(
+			`DailyProblem ${row.id} firstSolverId=${row.firstSolverId} has no matching solved first solve`
+		)
+	}
+
+	const expectedTotals = new Map<string, number>()
+	for (const row of ledgerRows) {
+		const previous = expectedTotals.get(row.userId) ?? 0
+		expectedTotals.set(row.userId, Math.max(0, previous + row.delta))
+	}
+
+	for (const user of users) {
+		const expected = expectedTotals.get(user.id) ?? 0
+		if (user.totalPoints !== expected) {
+			violations.push(
+				`User ${user.id} totalPoints=${user.totalPoints} expected=${expected}`
+			)
+		}
+	}
+
+	expect(violations).toEqual([])
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,9 @@ import { defineConfig } from "vitest/config"
 export default defineConfig({
 	plugins: [viteTsConfigPaths({ projects: ["./tsconfig.json"] })],
 	test: {
+		// Integration tests share one database and reset it between cases. Vitest
+		// project configs do not support a project-local fileParallelism setting.
+		fileParallelism: false,
 		projects: [
 			{
 				// Unit tests — all existing mock-based *.test.ts files.


### PR DESCRIPTION
## Summary

- add manifest-guarded stress coverage for every registered API route and Trigger module
- exercise the real Better Auth session boundary under concurrency
- assert delivery idempotency keys and bounded digest notifications
- harden points, roadmap, and admin DAO operations exposed by concurrent execution
- add deterministic integration-test database setup and stress helpers

## Verification

- `bun run typecheck`
- `bun run check`
- `bun run test:stress` (6 tests)
- `bun run test` (84 tests)

## Notes

Integration files run serially because they share and reset one database; Vitest does not support project-local `fileParallelism`. Unit tests remain isolated as a separate project.

The unrelated Polar signup-isolation change was intentionally excluded and will be handled separately.