### PR TITLE
docs: record #283 recovery + retention decisions (ADR 0006 amendment)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -233,13 +233,15 @@ No child remediation issue (#279–#294) is fully resolved and closed yet.
 ### Backup recovery and retention — [#283](https://github.com/husamql3/pstrack/issues/283)
 
 - [x] Produce current encrypted hourly custom-format PostgreSQL dumps.
-- [ ] Restore the newest dump into an isolated database and verify schema, row aggregates, auth/session isolation, and points invariants.
-- [ ] Measure and record restore time and data-loss window; set final RTO/RPO.
-- [ ] Replace Git-backed backup retention with backup-native object storage in a second failure domain.
-- [ ] Enforce and test hourly/daily/monthly retention rather than relying on Git history.
-- [ ] Enable PostgreSQL point-in-time recovery or document an approved alternative.
-- [ ] Alert when the newest successful backup exceeds its freshness threshold.
-- [ ] Schedule recurring automated restore drills.
+- [ ] Restore the newest dump into an isolated database and verify schema, row aggregates, auth/session isolation, and points invariants. — _Harness `scripts/drill.sh` built + synthetically proven; awaiting the real-key drill for production evidence._
+- [ ] Measure and record restore time and data-loss window; set final RTO/RPO. — _Targets set (RPO ≤ 1h, RTO minutes) in ADR amendment; final measured numbers pending the real drill._
+- [ ] ~~Replace Git-backed backup retention with backup-native object storage in a second failure domain.~~ — **Rejected with rationale** (ADR 0006 amendment): GitHub is already off the VPS = second failure domain; the immutability gap is closed by removing force-push (append-only + guarded squash checkpoint) instead.
+- [ ] Enforce and test hourly/daily/monthly retention rather than relying on Git history. — _Append-only model + `test/prune-retention-test.py` (4-tier) passing locally; awaiting deploy of the updated backup container._
+- [ ] Enable PostgreSQL point-in-time recovery or document an approved alternative. — _Approved alternative (snapshot-only, RPO ≤ 1h) documented in ADR amendment; awaiting merge._
+- [ ] Alert when the newest successful backup exceeds its freshness threshold. — _`backup-freshness.yml` written; awaiting `BOT_URL`/`BOT_NOTIFY_SECRET` repo secrets + merge._
+- [ ] Schedule recurring automated restore drills. — _`restore-drill-reminder.yml` (monthly, keyless) written; awaiting merge._
+
+**#283 status (2026-07-12):** All tooling built on branch `fix/prove-recovery-and-retention` in `husamql3/pstrack-db-backups`; 3 local test suites green (retention, dual-recipient, synthetic drill end-to-end). App-repo change is docs-only (ADR 0006 amendment + this file). Remaining to close: (1) run the real-key drill and record sanitized evidence, (2) deploy the append-only + dual-recipient backup container via Coolify, (3) add repo secrets + merge the two workflows. No box is checked until its production evidence exists, per the completion rule.
 
 ### Production host patching and SSH — [#284](https://github.com/husamql3/pstrack/issues/284)
 

--- a/docs/adr/0006-hourly-encrypted-database-backups.md
+++ b/docs/adr/0006-hourly-encrypted-database-backups.md
@@ -130,3 +130,61 @@ Automated restore drills can be added later if there is a secure runner that can
 **Branch per day** - rejected because it creates too many branches and does not solve Git storage growth unless branches are aggressively deleted and garbage-collected.
 
 **GitHub Actions pulls from production Postgres** - rejected for the first version because it would require exposing production database access outside the VPS. Running the backup job on the VPS keeps Postgres private to the Docker/Coolify network.
