### PR TITLE
fix(points): reconcile cached totals from ledger (#280)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -44,4 +44,6 @@ The `client` file pulls in `node:url` and `node:path` and crashes the browser bu
 
 ## Atomic points mutation in one DAO function
 
-Every point change goes through `applyPointsDelta(userId, delta, reason, meta)`. This function writes the history row, updates `totalPoints` clamped to floor 0, checks the Pro threshold, and runs in a single transaction. Callers never compute new balances directly. The floor lives here and nowhere else.
+Every gameplay point change goes through `applyPointsDelta(userId, delta, reason, meta)`. This function writes the history row, updates `totalPoints` clamped to floor 0, checks the Pro threshold, and runs in a single transaction. Callers never compute new balances directly.
+
+The sole exception is operational cache reconciliation. Its canonical balance is an ordered replay of the immutable ledger by `(createdAt, id)`, applying the zero floor after every entry. A repair updates only `User.totalPoints` (and grants permanent points-based Pro when appropriate); it never inserts, changes, or deletes ledger entries. Repairs require an expected mismatch count and fresh verified encrypted-backup proof, and run while affected point rows are locked in a serializable transaction.

--- a/docs/POINTS.md
+++ b/docs/POINTS.md
@@ -36,6 +36,11 @@ Notes:
 | Verification failure - 2nd+ in month | 0 points; counter-only abuse signal. The day is penalized only if `mark-missed` later marks it `MISSED`. |
 | Floor | 0 - scores cannot go negative |
 
+Because the floor applies to every event, the ledger-derived balance is not simply
+`MAX(0, SUM(delta))`. The canonical cache invariant replays entries in
+`(createdAt, id)` order and applies `MAX(0, previousBalance + delta)` after each entry.
+The daily reconciliation job checks this invariant and reports aggregate drift only.
+
 ### Clawback Mechanics
 
 When a user misses a day and their streak breaks, the clawback retroactively reverses *all bonuses* that streak earned them. Base solve points are kept; bonuses are gone.
@@ -228,7 +233,18 @@ This function:
 3. If crossing 3,000 and `!isPro`: sets `isPro = true`, `proSource = POINTS_THRESHOLD`
 4. Runs in a single transaction
 
-Callers never compute new balances directly. The floor is enforced here and nowhere else.
+Operational reconciliation is the only exception to this mutation path. The guarded
+operator workflow first performs an aggregate dry run, prepares a fresh encrypted
+backup, and pauses for an isolated restore drill. Only then may
+`bun run points:reconcile -- --expected=<count> --apply
+--restore-proof=<backup-sha256>` repair the cache over the SSH-only database path. It
+requires the expected count to still match under lock, records aggregate `JobRun`
+evidence, and verifies the post-repair aggregate is zero. Running without an operation
+flag is read-only.
+
+Gameplay callers never compute new balances directly; the regular mutation floor is
+enforced in `applyPointsDelta`. Operational reconciliation uses only the documented
+ordered-replay exception above.
 
 ### Job Changes
 

--- a/docs/TRIGGER_GITHUB_ACTIONS.md
+++ b/docs/TRIGGER_GITHUB_ACTIONS.md
@@ -46,6 +46,26 @@ Keep `trigger.dev`, `@trigger.dev/sdk`, and `@trigger.dev/build` on the same ver
 Query `GET /api/v3/internal/jobs/freshness` with the job bearer credential to
 confirm the latest successful run for every scheduled job.
 
+`reconcile-points` runs daily at 00:30 UTC, after the midnight assignment and miss
+jobs. It replays the immutable points ledger with the per-entry zero floor and sends
+an aggregate-only admin alert when cached totals drift. It never repairs automatically.
+
+Operators can inspect or repair drift with:
+
+```sh
+bun run points:reconcile
+bun run points:reconcile -- --expected=<count> --prepare
+# Restore that exact backup into an isolated database and verify it first.
+bun run points:reconcile -- --expected=<count> --apply --restore-proof=<backup-sha256>
+```
+
+The prepare form creates and checksum-verifies a fresh encrypted production backup over
+the configured `pstrack` SSH alias. The apply form refuses to proceed unless the dry-run
+count matches and the latest backup checksum matches the separately supplied isolated
+restore proof. It performs the repair only over SSH, records aggregate evidence in
+`JobRun`, and requires a zero-drift post-check. It does not print identities or
+credential values; the HTTP dispatch credential cannot invoke repairs.
+
 The skipped July 10 mark-missed window has a bounded one-day reconciliation:
 
 ```sh

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -100,6 +100,7 @@ durable `JobRun` idempotency ledger.
 | `reset-monthly-counters` | Cron: 1st of month | Resets monthly pause and verification counters |
 | `expire-admin-pro-grants` | Cron: daily | Revokes expired admin-granted Pro access |
 | `purge-system-events` | Cron: monthly | Applies event and JobRun retention policies |
+| `reconcile-points` | Cron: daily at 00:30 UTC | Checks ordered-ledger/cache equality and sends aggregate-only drift alerts |
 | `send-weekly-digest` | Cron: Monday | Sends the weekly admin digest |
 
 ## Post-MVP Services (not in v3)

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
 		"env:sync:trigger": "bun run scripts/sync-trigger.ts",
 		"env:sync:gh": "bun run scripts/sync-gh.ts",
 		"env:sync:stage": "bun run scripts/sync-vercel.ts",
-		"jobs:reconcile-mark-missed": "bun run scripts/reconcile-mark-missed.ts"
+		"jobs:reconcile-mark-missed": "bun run scripts/reconcile-mark-missed.ts",
+		"points:reconcile": "bun run scripts/reconcile-points.ts"
 	},
 	"portless": {
 		"name": "pstrack",

--- a/scripts/reconcile-points.ts
+++ b/scripts/reconcile-points.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env bun
+import { execFile, spawn } from "node:child_process"
+import { randomUUID } from "node:crypto"
+import { promisify } from "node:util"
+import { treaty } from "@elysiajs/eden"
+
+import type { App } from "@/server/app"
+import { buildPointRepairSql } from "@/server/points/points.repair-sql"
+import type { PointReconciliationResult } from "@/server/points/points.type"
+import { readProdEnv } from "./env-sync"
+
+type BackupProof = {
+	createdAt: string
+	sha256: string
+}
+
+const apply = process.argv.includes("--apply")
+const prepare = process.argv.includes("--prepare")
+const execFileAsync = promisify(execFile)
+const argumentValue = (name: string) =>
+	process.argv
+		.find((argument) => argument.startsWith(`--${name}=`))
+		?.slice(name.length + 3)
+const expectedValue = argumentValue("expected")
+const expectedMismatches = expectedValue === undefined ? null : Number(expectedValue)
+const restoreProof = argumentValue("restore-proof") ?? null
+
+if (apply && prepare) throw new Error("Choose either --prepare or --apply")
+if (
+	(apply || prepare) &&
+	(!Number.isInteger(expectedMismatches) || expectedMismatches === null)
+) {
+	throw new Error("Preparation and repair require --expected=<mismatch-count>")
+}
+if (apply && (!restoreProof || !/^[a-f0-9]{64}$/.test(restoreProof))) {
+	throw new Error("Repair requires --restore-proof=<restored-backup-sha256>")
+}
+
+const env = readProdEnv()
+const baseUrl = env.JOB_DISPATCH_URL?.replace(/\/$/, "")
+const secret = env.JOB_DISPATCH_SECRET
+if (!baseUrl || !secret) {
+	throw new Error("JOB_DISPATCH_URL and JOB_DISPATCH_SECRET are required in .env.prod")
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value)
+
+const parseResult = (value: unknown): PointReconciliationResult => {
+	if (!isRecord(value) || !isRecord(value.result)) {
+		throw new Error("Reconciliation endpoint returned an invalid response")
+	}
+	const result = value.result
+	const keys = [
+		"checkedUsers",
+		"mismatchedUsers",
+		"absoluteDrift",
+		"correctedUsers",
+		"proGranted",
+	]
+	if (!keys.every((key) => typeof result[key] === "number")) {
+		throw new Error("Reconciliation endpoint omitted aggregate evidence")
+	}
+	return {
+		checkedUsers: Number(result.checkedUsers),
+		mismatchedUsers: Number(result.mismatchedUsers),
+		absoluteDrift: Number(result.absoluteDrift),
+		correctedUsers: Number(result.correctedUsers),
+		proGranted: Number(result.proGranted),
+	}
+}
+
+const api = treaty<App>(baseUrl, {
+	headers: { authorization: `Bearer ${secret}` },
+}).api
+
+const runAudit = async (label: string) => {
+	const scheduledAt = new Date().toISOString()
+	const { data, error } = await api.v3.internal
+		.jobs({ jobName: "reconcile-points" })
+		.post({
+			idempotencyKey: `reconcile-points:${label}:${scheduledAt}`,
+			scheduledAt,
+		})
+	if (error) throw new Error(`Reconciliation request failed (${error.status})`)
+	return parseResult(data)
+}
+
+const runSsh = async (command: string) => {
+	const { stdout } = await execFileAsync("ssh", ["pstrack", command], {
+		maxBuffer: 10 * 1024 * 1024,
+	})
+	return stdout
+}
+
+const latestVerifiedBackup = async (): Promise<BackupProof> => {
+	const python = [
+		"import glob,hashlib,json,os",
+		"p=sorted(glob.glob('/var/lib/pstrack-backups/repo/backups/**/manifest.json', recursive=True))[-1]",
+		"d=json.load(open(p))",
+		"f=os.path.join('/var/lib/pstrack-backups/repo', d['dumpFile'])",
+		"actual=hashlib.sha256(open(f,'rb').read()).hexdigest()",
+		"assert actual == d['sha256']",
+		"print(json.dumps({'createdAt':d['createdAt'],'sha256':d['sha256']}))",
+	].join(";")
+	const output = await runSsh(
+		`docker exec pstrack-db-backups python3 -c ${JSON.stringify(python)}`
+	)
+	const parsed: unknown = JSON.parse(output)
+	if (
+		!isRecord(parsed) ||
+		typeof parsed.createdAt !== "string" ||
+		typeof parsed.sha256 !== "string" ||
+		!/^[a-f0-9]{64}$/.test(parsed.sha256)
+	) {
+		throw new Error("Backup verification did not produce valid aggregate proof")
+	}
+	return { createdAt: parsed.createdAt, sha256: parsed.sha256 }
+}
+
+const prepareBackup = async () => {
+	await runSsh("docker exec pstrack-db-backups /app/scripts/backup.sh")
+	return latestVerifiedBackup()
+}
+
+const runProductionSql = async (sql: string) => {
+	const command = [
+		"db=$(docker ps --filter ancestor=postgres:18-alpine --format '{{.Names}}' | head -1)",
+		'test -n "$db"',
+		'docker exec -i "$db" sh -lc \'psql -v ON_ERROR_STOP=1 -X -q -U "$POSTGRES_USER" -d "$POSTGRES_DB"\'',
+	].join("; ")
+	const child = spawn("ssh", ["pstrack", command], { stdio: ["pipe", "pipe", "pipe"] })
+	let stdout = ""
+	let stderr = ""
+	child.stdout.setEncoding("utf8").on("data", (chunk) => {
+		stdout += chunk
+	})
+	child.stderr.setEncoding("utf8").on("data", (chunk) => {
+		stderr += chunk
+	})
+	child.stdin.end(sql)
+	const exitCode = await new Promise<number>((resolve, reject) => {
+		child.once("error", reject)
+		child.once("close", (code) => resolve(code ?? 1))
+	})
+	if (exitCode !== 0) throw new Error(`Production repair failed: ${stderr.trim()}`)
+	const lastLine = stdout.trim().split("\n").at(-1)
+	if (!lastLine) throw new Error("Production repair returned no aggregate evidence")
+	const parsed: unknown = JSON.parse(lastLine)
+	if (!isRecord(parsed)) throw new Error("Production repair returned invalid evidence")
+	return parsed
+}
+
+const dryRun = await runAudit("operator")
+console.log(JSON.stringify({ mode: "dry-run", ...dryRun }))
+if (!apply && !prepare) process.exit(0)
+if (dryRun.mismatchedUsers !== expectedMismatches) {
+	throw new Error(
+		`Refusing operation: expected ${expectedMismatches} mismatches but found ${dryRun.mismatchedUsers}`
+	)
+}
+
+if (prepare) {
+	const backup = await prepareBackup()
+	console.log(JSON.stringify({ mode: "backup-prepared", ...backup }))
+	process.exit(0)
+}
+
+const backup = await latestVerifiedBackup()
+if (backup.sha256 !== restoreProof) {
+	throw new Error("Restore proof does not match the latest checksum-verified backup")
+}
+const backupAge = Date.now() - new Date(backup.createdAt).getTime()
+if (!Number.isFinite(backupAge) || backupAge < 0 || backupAge > 2 * 60 * 60 * 1000) {
+	throw new Error("The restored backup must be less than two hours old")
+}
+
+const repaired = await runProductionSql(
+	buildPointRepairSql({
+		expectedMismatches,
+		backupSha256: backup.sha256,
+		runId: randomUUID(),
+	})
+)
+console.log(
+	JSON.stringify({ mode: "apply", backupCreatedAt: backup.createdAt, ...repaired })
+)
+const verified = await runAudit("verify")
+console.log(JSON.stringify({ mode: "verify", ...verified }))
+if (verified.mismatchedUsers !== 0 || verified.absoluteDrift !== 0) {
+	throw new Error("Post-repair invariant is not zero")
+}

--- a/src/server/jobs/jobs.controller.ts
+++ b/src/server/jobs/jobs.controller.ts
@@ -27,6 +27,7 @@ const FRESHNESS_MS: Record<(typeof JOB_NAMES)[number], number> = {
 	"expire-admin-pro-grants": 26 * 60 * 60 * 1000,
 	"purge-system-events": 32 * 24 * 60 * 60 * 1000,
 	"send-weekly-digest": 8 * 24 * 60 * 60 * 1000,
+	"reconcile-points": 26 * 60 * 60 * 1000,
 	"reset-today-problems": Number.POSITIVE_INFINITY,
 	"reconcile-mark-missed": Number.POSITIVE_INFINITY,
 }

--- a/src/server/jobs/jobs.service.test.ts
+++ b/src/server/jobs/jobs.service.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const mocks = vi.hoisted(() => ({
 	markMissedForDate: vi.fn(),
 	logSystemEvent: vi.fn(),
+	auditCachedTotals: vi.fn(),
+	notifyAdmin: vi.fn(),
 }))
 
 vi.mock("@/env", () => ({
@@ -18,10 +20,13 @@ vi.mock("@/server/groups/groups.dao", () => ({
 vi.mock("@/server/groups/groups.notifications", () => ({
 	groupNotifications: { joinExpired: vi.fn() },
 }))
-vi.mock("@/server/lib/bot", () => ({ notifyAdmin: vi.fn() }))
+vi.mock("@/server/lib/bot", () => ({ notifyAdmin: mocks.notifyAdmin }))
 vi.mock("@/server/lib/db", () => ({ db: {} }))
 vi.mock("@/server/lib/email", () => ({ resend: { batch: { send: vi.fn() } } }))
 vi.mock("@/server/lib/sentry", () => ({ captureServerException: vi.fn() }))
+vi.mock("@/server/points/points.reconciliation", () => ({
+	auditCachedTotals: mocks.auditCachedTotals,
+}))
 vi.mock("@/server/problems/problems.dao", () => ({
 	problemsDao: {
 		markMissedForDate: mocks.markMissedForDate,
@@ -40,6 +45,7 @@ describe("app-owned jobs", () => {
 		vi.clearAllMocks()
 		mocks.markMissedForDate.mockResolvedValue({ missed: 2, warned: 1, removed: 0 })
 		mocks.logSystemEvent.mockResolvedValue(undefined)
+		mocks.notifyAdmin.mockResolvedValue(undefined)
 	})
 
 	it("reconciles only the explicitly requested missed day", async () => {
@@ -57,5 +63,53 @@ describe("app-owned jobs", () => {
 				metadata: expect.objectContaining({ reconciliation: true }),
 			})
 		)
+	})
+
+	it("checks point-cache drift without applying it and sends only aggregate evidence", async () => {
+		const result = {
+			checkedUsers: 14,
+			mismatchedUsers: 2,
+			absoluteDrift: 8,
+			correctedUsers: 0,
+			proGranted: 0,
+		}
+		mocks.auditCachedTotals.mockResolvedValue(result)
+
+		await expect(
+			executeJob("reconcile-points", new Date("2026-07-12T00:30:00.000Z"))
+		).resolves.toEqual(result)
+
+		expect(mocks.auditCachedTotals).toHaveBeenCalledOnce()
+		expect(mocks.notifyAdmin).toHaveBeenCalledWith("points.reconciliation_drift", {
+			checkedUsers: 14,
+			mismatchedUsers: 2,
+			absoluteDrift: 8,
+		})
+	})
+
+	it("does not send a reconciliation alert when every cached total is valid", async () => {
+		mocks.auditCachedTotals.mockResolvedValue({
+			checkedUsers: 14,
+			mismatchedUsers: 0,
+			absoluteDrift: 0,
+			correctedUsers: 0,
+			proGranted: 0,
+		})
+
+		await executeJob("reconcile-points", new Date("2026-07-12T00:30:00.000Z"))
+
+		expect(mocks.notifyAdmin).not.toHaveBeenCalled()
+	})
+
+	it("sends a sanitized alert when the reconciliation check fails", async () => {
+		mocks.auditCachedTotals.mockRejectedValue(new Error("database detail"))
+
+		await expect(
+			executeJob("reconcile-points", new Date("2026-07-12T00:30:00.000Z"))
+		).rejects.toThrow("database detail")
+
+		expect(mocks.notifyAdmin).toHaveBeenCalledWith("points.reconciliation_failed", {
+			occurredAt: expect.any(String),
+		})
 	})
 })

--- a/src/server/jobs/jobs.service.ts
+++ b/src/server/jobs/jobs.service.ts
@@ -7,6 +7,7 @@ import { notifyAdmin } from "@/server/lib/bot"
 import { db } from "@/server/lib/db"
 import { resend } from "@/server/lib/email"
 import { captureServerException } from "@/server/lib/sentry"
+import { auditCachedTotals } from "@/server/points/points.reconciliation"
 import { problemsDao } from "@/server/problems/problems.dao"
 import { systemEventsDao } from "@/server/system-events/system-events.dao"
 import type { JobName } from "./jobs.types"
@@ -206,6 +207,25 @@ const sendWeeklyDigest = async (scheduledAt: Date) => {
 	return { users, solves, newUsers }
 }
 
+const reconcilePoints = async () => {
+	try {
+		const result = await auditCachedTotals()
+		if (result.mismatchedUsers > 0) {
+			await notifyAdmin("points.reconciliation_drift", {
+				checkedUsers: result.checkedUsers,
+				mismatchedUsers: result.mismatchedUsers,
+				absoluteDrift: result.absoluteDrift,
+			})
+		}
+		return result
+	} catch (error) {
+		await notifyAdmin("points.reconciliation_failed", {
+			occurredAt: new Date().toISOString(),
+		})
+		throw error
+	}
+}
+
 const resetTodayProblems = async (scheduledAt: Date) => {
 	const date = utcDay(scheduledAt)
 	const dailyProblems = await db.dailyProblem.findMany({
@@ -239,6 +259,8 @@ export const executeJob = async (
 			return purgeSystemEvents()
 		case "send-weekly-digest":
 			return sendWeeklyDigest(scheduledAt)
+		case "reconcile-points":
+			return reconcilePoints()
 		case "reset-today-problems":
 			return resetTodayProblems(scheduledAt)
 		case "reconcile-mark-missed":

--- a/src/server/jobs/jobs.types.ts
+++ b/src/server/jobs/jobs.types.ts
@@ -6,6 +6,7 @@ export const JOB_NAMES = [
 	"expire-admin-pro-grants",
 	"purge-system-events",
 	"send-weekly-digest",
+	"reconcile-points",
 	"reset-today-problems",
 	"reconcile-mark-missed",
 ] as const

--- a/src/server/points/points.dao.ts
+++ b/src/server/points/points.dao.ts
@@ -1,7 +1,7 @@
 import type { Prisma } from "@/generated/prisma/client"
 import { PointReason, ProSource } from "@/generated/prisma/enums"
 import { db } from "@/server/lib/db"
-import { MISSED_PENALTY, PRO_THRESHOLD } from "./points.type"
+import { MISSED_PENALTY, type PointDriftRow, PRO_THRESHOLD } from "./points.type"
 
 type Tx = Prisma.TransactionClient
 
@@ -16,6 +16,53 @@ type LockedUserPoints = {
 	totalPoints: number
 	isPro: boolean
 }
+
+const findPointDrift = (tx: Tx): Promise<PointDriftRow[]> =>
+	tx.$queryRaw<PointDriftRow[]>`
+		WITH RECURSIVE ordered AS (
+			SELECT
+				p."userId",
+				p.delta,
+				ROW_NUMBER() OVER (
+					PARTITION BY p."userId"
+					ORDER BY p."createdAt", p.id
+				) AS sequence
+			FROM "PointsHistory" p
+		), replay AS (
+			SELECT
+				ordered."userId",
+				ordered.sequence,
+				GREATEST(0, ordered.delta)::integer AS balance
+			FROM ordered
+			WHERE ordered.sequence = 1
+
+			UNION ALL
+
+			SELECT
+				ordered."userId",
+				ordered.sequence,
+				GREATEST(0, replay.balance + ordered.delta)::integer AS balance
+			FROM replay
+			JOIN ordered
+				ON ordered."userId" = replay."userId"
+				AND ordered.sequence = replay.sequence + 1
+		), final_balance AS (
+			SELECT DISTINCT ON (replay."userId")
+				replay."userId",
+				replay.balance
+			FROM replay
+			ORDER BY replay."userId", replay.sequence DESC
+		)
+		SELECT
+			u.id AS "userId",
+			u."totalPoints" AS "currentTotal",
+			COALESCE(final_balance.balance, 0)::integer AS "expectedTotal",
+			u."isPro" AS "isPro"
+		FROM "user" u
+		LEFT JOIN final_balance ON final_balance."userId" = u.id
+		WHERE u."totalPoints" <> COALESCE(final_balance.balance, 0)
+		ORDER BY u.id
+	`
 
 const lockUserPoints = async (tx: Tx, userId: string): Promise<LockedUserPoints> => {
 	const rows = await tx.$queryRaw<LockedUserPoints[]>`
@@ -72,6 +119,33 @@ const applyPointsDeltaInTx = async (
 }
 
 export const pointsDao = {
+	countUsers: (tx: Tx): Promise<number> => tx.user.count(),
+
+	findCachedTotalDrift: (tx: Tx): Promise<PointDriftRow[]> => findPointDrift(tx),
+
+	lockAllUserPoints: async (tx: Tx): Promise<void> => {
+		await tx.$queryRaw<Array<{ id: string }>>`
+			SELECT id FROM "user" ORDER BY id FOR NO KEY UPDATE
+		`
+	},
+
+	updateCachedTotal: async (
+		tx: Tx,
+		row: PointDriftRow,
+		grantsPro: boolean
+	): Promise<void> => {
+		await tx.user.update({
+			where: { id: row.userId },
+			data: {
+				totalPoints: row.expectedTotal,
+				...(grantsPro && {
+					isPro: true,
+					proSource: ProSource.POINTS_THRESHOLD,
+				}),
+			},
+		})
+	},
+
 	applyPointsDelta: async (
 		userId: string,
 		delta: number,

--- a/src/server/points/points.reconciliation.integration.test.ts
+++ b/src/server/points/points.reconciliation.integration.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+
+import { PointReason, ProSource } from "@/generated/prisma/enums"
+import { createUser, testDb } from "@/test/db"
+import { auditCachedTotals, repairCachedTotals } from "./points.reconciliation"
+
+const addLedgerEntry = async (userId: string, delta: number, createdAt: Date) =>
+	testDb.pointsHistory.create({
+		data: {
+			userId,
+			delta,
+			reason: PointReason.ADMIN_ADJUSTMENT,
+			createdAt,
+		},
+	})
+
+describe("points cache reconciliation", () => {
+	it("detects drift by replaying the immutable ledger with the zero floor after every entry", async () => {
+		const drifted = await createUser({ totalPoints: 2 })
+		await addLedgerEntry(drifted.id, -3, new Date("2026-07-01T00:00:00.000Z"))
+		await addLedgerEntry(drifted.id, 5, new Date("2026-07-02T00:00:00.000Z"))
+
+		const correctlyFloored = await createUser({ totalPoints: 0 })
+		await addLedgerEntry(correctlyFloored.id, -13, new Date("2026-07-01T00:00:00.000Z"))
+
+		await expect(auditCachedTotals()).resolves.toEqual({
+			checkedUsers: 2,
+			mismatchedUsers: 1,
+			absoluteDrift: 3,
+			correctedUsers: 0,
+			proGranted: 0,
+		})
+
+		await expect(
+			testDb.user.findUniqueOrThrow({ where: { id: drifted.id } })
+		).resolves.toMatchObject({ totalPoints: 2, isPro: false })
+	})
+
+	it("transactionally repairs drift, grants threshold Pro, and never revokes Pro", async () => {
+		const thresholdCrossing = await createUser({ totalPoints: 2_998 })
+		await addLedgerEntry(
+			thresholdCrossing.id,
+			3_005,
+			new Date("2026-07-01T00:00:00.000Z")
+		)
+
+		const existingPro = await createUser({
+			totalPoints: 25,
+			isPro: true,
+			proSource: ProSource.POLAR_PURCHASE,
+		})
+		await addLedgerEntry(existingPro.id, 10, new Date("2026-07-01T00:00:00.000Z"))
+
+		await expect(repairCachedTotals(2)).resolves.toEqual({
+			checkedUsers: 2,
+			mismatchedUsers: 2,
+			absoluteDrift: 22,
+			correctedUsers: 2,
+			proGranted: 1,
+		})
+
+		await expect(
+			testDb.user.findUniqueOrThrow({ where: { id: thresholdCrossing.id } })
+		).resolves.toMatchObject({
+			totalPoints: 3_005,
+			isPro: true,
+			proSource: ProSource.POINTS_THRESHOLD,
+		})
+		await expect(
+			testDb.user.findUniqueOrThrow({ where: { id: existingPro.id } })
+		).resolves.toMatchObject({
+			totalPoints: 10,
+			isPro: true,
+			proSource: ProSource.POLAR_PURCHASE,
+		})
+	})
+
+	it("refuses to repair when the observed mismatch count differs from the operator precondition", async () => {
+		const user = await createUser({ totalPoints: 1 })
+		await addLedgerEntry(user.id, 5, new Date("2026-07-01T00:00:00.000Z"))
+
+		await expect(repairCachedTotals(2)).rejects.toThrow(
+			"Point repair expected 2 mismatches but found 1"
+		)
+		await expect(
+			testDb.user.findUniqueOrThrow({ where: { id: user.id } })
+		).resolves.toMatchObject({ totalPoints: 1 })
+	})
+})

--- a/src/server/points/points.reconciliation.ts
+++ b/src/server/points/points.reconciliation.ts
@@ -1,0 +1,62 @@
+import { db } from "@/server/lib/db"
+import { pointsDao } from "./points.dao"
+import {
+	type PointDriftRow,
+	type PointReconciliationResult,
+	PRO_THRESHOLD,
+} from "./points.type"
+
+const summarize = (
+	checkedUsers: number,
+	drift: PointDriftRow[],
+	correctedUsers: number,
+	proGranted: number
+): PointReconciliationResult => ({
+	checkedUsers,
+	mismatchedUsers: drift.length,
+	absoluteDrift: drift.reduce(
+		(total, row) => total + Math.abs(row.currentTotal - row.expectedTotal),
+		0
+	),
+	correctedUsers,
+	proGranted,
+})
+
+export const auditCachedTotals = async (): Promise<PointReconciliationResult> =>
+	db.$transaction(
+		async (tx) => {
+			const [checkedUsers, drift] = await Promise.all([
+				pointsDao.countUsers(tx),
+				pointsDao.findCachedTotalDrift(tx),
+			])
+			return summarize(checkedUsers, drift, 0, 0)
+		},
+		{ isolationLevel: "RepeatableRead" }
+	)
+
+export const repairCachedTotals = async (
+	expectedMismatches: number
+): Promise<PointReconciliationResult> =>
+	db.$transaction(
+		async (tx) => {
+			await pointsDao.lockAllUserPoints(tx)
+			const [checkedUsers, drift] = await Promise.all([
+				pointsDao.countUsers(tx),
+				pointsDao.findCachedTotalDrift(tx),
+			])
+			if (drift.length !== expectedMismatches) {
+				throw new Error(
+					`Point repair expected ${expectedMismatches} mismatches but found ${drift.length}`
+				)
+			}
+
+			let proGranted = 0
+			for (const row of drift) {
+				const grantsPro = !row.isPro && row.expectedTotal >= PRO_THRESHOLD
+				await pointsDao.updateCachedTotal(tx, row, grantsPro)
+				if (grantsPro) proGranted++
+			}
+			return summarize(checkedUsers, drift, drift.length, proGranted)
+		},
+		{ isolationLevel: "Serializable" }
+	)

--- a/src/server/points/points.repair-sql.integration.test.ts
+++ b/src/server/points/points.repair-sql.integration.test.ts
@@ -1,0 +1,60 @@
+import { Pool } from "pg"
+import { afterAll, describe, expect, it } from "vitest"
+
+import { PointReason } from "@/generated/prisma/enums"
+import { createUser, testDb } from "@/test/db"
+import { buildPointRepairSql } from "./points.repair-sql"
+
+const pool = new Pool({
+	connectionString:
+		process.env.TEST_DATABASE_URL ??
+		"postgresql://pstrack:pstrack@127.0.0.1:5433/pstrack?schema=public",
+})
+
+afterAll(() => pool.end())
+
+describe("points repair operator SQL", () => {
+	it("repairs the cache and records complete aggregate JobRun evidence", async () => {
+		const user = await createUser({ totalPoints: 1 })
+		await testDb.pointsHistory.create({
+			data: {
+				userId: user.id,
+				delta: 5,
+				reason: PointReason.ADMIN_ADJUSTMENT,
+			},
+		})
+
+		await pool.query(
+			buildPointRepairSql({
+				expectedMismatches: 1,
+				backupSha256: "a".repeat(64),
+				runId: "point-repair-test-run",
+			})
+		)
+
+		await expect(
+			testDb.user.findUniqueOrThrow({ where: { id: user.id } })
+		).resolves.toMatchObject({ totalPoints: 5 })
+		await expect(
+			testDb.jobRun.findUniqueOrThrow({
+				where: {
+					jobName_idempotencyKey: {
+						jobName: "repair-points",
+						idempotencyKey: "repair-points:aaaaaaaaaaaaaaaa:1",
+					},
+				},
+			})
+		).resolves.toMatchObject({
+			id: "point-repair-test-run",
+			status: "SUCCEEDED",
+			result: {
+				checkedUsers: 1,
+				mismatchedUsers: 1,
+				absoluteDrift: 4,
+				correctedUsers: 1,
+				proGranted: 0,
+			},
+			updatedAt: expect.any(Date),
+		})
+	})
+})

--- a/src/server/points/points.repair-sql.ts
+++ b/src/server/points/points.repair-sql.ts
@@ -1,0 +1,71 @@
+const pointReplayCte = `
+	WITH RECURSIVE ordered AS (
+		SELECT p."userId", p.delta,
+			ROW_NUMBER() OVER (PARTITION BY p."userId" ORDER BY p."createdAt", p.id) AS sequence
+		FROM "PointsHistory" p
+	), replay AS (
+		SELECT ordered."userId", ordered.sequence, GREATEST(0, ordered.delta)::integer AS balance
+		FROM ordered WHERE ordered.sequence = 1
+		UNION ALL
+		SELECT ordered."userId", ordered.sequence,
+			GREATEST(0, replay.balance + ordered.delta)::integer AS balance
+		FROM replay JOIN ordered ON ordered."userId" = replay."userId"
+			AND ordered.sequence = replay.sequence + 1
+	), final_balance AS (
+		SELECT DISTINCT ON (replay."userId") replay."userId", replay.balance
+		FROM replay ORDER BY replay."userId", replay.sequence DESC
+	)
+	SELECT u.id AS "userId", u."totalPoints" AS "currentTotal",
+		COALESCE(final_balance.balance, 0)::integer AS "expectedTotal", u."isPro" AS "isPro"
+	FROM "user" u LEFT JOIN final_balance ON final_balance."userId" = u.id
+	WHERE u."totalPoints" <> COALESCE(final_balance.balance, 0)
+`
+
+export const buildPointRepairSql = ({
+	expectedMismatches,
+	backupSha256,
+	runId,
+}: {
+	expectedMismatches: number
+	backupSha256: string
+	runId: string
+}) => {
+	const idempotencyKey = `repair-points:${backupSha256.slice(0, 16)}:${expectedMismatches}`
+	return `
+		BEGIN;
+		SELECT id FROM "user" ORDER BY id FOR NO KEY UPDATE;
+		CREATE TEMP TABLE point_repair_drift ON COMMIT DROP AS ${pointReplayCte};
+		DO $$ BEGIN
+			IF (SELECT COUNT(*) FROM point_repair_drift) <> ${expectedMismatches} THEN
+				RAISE EXCEPTION 'Point repair expected ${expectedMismatches} mismatches but observed a different count';
+			END IF;
+		END $$;
+		CREATE TEMP TABLE point_repair_summary ON COMMIT DROP AS
+		WITH updated AS (
+			UPDATE "user" u SET
+				"totalPoints" = d."expectedTotal",
+				"isPro" = u."isPro" OR (NOT d."isPro" AND d."expectedTotal" >= 3000),
+				"proSource" = CASE
+					WHEN NOT d."isPro" AND d."expectedTotal" >= 3000
+					THEN 'POINTS_THRESHOLD'::"ProSource" ELSE u."proSource" END
+			FROM point_repair_drift d WHERE u.id = d."userId"
+			RETURNING (NOT d."isPro" AND d."expectedTotal" >= 3000) AS "grantedPro"
+		)
+		SELECT
+			(SELECT COUNT(*)::integer FROM "user") AS "checkedUsers",
+			(SELECT COUNT(*)::integer FROM point_repair_drift) AS "mismatchedUsers",
+			(SELECT COALESCE(SUM(ABS("currentTotal" - "expectedTotal")), 0)::integer FROM point_repair_drift) AS "absoluteDrift",
+			(SELECT COUNT(*)::integer FROM updated) AS "correctedUsers",
+			(SELECT COUNT(*)::integer FROM updated WHERE "grantedPro") AS "proGranted";
+		INSERT INTO job_run (
+			id, "jobName", "idempotencyKey", status, attempts,
+			"startedAt", "finishedAt", "updatedAt", result
+		)
+		SELECT
+			'${runId}', 'repair-points', '${idempotencyKey}', 'SUCCEEDED', 1,
+			NOW(), NOW(), NOW(), TO_JSONB(s)
+		FROM point_repair_summary s;
+		SELECT ROW_TO_JSON(s) FROM point_repair_summary s;
+		COMMIT;
+	`
+}

--- a/src/server/points/points.type.ts
+++ b/src/server/points/points.type.ts
@@ -14,3 +14,18 @@ export const JOIN_GROUP_BONUS = 20
 export const PRO_THRESHOLD = 3_000
 export const STREAK_MULTIPLIER_7 = 1.2
 export const STREAK_MULTIPLIER_30 = 1.5
+
+export type PointDriftRow = {
+	userId: string
+	currentTotal: number
+	expectedTotal: number
+	isPro: boolean
+}
+
+export type PointReconciliationResult = {
+	checkedUsers: number
+	mismatchedUsers: number
+	absoluteDrift: number
+	correctedUsers: number
+	proGranted: number
+}

--- a/src/server/problems/daily-loop.integration.test.ts
+++ b/src/server/problems/daily-loop.integration.test.ts
@@ -13,6 +13,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { PointReason, SolveStatus } from "@/generated/prisma/enums"
+import { auditCachedTotals } from "@/server/points/points.reconciliation"
 import {
 	FIRST_IN_GROUP_BONUS,
 	MISSED_PENALTY,
@@ -110,6 +111,16 @@ const seedHappyPath = async (assignedDate: Date) => {
 	return { user, group, problem, dailyProblem }
 }
 
+const addLedgerEntryForDailyLoop = (userId: string, delta: number, createdAt: Date) =>
+	testDb.pointsHistory.create({
+		data: {
+			userId,
+			delta,
+			reason: PointReason.ADMIN_ADJUSTMENT,
+			createdAt,
+		},
+	})
+
 // ---------------------------------------------------------------------------
 // Test: happy-path solve
 // ---------------------------------------------------------------------------
@@ -181,7 +192,7 @@ describe("verifyAndMarkSolved — happy path", () => {
 // ---------------------------------------------------------------------------
 
 describe("verifyAndMarkSolved — idempotency", () => {
-	it("calling twice produces exactly one DAILY_SOLVE and one FIRST_IN_GROUP row", async () => {
+	it("concurrent solve requests produce one base award and each bonus at most once", async () => {
 		const today = new Date(
 			Date.UTC(
 				new Date().getUTCFullYear(),
@@ -194,11 +205,9 @@ describe("verifyAndMarkSolved — idempotency", () => {
 		const submittedAtMs = today.getTime() + 2 * 60 * 60 * 1000
 		mockLeetCodeMatch(problem.slug, submittedAtMs)
 
-		await problemsDao.verifyAndMarkSolved(user.id)
-
-		// Second call — mock still returns the same submission
-		mockLeetCodeMatch(problem.slug, submittedAtMs)
-		await problemsDao.verifyAndMarkSolved(user.id)
+		await Promise.all(
+			Array.from({ length: 8 }, () => problemsDao.verifyAndMarkSolved(user.id))
+		)
 
 		const dailySolveRows = await testDb.pointsHistory.findMany({
 			where: { userId: user.id, reason: PointReason.DAILY_SOLVE },
@@ -209,6 +218,110 @@ describe("verifyAndMarkSolved — idempotency", () => {
 			where: { userId: user.id, reason: PointReason.FIRST_IN_GROUP },
 		})
 		expect(firstRows).toHaveLength(1)
+
+		const earlyBirdRows = await testDb.pointsHistory.findMany({
+			where: { userId: user.id, reason: PointReason.EARLY_BIRD },
+		})
+		expect(earlyBirdRows).toHaveLength(1)
+		await expect(auditCachedTotals()).resolves.toMatchObject({
+			mismatchedUsers: 0,
+			absoluteDrift: 0,
+		})
+	})
+})
+
+describe("points invariant across daily outcomes", () => {
+	it("keeps multiplier and first-solver bonuses aligned with the cached total", async () => {
+		const today = new Date(
+			Date.UTC(
+				new Date().getUTCFullYear(),
+				new Date().getUTCMonth(),
+				new Date().getUTCDate()
+			)
+		)
+		const { user, problem } = await seedHappyPath(today)
+		const streakStartedAt = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000)
+		await testDb.user.update({
+			where: { id: user.id },
+			data: {
+				totalPoints: 100,
+				currentStreak: 7,
+				longestStreak: 7,
+				currentStreakStartedAt: streakStartedAt,
+			},
+		})
+		await addLedgerEntryForDailyLoop(user.id, 100, streakStartedAt)
+		mockLeetCodeMatch(problem.slug, today.getTime() + 60 * 60 * 1000)
+
+		await problemsDao.verifyAndMarkSolved(user.id)
+
+		await expect(
+			testDb.pointsHistory.findFirstOrThrow({
+				where: { userId: user.id, reason: PointReason.STREAK_MULTIPLIER_BONUS },
+			})
+		).resolves.toMatchObject({ delta: 2 })
+		await expect(auditCachedTotals()).resolves.toMatchObject({
+			mismatchedUsers: 0,
+			absoluteDrift: 0,
+		})
+	})
+
+	it("keeps a pause penalty aligned with the cached total", async () => {
+		const today = new Date(
+			Date.UTC(
+				new Date().getUTCFullYear(),
+				new Date().getUTCMonth(),
+				new Date().getUTCDate()
+			)
+		)
+		const { user } = await seedHappyPath(today)
+		await testDb.user.update({ where: { id: user.id }, data: { totalPoints: 20 } })
+		await addLedgerEntryForDailyLoop(user.id, 20, new Date(today.getTime() - 1_000))
+
+		await problemsDao.pauseToday(user.id)
+
+		await expect(
+			testDb.pointsHistory.findFirstOrThrow({
+				where: { userId: user.id, reason: PointReason.PAUSE },
+			})
+		).resolves.toMatchObject({ delta: -5 })
+		await expect(auditCachedTotals()).resolves.toMatchObject({
+			mismatchedUsers: 0,
+			absoluteDrift: 0,
+		})
+	})
+
+	it("retries cleanly after an external verification failure", async () => {
+		const today = new Date(
+			Date.UTC(
+				new Date().getUTCFullYear(),
+				new Date().getUTCMonth(),
+				new Date().getUTCDate()
+			)
+		)
+		const { user, problem } = await seedHappyPath(today)
+		mockFetch.mockRejectedValueOnce(new Error("temporary LeetCode outage"))
+
+		await expect(problemsDao.verifyAndMarkSolved(user.id)).resolves.toMatchObject({
+			error: "NOT_VERIFIED",
+		})
+		await expect(testDb.userSolve.count({ where: { userId: user.id } })).resolves.toBe(0)
+		await expect(
+			testDb.pointsHistory.findMany({ where: { userId: user.id } })
+		).resolves.toEqual([
+			expect.objectContaining({
+				reason: PointReason.VERIFICATION_FAILURE_GRACE,
+				delta: 0,
+			}),
+		])
+
+		mockLeetCodeMatch(problem.slug, today.getTime() + 60 * 60 * 1000)
+		await problemsDao.verifyAndMarkSolved(user.id)
+
+		await expect(auditCachedTotals()).resolves.toMatchObject({
+			mismatchedUsers: 0,
+			absoluteDrift: 0,
+		})
 	})
 })
 
@@ -295,5 +408,84 @@ describe("markMissedForDate", () => {
 		const updatedUser = await testDb.user.findUniqueOrThrow({ where: { id: user.id } })
 		expect(updatedUser.currentStreak).toBe(0)
 		expect(updatedUser.currentStreakStartedAt).toBeNull()
+	})
+
+	it("applies one penalty and one bonus clawback under concurrent miss sweeps", async () => {
+		const yesterday = new Date(
+			Date.UTC(
+				new Date().getUTCFullYear(),
+				new Date().getUTCMonth(),
+				new Date().getUTCDate() - 1
+			)
+		)
+		const streakStartedAt = new Date(yesterday.getTime() - 7 * 24 * 60 * 60 * 1000)
+		const user = await createUser({
+			leetcodeHandle: "concurrent-miss",
+			currentStreak: 7,
+			currentStreakStartedAt: streakStartedAt,
+			totalPoints: 50,
+		})
+		const group = await createGroup({ roadmap: "NC250", isActive: true, isStarted: true })
+		const member = await addMember(group.id, user.id)
+		await testDb.groupMember.update({
+			where: { id: member.id },
+			data: { joinedAt: new Date(streakStartedAt.getTime() - 24 * 60 * 60 * 1000) },
+		})
+		const problem = await createProblem({ slug: "concurrent-missed-problem" })
+		await createDailyProblem({
+			groupId: group.id,
+			problemId: problem.id,
+			assignedDate: yesterday,
+		})
+		await testDb.pointsHistory.createMany({
+			data: [
+				{
+					userId: user.id,
+					delta: 38,
+					reason: PointReason.ADMIN_ADJUSTMENT,
+					createdAt: streakStartedAt,
+				},
+				{
+					userId: user.id,
+					delta: 10,
+					reason: PointReason.FIRST_IN_GROUP,
+					createdAt: new Date(streakStartedAt.getTime() + 1_000),
+				},
+				{
+					userId: user.id,
+					delta: 2,
+					reason: PointReason.STREAK_MULTIPLIER_BONUS,
+					createdAt: new Date(streakStartedAt.getTime() + 2_000),
+				},
+			],
+		})
+
+		const results = await Promise.all(
+			Array.from({ length: 8 }, () =>
+				problemsDao.markMissedForDate(yesterday, { evaluateWarnings: false })
+			)
+		)
+
+		expect(results.reduce((sum, result) => sum + result.missed, 0)).toBe(1)
+		await expect(
+			testDb.userSolve.count({ where: { userId: user.id, status: SolveStatus.MISSED } })
+		).resolves.toBe(1)
+		await expect(
+			testDb.pointsHistory.count({
+				where: { userId: user.id, reason: PointReason.CLAWBACK },
+			})
+		).resolves.toBe(1)
+		await expect(
+			testDb.pointsHistory.count({
+				where: { userId: user.id, reason: PointReason.MISSED_DAY },
+			})
+		).resolves.toBe(1)
+		await expect(
+			testDb.user.findUniqueOrThrow({ where: { id: user.id } })
+		).resolves.toMatchObject({ totalPoints: 35, currentStreak: 0 })
+		await expect(auditCachedTotals()).resolves.toMatchObject({
+			mismatchedUsers: 0,
+			absoluteDrift: 0,
+		})
 	})
 })

--- a/src/server/stress/api.stress.integration.test.ts
+++ b/src/server/stress/api.stress.integration.test.ts
@@ -1124,5 +1124,5 @@ describe("API stress suite", () => {
 		}
 
 		await expectCoreStressInvariants()
-	})
+	}, 20_000)
 })

--- a/src/server/stress/trigger-modules.stress.integration.test.ts
+++ b/src/server/stress/trigger-modules.stress.integration.test.ts
@@ -48,6 +48,7 @@ import { expireAdminProGrantsTask } from "@/server/trigger/expire-admin-pro-gran
 import { expireJoinRequestsTask } from "@/server/trigger/expire-join-requests"
 import { markMissedTask } from "@/server/trigger/mark-missed"
 import { purgeSystemEventsTask } from "@/server/trigger/purge-system-events"
+import { reconcilePointsTask } from "@/server/trigger/reconcile-points"
 import { resetMonthlyCountersTask } from "@/server/trigger/reset-monthly-counters"
 import { resetTodayProblemsTask } from "@/server/trigger/reset-today-problems"
 import { sendWeeklyDigestTask } from "@/server/trigger/send-weekly-digest"
@@ -183,6 +184,7 @@ describe("Trigger module stress suite", () => {
 			() => runStressTask(resetMonthlyCountersTask, { timestamp: state.today }),
 			() => runStressTask(expireAdminProGrantsTask, { timestamp: state.today }),
 			() => runStressTask(purgeSystemEventsTask, { timestamp: state.today }),
+			() => runStressTask(reconcilePointsTask, { timestamp: state.today }),
 			() => runStressTask(sendWeeklyDigestTask, { timestamp: state.today }),
 		]
 		const work = tasks.flatMap((task) => Array.from({ length: repetitions }, () => task))

--- a/src/server/trigger/reconcile-points.ts
+++ b/src/server/trigger/reconcile-points.ts
@@ -1,0 +1,11 @@
+import { schedules } from "@trigger.dev/sdk/v3"
+
+import { dailyKey, dispatchJob } from "./dispatch-job"
+
+export const reconcilePointsTask = schedules.task({
+	id: "reconcile-points",
+	cron: "30 0 * * *",
+	maxDuration: 180,
+	run: async ({ timestamp }) =>
+		dispatchJob("reconcile-points", timestamp, dailyKey("reconcile-points", timestamp)),
+})

--- a/src/server/trigger/trigger.test.ts
+++ b/src/server/trigger/trigger.test.ts
@@ -11,6 +11,7 @@ import { expireAdminProGrantsTask } from "./expire-admin-pro-grants"
 import { expireJoinRequestsTask } from "./expire-join-requests"
 import { markMissedTask } from "./mark-missed"
 import { purgeSystemEventsTask } from "./purge-system-events"
+import { reconcilePointsTask } from "./reconcile-points"
 import { resetMonthlyCountersTask } from "./reset-monthly-counters"
 import { resetTodayProblemsTask } from "./reset-today-problems"
 import { sendWeeklyDigestTask } from "./send-weekly-digest"
@@ -55,6 +56,7 @@ describe("Trigger job dispatchers", () => {
 			"expire-admin-pro-grants:2026-07-11",
 		],
 		[purgeSystemEventsTask, "purge-system-events", "purge-system-events:2026-07"],
+		[reconcilePointsTask, "reconcile-points", "reconcile-points:2026-07-11"],
 		[sendWeeklyDigestTask, "send-weekly-digest", "send-weekly-digest:2026-07-11"],
 	])("dispatches %s through the authenticated app endpoint", async (task, jobName, key) => {
 		await task.run({ timestamp })

--- a/src/test/stress-manifest.ts
+++ b/src/test/stress-manifest.ts
@@ -541,6 +541,11 @@ export const STRESS_BACKGROUND_MODULES: StressBackgroundModule[] = [
 		dimensions: ["idempotency", "side-effect"],
 	},
 	{
+		file: "reconcile-points.ts",
+		module: "trigger",
+		dimensions: ["idempotency", "invariant", "read", "side-effect"],
+	},
+	{
 		file: "reset-monthly-counters.ts",
 		module: "trigger",
 		dimensions: ["idempotency", "side-effect"],


### PR DESCRIPTION
## Summary
- define ordered per-entry-floor replay as the canonical points cache invariant
- add daily aggregate-only reconciliation with drift/failure alerts and freshness evidence
- add an SSH-only, expected-count and isolated-restore-gated repair workflow with aggregate JobRun evidence
- cover concurrent solve, multiplier, pause, verification retry, miss/clawback, Pro transitions, and direct repair SQL

## Verification
- `bun run typecheck`
- `bun run check`
- `bun run test` (112 tests)
- `bun run build`
- `bun run knip` remains non-blocking on the existing #293 baseline

Refs #280