### PR TITLE
Harden Coolify production deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,9 +187,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [typecheck, lint, knip, test, validate-schema, build, docker-changes]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.docker-changes.outputs.publish == 'true'
+    outputs:
+      image_ref: ${{ steps.image.outputs.ref }}
+      image_digest: ${{ steps.build.outputs.digest }}
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -212,17 +217,18 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            type=sha,prefix=
+            type=sha,format=long,prefix=
             type=ref,event=branch
             type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
           target: runtime-prebuilt
           platforms: linux/amd64
-          provenance: false
-          sbom: false
+          provenance: true
+          sbom: true
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -231,6 +237,27 @@ jobs:
           build-args: |
             VITE_BASE_URL=${{ vars.VITE_BASE_URL }}
             VITE_SENTRY_DSN=${{ vars.VITE_SENTRY_DSN }}
+      - name: Resolve immutable image reference
+        id: image
+        run: |
+          digest="${{ steps.build.outputs.digest }}"
+          test -n "$digest" || {
+            echo "Docker build did not return an image digest" >&2
+            exit 1
+          }
+          echo "ref=${IMAGE_NAME}@${digest}" >> "$GITHUB_OUTPUT"
+          {
+            echo "image=${IMAGE_NAME}@${digest}"
+            echo "digest=${digest}"
+            echo "git_sha=${GITHUB_SHA}"
+          } > image-release.env
+      - name: Upload image release evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-release-${{ github.sha }}
+          path: image-release.env
+          retention-days: 30
+          if-no-files-found: error
 
   deploy-coolify:
     name: Deploy to Coolify
@@ -239,32 +266,36 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment: production
     steps:
-      - name: Trigger Coolify redeploy
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - name: Deploy immutable image with Coolify
         env:
           COOLIFY_API_URL: ${{ secrets.COOLIFY_API_URL }}
           COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
           COOLIFY_APP_UUID: ${{ secrets.COOLIFY_APP_UUID }}
+          PSTRACK_GIT_SHA: ${{ github.sha }}
+          PSTRACK_IMAGE_DIGEST: ${{ needs.publish-docker-image.outputs.image_digest }}
+          PSTRACK_IMAGE_REF: ${{ needs.publish-docker-image.outputs.image_ref }}
         run: |
-          test -n "$COOLIFY_API_URL" || {
-            echo "COOLIFY_API_URL is not set" >&2
-            exit 1
-          }
-          test -n "$COOLIFY_API_TOKEN" || {
-            echo "COOLIFY_API_TOKEN is not set" >&2
-            exit 1
-          }
-          test -n "$COOLIFY_APP_UUID" || {
-            echo "COOLIFY_APP_UUID is not set" >&2
-            exit 1
-          }
-
-          api_url="${COOLIFY_API_URL%/}"
-
-          curl --silent --fail-with-body --show-error \
-            --request GET \
-            --header "Authorization: Bearer $COOLIFY_API_TOKEN" \
-            --header "Accept: application/json" \
-            "$api_url/api/v1/deploy?uuid=$COOLIFY_APP_UUID&force=false"
+          bun run scripts/deploy-coolify.ts
+      - name: Run production smoke checks
+        env:
+          PSTRACK_PRODUCTION_URL: ${{ vars.PSTRACK_PRODUCTION_URL }}
+          PSTRACK_GIT_SHA: ${{ github.sha }}
+          PSTRACK_IMAGE_DIGEST: ${{ needs.publish-docker-image.outputs.image_digest }}
+          JOB_DISPATCH_SECRET: ${{ secrets.JOB_DISPATCH_SECRET }}
+        run: |
+          bun run scripts/smoke-prod.ts
+      - name: Upload deployment evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-evidence-${{ github.sha }}
+          path: |
+            deploy-evidence.json
+            smoke-evidence.json
+          retention-days: 30
+          if-no-files-found: warn
 
   # Trigger.dev production deployment is intentionally paused while production
   # Postgres is private to Coolify. Re-enable after Trigger.dev tasks are

