### PR TITLE
fix(env): fail fast on missing production config (#281)

### DIFF
--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest"
+
+// Importing "@/env" builds the singleton `env` at module load, which validates
+// the ambient process.env. Set the escape hatch first and load the module
+// dynamically so this suite is import-safe on a machine without a .env — the
+// same way CI runs (SKIP_ENV_VALIDATION=1). The functions under test take
+// explicit inputs, so this ambient skip never leaks into the assertions below.
+process.env.SKIP_ENV_VALIDATION = "1"
+const { buildEnv, resolveSkipValidation } = await import("@/env")
+
+// Obviously-fake values — never real credentials. Covers every required server
+// var so validation only fails on the field a given test intentionally omits.
+const validServerEnv = {
+	NODE_ENV: "production",
+	DATABASE_URL: "postgresql://user:pass@localhost:5432/db",
+	DIRECT_URL: "postgresql://user:pass@localhost:5432/db",
+	BETTER_AUTH_SECRET: "x".repeat(32),
+	BETTER_AUTH_API_KEY: "test-api-key",
+	GOOGLE_CLIENT_ID: "test-google-id",
+	GOOGLE_CLIENT_SECRET: "test-google-secret",
+	GITHUB_CLIENT_ID: "test-github-id",
+	GITHUB_CLIENT_SECRET: "test-github-secret",
+	RESEND_API_KEY: "test-resend-key",
+	POLAR_ACCESS_TOKEN: "test-polar-token",
+	POLAR_PRODUCT_ID: "test-product-id",
+	POLAR_SUCCESS_URL: "https://pstrack.test/success",
+}
+
+describe("resolveSkipValidation", () => {
+	it("never skips validation in a production server, even if SKIP_ENV_VALIDATION is set", () => {
+		// This is the core of #281: a production server must fail fast on missing
+		// required config, so the escape hatch is ignored there.
+		expect(
+			resolveSkipValidation({ isServer: true, nodeEnv: "production", skipFlag: "1" })
+		).toBe(false)
+		expect(
+			resolveSkipValidation({
+				isServer: true,
+				nodeEnv: "production",
+				skipFlag: undefined,
+			})
+		).toBe(false)
+	})
+
+	it("honors the escape hatch off the production server (build, tests, dev)", () => {
+		expect(
+			resolveSkipValidation({ isServer: true, nodeEnv: "test", skipFlag: "1" })
+		).toBe(true)
+		expect(
+			resolveSkipValidation({ isServer: true, nodeEnv: "development", skipFlag: "1" })
+		).toBe(true)
+		// Client bundle (isServer=false) may skip regardless of node env.
+		expect(
+			resolveSkipValidation({ isServer: false, nodeEnv: "production", skipFlag: "1" })
+		).toBe(true)
+	})
+
+	it("validates by default when the escape hatch is unset", () => {
+		expect(
+			resolveSkipValidation({
+				isServer: true,
+				nodeEnv: "development",
+				skipFlag: undefined,
+			})
+		).toBe(false)
+		expect(
+			resolveSkipValidation({
+				isServer: false,
+				nodeEnv: "production",
+				skipFlag: undefined,
+			})
+		).toBe(false)
+	})
+})
+
+describe("buildEnv fail-fast", () => {
+	it("throws when a required server var is missing and validation is not skipped", () => {
+		const spy = vi.spyOn(console, "error").mockImplementation(() => {})
+		expect(() =>
+			buildEnv({
+				isServer: true,
+				skipValidation: false,
+				runtimeEnv: { ...validServerEnv, POLAR_PRODUCT_ID: undefined },
+			})
+		).toThrow()
+		spy.mockRestore()
+	})
+
+	it("boots when every required server var is present", () => {
+		const env = buildEnv({
+			isServer: true,
+			skipValidation: false,
+			runtimeEnv: validServerEnv,
+		})
+		expect(env.POLAR_PRODUCT_ID).toBe("test-product-id")
+		expect(env.POLAR_SUCCESS_URL).toBe("https://pstrack.test/success")
+	})
+
+	it("tolerates a missing required var only when validation is skipped", () => {
+		expect(() =>
+			buildEnv({
+				isServer: true,
+				skipValidation: true,
+				runtimeEnv: { ...validServerEnv, POLAR_PRODUCT_ID: undefined },
+			})
+		).not.toThrow()
+	})
+
+	it("does not surface provided secret values in the validation failure output", () => {
+		const secret = "polar_secret_value_that_must_not_leak"
+		const logged: string[] = []
+		const spy = vi.spyOn(console, "error").mockImplementation((...args) => {
+			logged.push(
+				args.map((a) => (typeof a === "string" ? a : JSON.stringify(a))).join(" ")
+			)
+		})
+		expect(() =>
+			buildEnv({
+				isServer: true,
+				skipValidation: false,
+				// A valid secret is supplied; a *different* required var is omitted so
+				// validation fails. The failure output must reference field names only.
+				runtimeEnv: {
+					...validServerEnv,
+					POLAR_ACCESS_TOKEN: secret,
+					POLAR_PRODUCT_ID: undefined,
+				},
+			})
+		).toThrow()
+		spy.mockRestore()
+		expect(logged.join("\n")).not.toContain(secret)
+	})
+})

--- a/src/env.ts
+++ b/src/env.ts
@@ -7,64 +7,119 @@ if (typeof window === "undefined") {
 	config()
 }
 
-export const env = createEnv({
-	server: {
-		// node environment
-		NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+const server = {
+	// node environment
+	NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
 
-		// database
-		DATABASE_URL: z.string().min(1),
-		DIRECT_URL: z.string().min(1),
+	// database
+	DATABASE_URL: z.string().min(1),
+	DIRECT_URL: z.string().min(1),
 
-		// redis
-		UPSTASH_REDIS_REST_URL: z.string().min(1).optional(),
-		UPSTASH_REDIS_REST_TOKEN: z.string().min(1).optional(),
-		REDIS_URL: z.url().optional(),
+	// redis
+	UPSTASH_REDIS_REST_URL: z.string().min(1).optional(),
+	UPSTASH_REDIS_REST_TOKEN: z.string().min(1).optional(),
+	REDIS_URL: z.url().optional(),
 
-		// error tracking
-		SENTRY_DSN: z.url().optional(),
-		SENTRY_ENVIRONMENT: z.string().min(1).optional(),
-		SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
+	// error tracking
+	SENTRY_DSN: z.url().optional(),
+	SENTRY_ENVIRONMENT: z.string().min(1).optional(),
+	SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
 
-		// auth
-		BETTER_AUTH_SECRET: z.string().min(32),
-		BETTER_AUTH_URL: z.url().default("https://pstrack.localhost"),
-		BETTER_AUTH_API_KEY: z.string().min(1),
-		GOOGLE_CLIENT_ID: z.string().min(1),
-		GOOGLE_CLIENT_SECRET: z.string().min(1),
-		GITHUB_CLIENT_ID: z.string().min(1),
-		GITHUB_CLIENT_SECRET: z.string().min(1),
+	// auth
+	BETTER_AUTH_SECRET: z.string().min(32),
+	BETTER_AUTH_URL: z.url().default("https://pstrack.localhost"),
+	BETTER_AUTH_API_KEY: z.string().min(1),
+	GOOGLE_CLIENT_ID: z.string().min(1),
+	GOOGLE_CLIENT_SECRET: z.string().min(1),
+	GITHUB_CLIENT_ID: z.string().min(1),
+	GITHUB_CLIENT_SECRET: z.string().min(1),
 
-		// email
-		RESEND_API_KEY: z.string().min(1),
-		EMAIL_FROM: z.string().default("PStrack <info@pstrack.app>"),
+	// email
+	RESEND_API_KEY: z.string().min(1),
+	EMAIL_FROM: z.string().default("PStrack <info@pstrack.app>"),
 
-		// payments
-		POLAR_ACCESS_TOKEN: z.string().min(1),
-		// Environment-specific: Polar sandbox and production are separate catalogs
-		// with DIFFERENT product UUIDs. Must match the env POLAR_ACCESS_TOKEN targets.
-		POLAR_PRODUCT_ID: z.string().min(1),
-		POLAR_SUCCESS_URL: z.url(),
-		POLAR_WEBHOOK_SECRET: z.string().min(1).optional(),
+	// payments
+	POLAR_ACCESS_TOKEN: z.string().min(1),
+	// Environment-specific: Polar sandbox and production are separate catalogs
+	// with DIFFERENT product UUIDs. Must match the env POLAR_ACCESS_TOKEN targets.
+	POLAR_PRODUCT_ID: z.string().min(1),
+	POLAR_SUCCESS_URL: z.url(),
+	POLAR_WEBHOOK_SECRET: z.string().min(1).optional(),
 
-		// husam-bot
-		BOT_URL: z.string().url().optional(),
-		BOT_NOTIFY_SECRET: z.string().min(1).optional(),
-		JOB_DISPATCH_SECRET: z.string().min(32).optional(),
+	// husam-bot
+	BOT_URL: z.string().url().optional(),
+	BOT_NOTIFY_SECRET: z.string().min(1).optional(),
+	JOB_DISPATCH_SECRET: z.string().min(32).optional(),
 
-		// observability
-		AXIOM_TOKEN: z.string().min(1).optional(),
-		AXIOM_DATASET: z.string().min(1).optional(),
-	},
-	client: {
-		VITE_BASE_URL: z.url().default("https://pstrack.localhost"),
-		VITE_SENTRY_DSN: z.url().optional(),
-		VITE_SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
-		VITE_SENTRY_REPLAY_SESSION_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
-		VITE_SENTRY_REPLAY_ERROR_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
-	},
-	clientPrefix: "VITE_",
-	// Load environment variables from .env file if we are on the client
-	runtimeEnv: typeof window === "undefined" ? process.env : import.meta.env,
-	skipValidation: !!process.env.SKIP_ENV_VALIDATION || import.meta.env?.PROD,
+	// observability
+	AXIOM_TOKEN: z.string().min(1).optional(),
+	AXIOM_DATASET: z.string().min(1).optional(),
+}
+
+const client = {
+	VITE_BASE_URL: z.url().default("https://pstrack.localhost"),
+	VITE_SENTRY_DSN: z.url().optional(),
+	VITE_SENTRY_TRACES_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
+	VITE_SENTRY_REPLAY_SESSION_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
+	VITE_SENTRY_REPLAY_ERROR_SAMPLE_RATE: z.coerce.number().min(0).max(1).default(0),
+}
+
+/**
+ * Decide whether to skip environment validation.
+ *
+ * `SKIP_ENV_VALIDATION` is a build/test/dev-only escape hatch: it lets CI build
+ * the client bundle and unit tests run without every server secret present. It
+ * must NEVER disable validation in a running production server — doing so once
+ * let the production app boot without `POLAR_PRODUCT_ID`, silently breaking
+ * checkout (audit #281). So a production server process always validates and
+ * fails fast, regardless of the flag; the escape hatch only applies to the
+ * client bundle and to non-production server processes.
+ */
+export const resolveSkipValidation = ({
+	isServer,
+	nodeEnv,
+	skipFlag,
+}: {
+	isServer: boolean
+	nodeEnv: string | undefined
+	skipFlag: string | undefined
+}): boolean => {
+	if (isServer && nodeEnv === "production") return false
+	return !!skipFlag
+}
+
+/**
+ * Build a validated env object. Extracted from the singleton below so tests can
+ * exercise validation with controlled inputs (e.g. assert a production server
+ * throws when a required var is missing).
+ */
+export const buildEnv = ({
+	runtimeEnv,
+	isServer,
+	skipValidation,
+}: {
+	runtimeEnv: Record<string, string | undefined>
+	isServer: boolean
+	skipValidation: boolean
+}) =>
+	createEnv({
+		server,
+		client,
+		clientPrefix: "VITE_",
+		runtimeEnv,
+		isServer,
+		skipValidation,
+	})
+
+const isServer = typeof window === "undefined"
+
+export const env = buildEnv({
+	// On the client, values come from the statically-replaced import.meta.env.
+	runtimeEnv: isServer ? process.env : import.meta.env,
+	isServer,
+	skipValidation: resolveSkipValidation({
+		isServer,
+		nodeEnv: process.env.NODE_ENV,
+		skipFlag: process.env.SKIP_ENV_VALIDATION,
+	}),
 })


### PR DESCRIPTION
## Problem (audit #281)

Production server env validation was globally disabled by:

```ts
skipValidation: !!process.env.SKIP_ENV_VALIDATION || import.meta.env?.PROD
```

In a production Vite build, `import.meta.env.PROD` is statically inlined to `true`, so the **server** skipped *all* env validation at runtime. That is how production once booted without `POLAR_PRODUCT_ID`, silently breaking checkout instead of failing fast.

## Empirical finding

Confirmed in an isolated build with no `.env` and no secrets: forcing `skipValidation: false` still builds cleanly (exit 0). `vite build` never executes `createEnv` — Nitro bundles the module without evaluating its top-level. So the `import.meta.env.PROD` bypass was **never needed for the build**; it only ever weakened runtime safety. No build/CI/Dockerfile changes are required.

## Change

- Remove the `import.meta.env.PROD` bypass.
- A production server (`isServer && NODE_ENV=production`) **always validates and fails fast** on missing required config. `SKIP_ENV_VALIDATION` is honored only for the client bundle and non-production server processes (build/test/dev), and is **ignored even if it leaks into a production runtime** — satisfying the audit requirement that production reject the skip.
- Extract `resolveSkipValidation` (pure) and a testable `buildEnv` factory.
- Add `src/env.test.ts`: covers the prod fail-fast guard and asserts no provided secret value appears in validation-failure output.

## Verification

- `typecheck` ✅ · `check` (Biome, 348 files) ✅ · `test` unit ✅ 87/87 (incl. new `env.test.ts` 7) · `build` ✅ exit 0 without secrets.
- Knip unchanged (pre-existing unused-export baseline only; that's #293).

## Scope / follow-up

This PR does **not** close #281. The remaining acceptance items are production ops that need prod authorization and can only be verified post-deploy:
- Set production `POLAR_PRODUCT_ID` in Coolify; confirm token/product/success-URL/webhook all target the same Polar environment.
- Sandbox + production smoke checkout/refund with webhook evidence.

Refs #281.