+
+---
+
+## Amendment 2026-07-12 — recovery proof and retention ([#283](https://github.com/husamql3/pstrack/issues/283))
+
+The July 11 production audit required proving recovery and hardening retention. The
+decisions below refine (not replace) the original ADR. Tooling lives in the
+`husamql3/pstrack-db-backups` repo unless noted.
+
+### Recovery objectives
+
+- **RPO ≤ 1 hour, snapshot-only.** PITR/WAL archiving is **rejected** as the ticket's
+  "approved alternative": on a Coolify-managed single Postgres container it is heavy
+  ops (archive_command, base backups, WAL shipping, timeline management) for marginal
+  gain at the current scale (sub-1 MB dump, beta cohort, hourly cadence).
+- **RTO: minutes.** Measured by the isolated restore drill (`rto.total_restore_ms`),
+  dominated by human decision time rather than data size.
+
+### Object storage — rejected, keep GitHub with an immutability fix
+
+- Migrating to backup-native object storage is **rejected with rationale**: GitHub is
+  already off the production VPS, so the "survives total VPS loss / second failure
+  domain" property is met. What GitHub lacked was immutability against a bad push.
+- **Force-push is removed.** The hourly job is now **append-only**: pruning deletes
+  files in a normal commit, so old dumps remain recoverable in history. A bad run,
+  prune bug, or compromised deploy key can no longer wipe the retained set. History
+  growth is reclaimed only by an operator-run, guarded `squash-checkpoint.sh` (the one
+  sanctioned force-push).
+
+### Retention — unchanged, now enforced and tested
+
+- Windows stay 48h / 30d / 12w / 12mo. `test/prune-retention-test.py` pins "now" and
+  asserts the exact retained set across all four tiers.
+
+### Encryption key custody — dual recipient
+
+- Each dump is now encrypted to **two** age recipients (primary + escrow), stored in
+  separate custody. Either private key can restore. Removes the single-lost-key =
+  total-loss failure mode. Legacy single-recipient dumps roll off within retention.
+
+### Recovery verification — isolated restore drill
+
+- `scripts/drill.sh` restores the newest dump into an **ephemeral Postgres 18 container
+  on a Docker `--internal` (no-egress) network**, then verifies schema/migration, row
+  aggregates, auth/session isolation counts, and the points invariant
+  (`user.totalPoints == Σ PointsHistory.delta`), measures RTO + RPO, proves egress is
+  blocked, and destroys everything. Aggregate-only output; the age key is referenced by
+  path and never printed. A small non-zero points drift on a pre-#280 backup is expected
+  and is evidence of a faithful restore, not a failure.
+- Automated drills keep the age key **out of cloud CI**: a monthly keyless GitHub Action
+  (`restore-drill-reminder.yml`) opens a `restore-drill` issue; an operator runs the
+  one-command local drill and records sanitized evidence.
+
+### Freshness alerting
+
+- `backup-freshness.yml` (hourly) reads the newest manifest on `backup-data` and alerts
+  the existing admin bot (`POST $BOT_URL/api/notify`) if it exceeds ~2h. Independent /
+  dead-man's-switch alerting is tracked in [#290](https://github.com/husamql3/pstrack/issues/290).


### PR DESCRIPTION
Docs-only companion to https://github.com/husamql3/pstrack/issues/283. The tooling lives in the `pstrack-db-backups` repo ([PR #1](https://github.com/husamql3/pstrack-db-backups/pull/1)).

## Changes
- **`docs/adr/0006-hourly-encrypted-database-backups.md`** — amendment recording the #283 decisions: RPO ≤ 1h snapshot-only (PITR rejected as approved alternative), object storage rejected with rationale (GitHub already off-VPS; force-push removed for append-only + guarded squash), dual-recipient age encryption, isolated no-egress restore drill, and admin-bot freshness alerting.
- **`TODO.md`** — #283 status. **No box checked** without production evidence, per the #278 completion rule.

## Verification
Biome `bun run check` clean. No code changed (docs only), so typecheck/knip/test/build are N/A.

## Remaining to close #283 (needs key + prod access)
Real-key restore drill evidence, Coolify deploy of the append-only + dual-recipient container, freshness secrets. See `docs/deploy-checklist.md` in the backup repo.