--- a/docs/adr/0007-prebuilt-ghcr-images-for-coolify-deployments.md
+++ b/docs/adr/0007-prebuilt-ghcr-images-for-coolify-deployments.md
@@ -5,3 +5,43 @@ Production deploys to Coolify use Docker images built and verified by GitHub Act
 This keeps the VPS focused on running PStrack, Postgres, Redis, and operational services instead of spending CPU and memory on builds. It also makes `main` the production release gate: CI typechecks, lints, tests, validates the schema, builds the app, publishes a GHCR image, and only then triggers Coolify to deploy that known-good artifact.
 
 Only pushes to `main` publish production images and trigger production Coolify deploys. The `stage` branch remains the integration branch and reaches production through the existing `stage` to `main` release flow.
+
+## Immutable rollout contract
+
+Production deploys use the pushed image digest, not a mutable tag. CI publishes a full commit-SHA tag, a branch tag, and the immutable digest reference (`ghcr.io/husamql3/pstrack@sha256:...`).
+
+The Coolify deploy job sets the application image to the digest reference and injects sanitized runtime metadata:
+
+- `PSTRACK_GIT_SHA`
+- `PSTRACK_IMAGE_DIGEST`
+- `PSTRACK_IMAGE_REF`
+- `PSTRACK_DEPLOYED_AT`
+
+`GET /api/v3/health` returns these fields under `revision` next to DB readiness, so CI can prove the running app is the artifact it just built.
+
+After Coolify accepts the digest deploy, CI polls the returned deployment id until terminal success or failure. A successful trigger response is not considered a deployment.
+
+CI then runs smoke checks for root page availability, health plus database readiness, anonymous auth session behavior, and internal job freshness when `JOB_DISPATCH_SECRET` is available. Deploy and smoke evidence are retained as GitHub Actions artifacts for 30 days.
+
+## Rollback
+
+Use the last known-good digest from the retained `image-release-*` or `deploy-evidence-*` artifact:
+
+```sh
+PSTRACK_ROLLBACK_IMAGE_REF='ghcr.io/husamql3/pstrack@sha256:...' \
+PSTRACK_ROLLBACK_GIT_SHA='previous-good-sha' \
+COOLIFY_API_URL='https://admin.pstrack.app' \
+COOLIFY_API_TOKEN='...' \
+COOLIFY_APP_UUID='...' \
+bun run scripts/rollback-coolify.ts
+```
+
+After rollback completes, run the production smoke checks with the previous digest:
+
+```sh
+PSTRACK_PRODUCTION_URL='https://pstrack.app' \
+PSTRACK_GIT_SHA='previous-good-sha' \
+PSTRACK_IMAGE_DIGEST='sha256:...' \
+JOB_DISPATCH_SECRET='...' \
+bun run scripts/smoke-prod.ts
+```

--- a/scripts/deploy-coolify.ts
+++ b/scripts/deploy-coolify.ts
@@ -1,0 +1,164 @@
+import { writeFile } from "node:fs/promises"
+
+const required = (name: string) => {
+	const value = process.env[name]
+	if (!value) throw new Error(`${name} is not set`)
+	return value
+}
+
+const optionalNumber = (name: string, fallback: number) => {
+	const value = process.env[name]
+	if (!value) return fallback
+	const parsed = Number(value)
+	if (!Number.isFinite(parsed) || parsed <= 0)
+		throw new Error(`${name} must be a positive number`)
+	return parsed
+}
+
+const createConfig = () => ({
+	apiUrl: required("COOLIFY_API_URL").replace(/\/$/, ""),
+	token: required("COOLIFY_API_TOKEN"),
+	appUuid: required("COOLIFY_APP_UUID"),
+	imageRef: required("PSTRACK_IMAGE_REF"),
+	gitSha: required("PSTRACK_GIT_SHA"),
+	imageDigest: required("PSTRACK_IMAGE_DIGEST"),
+	deployedAt: new Date().toISOString(),
+	timeoutMs: optionalNumber("COOLIFY_DEPLOY_TIMEOUT_MS", 15 * 60 * 1000),
+	pollMs: optionalNumber("COOLIFY_DEPLOY_POLL_MS", 10 * 1000),
+})
+
+type Config = ReturnType<typeof createConfig>
+
+const coolifyFetch = async (config: Config, path: string, init?: RequestInit) => {
+	const headers = {
+		Accept: "application/json",
+		Authorization: `Bearer ${config.token}`,
+		"Content-Type": "application/json",
+	}
+	const res = await fetch(`${config.apiUrl}${path}`, {
+		...init,
+		headers: { ...headers, ...init?.headers },
+	})
+	const text = await res.text()
+	let body: unknown = text
+	try {
+		body = text ? JSON.parse(text) : null
+	} catch {
+		body = text
+	}
+
+	if (!res.ok) {
+		throw new Error(`Coolify API ${path} failed (${res.status}): ${text}`)
+	}
+	return body
+}
+
+const readString = (body: unknown, keys: string[]) => {
+	if (!body || typeof body !== "object") return null
+	for (const key of keys) {
+		const value = Reflect.get(body, key)
+		if (typeof value === "string" && value.length > 0) return value
+	}
+	return null
+}
+
+const deploymentIdFrom = (body: unknown) =>
+	readString(body, ["deployment_uuid", "deploymentId", "deployment_id", "id", "uuid"])
+
+const statusFrom = (body: unknown) =>
+	readString(body, ["status", "state", "deployment_status"])?.toLowerCase() ?? "unknown"
+
+const terminalStatus = (value: string) => {
+	if (
+		["success", "succeeded", "finished", "completed", "healthy", "running"].includes(
+			value
+		)
+	) {
+		return "success"
+	}
+	if (["failed", "error", "cancelled", "canceled", "unhealthy"].includes(value))
+		return "failure"
+	return null
+}
+
+const patchApplication = async (config: Config) => {
+	const body = {
+		docker_registry_image_name: config.imageRef,
+		docker_registry_image_tag: "",
+		environment_variables: [
+			`PSTRACK_GIT_SHA=${config.gitSha}`,
+			`PSTRACK_IMAGE_DIGEST=${config.imageDigest}`,
+			`PSTRACK_IMAGE_REF=${config.imageRef}`,
+			`PSTRACK_DEPLOYED_AT=${config.deployedAt}`,
+		],
+	}
+
+	return coolifyFetch(config, `/api/v1/applications/${config.appUuid}`, {
+		method: "PATCH",
+		body: JSON.stringify(body),
+	})
+}
+
+const triggerDeployment = (config: Config) =>
+	coolifyFetch(
+		config,
+		`/api/v1/deploy?uuid=${encodeURIComponent(config.appUuid)}&force=false`,
+		{
+			method: "GET",
+		}
+	)
+
+const fetchDeployment = (config: Config, deploymentId: string) =>
+	coolifyFetch(config, `/api/v1/deployments/${encodeURIComponent(deploymentId)}`, {
+		method: "GET",
+	})
+
+const pollDeployment = async (config: Config, deploymentId: string) => {
+	const startedAt = Date.now()
+	for (;;) {
+		const body = await fetchDeployment(config, deploymentId)
+		const current = statusFrom(body)
+		const terminal = terminalStatus(current)
+		console.log(JSON.stringify({ deploymentId, status: current, body }))
+		if (terminal === "success") return body
+		if (terminal === "failure") {
+			throw new Error(`Coolify deployment ${deploymentId} failed with status ${current}`)
+		}
+		if (Date.now() - startedAt > config.timeoutMs) {
+			throw new Error(`Timed out waiting for Coolify deployment ${deploymentId}`)
+		}
+		await new Promise((resolve) => setTimeout(resolve, config.pollMs))
+	}
+}
+
+export const deployCoolify = async () => {
+	const config = createConfig()
+	const patch = await patchApplication(config)
+	const deployment = await triggerDeployment(config)
+	const deploymentId = deploymentIdFrom(deployment)
+	if (!deploymentId) {
+		throw new Error(
+			`Coolify did not return a deployment id: ${JSON.stringify(deployment)}`
+		)
+	}
+	const finalDeployment = await pollDeployment(config, deploymentId)
+	const evidence = {
+		appUuid: config.appUuid,
+		imageRef: config.imageRef,
+		gitSha: config.gitSha,
+		imageDigest: config.imageDigest,
+		deployedAt: config.deployedAt,
+		patch,
+		deployment,
+		finalDeployment,
+	}
+	console.log(JSON.stringify(evidence, null, 2))
+	await writeFile("deploy-evidence.json", `${JSON.stringify(evidence, null, 2)}\n`)
+}
+
+if (import.meta.main) {
+	deployCoolify().catch((error) => {
+		console.error(error)
+		process.exit(1)
+	})
+}

--- a/scripts/rollback-coolify.ts
+++ b/scripts/rollback-coolify.ts
@@ -1,0 +1,25 @@
+const required = (name: string) => {
+	const value = process.env[name]
+	if (!value) throw new Error(`${name} is not set`)
+	return value
+}
+
+const main = async () => {
+	const previousImageRef = required("PSTRACK_ROLLBACK_IMAGE_REF")
+	const previousDigest = previousImageRef.includes("@sha256:")
+		? `sha256:${previousImageRef.split("@sha256:")[1]}`
+		: previousImageRef
+
+	process.env.PSTRACK_IMAGE_REF = previousImageRef
+	process.env.PSTRACK_IMAGE_DIGEST = previousDigest
+	process.env.PSTRACK_GIT_SHA = process.env.PSTRACK_ROLLBACK_GIT_SHA ?? "rollback"
+	const { deployCoolify } = await import("./deploy-coolify")
+	await deployCoolify()
+}
+
+main().catch((error) => {
+	console.error(error)
+	process.exit(1)
+})
+
+export {}

--- a/scripts/smoke-prod.ts
+++ b/scripts/smoke-prod.ts
@@ -1,0 +1,78 @@
+import { writeFile } from "node:fs/promises"
+
+const required = (name: string) => {
+	const value = process.env[name]
+	if (!value) throw new Error(`${name} is not set`)
+	return value
+}
+
+const baseUrl = required("PSTRACK_PRODUCTION_URL").replace(/\/$/, "")
+const expectedGitSha = required("PSTRACK_GIT_SHA")
+const expectedImageDigest = required("PSTRACK_IMAGE_DIGEST")
+const jobSecret = process.env.JOB_DISPATCH_SECRET
+
+const checkFetch = async (path: string, init?: RequestInit) => {
+	const res = await fetch(`${baseUrl}${path}`, init)
+	if (!res.ok) throw new Error(`${path} returned ${res.status}`)
+	return res
+}
+
+const isFreshnessJob = (value: unknown): value is { jobName: string; fresh: boolean } =>
+	Boolean(
+		value &&
+			typeof value === "object" &&
+			typeof Reflect.get(value, "jobName") === "string" &&
+			typeof Reflect.get(value, "fresh") === "boolean"
+	)
+
+const main = async () => {
+	const root = await checkFetch("/")
+	const rootText = await root.text()
+	if (!rootText.includes("PStrack"))
+		throw new Error("Root smoke check did not find app marker")
+
+	const health = await checkFetch("/api/v3/health")
+	const healthBody = await health.json()
+	if (healthBody.status !== "ok" || healthBody.db !== "ok") {
+		throw new Error(`Health smoke check failed: ${JSON.stringify(healthBody)}`)
+	}
+	if (healthBody.revision?.gitSha !== expectedGitSha) {
+		throw new Error(`Health git SHA mismatch: ${healthBody.revision?.gitSha}`)
+	}
+	if (healthBody.revision?.imageDigest !== expectedImageDigest) {
+		throw new Error(`Health image digest mismatch: ${healthBody.revision?.imageDigest}`)
+	}
+
+	const session = await checkFetch("/api/v3/auth/get-session")
+	const sessionBody = await session.json()
+	if (sessionBody !== null)
+		throw new Error("Anonymous auth session check returned a session")
+
+	if (jobSecret) {
+		const freshness = await checkFetch("/api/v3/internal/jobs/freshness", {
+			headers: { Authorization: `Bearer ${jobSecret}` },
+		})
+		const body = await freshness.json()
+		const rawJobs: unknown = Reflect.get(body, "jobs")
+		const jobs = Array.isArray(rawJobs) ? rawJobs.filter(isFreshnessJob) : []
+		const stale = jobs.filter((job) => !job.fresh)
+		if (stale.length > 0) {
+			throw new Error(`Stale jobs: ${stale.map((job) => job.jobName).join(", ")}`)
+		}
+	}
+
+	const evidence = {
+		baseUrl,
+		gitSha: expectedGitSha,
+		imageDigest: expectedImageDigest,
+		checkedAt: new Date().toISOString(),
+		health: healthBody,
+	}
+	console.log(JSON.stringify(evidence, null, 2))
+	await writeFile("smoke-evidence.json", `${JSON.stringify(evidence, null, 2)}\n`)
+}
+
+main().catch((error) => {
+	console.error(error)
+	process.exit(1)
+})

--- a/src/server/modules/health.test.ts
+++ b/src/server/modules/health.test.ts
@@ -8,6 +8,13 @@ vi.mock("@/server/lib/db", () => ({
 import { db } from "@/server/lib/db"
 import { health } from "@/server/modules/health"
 
+const revision = {
+	gitSha: null,
+	imageDigest: null,
+	imageRef: null,
+	deployedAt: null,
+}
+
 describe("GET /health", () => {
 	afterEach(() => vi.clearAllMocks())
 
@@ -18,7 +25,7 @@ describe("GET /health", () => {
 		const body = await res.json()
 
 		expect(res.status).toBe(200)
-		expect(body).toEqual({ status: "ok", db: "ok" })
+		expect(body).toEqual({ status: "ok", db: "ok", revision })
 	})
 
 	it("returns 503 when DB throws", async () => {
@@ -28,7 +35,12 @@ describe("GET /health", () => {
 		const body = await res.json()
 
 		expect(res.status).toBe(503)
-		expect(body).toEqual({ status: "degraded", db: "error", error: "Connection refused" })
+		expect(body).toEqual({
+			status: "degraded",
+			db: "error",
+			error: "Connection refused",
+			revision,
+		})
 	})
 
 	it("returns 503 on timeout", async () => {
@@ -41,7 +53,12 @@ describe("GET /health", () => {
 		const body = await res.json()
 
 		expect(res.status).toBe(503)
-		expect(body).toEqual({ status: "degraded", db: "error", error: "DB timeout" })
+		expect(body).toEqual({
+			status: "degraded",
+			db: "error",
+			error: "DB timeout",
+			revision,
+		})
 
 		vi.useRealTimers()
 	})

--- a/src/server/modules/health.ts
+++ b/src/server/modules/health.ts
@@ -2,18 +2,26 @@ import { Elysia, status } from "elysia"
 
 import { db } from "@/server/lib/db"
 
+const revision = {
+	gitSha: process.env.PSTRACK_GIT_SHA ?? null,
+	imageDigest: process.env.PSTRACK_IMAGE_DIGEST ?? null,
+	imageRef: process.env.PSTRACK_IMAGE_REF ?? null,
+	deployedAt: process.env.PSTRACK_DEPLOYED_AT ?? null,
+}
+
 async function healthHandler() {
 	try {
 		await Promise.race([
 			db.$queryRaw`SELECT 1`,
 			new Promise((_, reject) => setTimeout(() => reject(new Error("DB timeout")), 3000)),
 		])
-		return { status: "ok", db: "ok" }
+		return { status: "ok", db: "ok", revision }
 	} catch (err) {
 		return status(503, {
 			status: "degraded",
 			db: "error",
 			error: err instanceof Error ? err.message : "unknown",
+			revision,
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Resolves #286 by making the production Docker rollout path digest-based and adding end-to-end deployment verification.

## Changes

- Publish Docker images with full commit-SHA tags, branch tags, SBOM, provenance, and a retained digest evidence artifact.
- Deploy Coolify using the immutable `ghcr.io/...@sha256:...` image ref instead of relying on a mutable branch/latest tag.
- Add runtime revision metadata to `GET /api/v3/health` so CI can verify the running SHA and image digest.
- Add Coolify deploy polling, production smoke checks, retained deploy/smoke evidence, and a one-command rollback helper.
- Document the immutable rollout and rollback flow in the GHCR/Coolify ADR.

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run test -- src/server/modules/health.test.ts`
- pre-commit Biome check
- pre-push typecheck
