### PR TITLE
feat(staging): isolate Vercel environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,8 +32,12 @@ GITHUB_CLIENT_ID=""
 GITHUB_CLIENT_SECRET=""
 
 # Email (Resend) — use onboarding@resend.dev in dev until a sending domain is verified
+EMAIL_TRANSPORT="resend"
 RESEND_API_KEY="re_xxx"
 EMAIL_FROM="PStrack <onboarding@resend.dev>"
+
+# Deployment identity (use "staging" for pstrack.vercel.app)
+PSTRACK_ENVIRONMENT="development"
 
 # Payments (Polar) — get an access token at https://polar.sh/dashboard
 POLAR_ACCESS_TOKEN=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,49 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
 
+  deploy-vercel-staging:
+    name: Deploy Vercel staging
+    runs-on: ubuntu-latest
+    needs: [typecheck, lint, knip, test, validate-schema, build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/stage'
+    environment:
+      name: Staging
+      url: ${{ steps.deploy.outputs.url }}
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      PSTRACK_GIT_SHA: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ./.github/actions/setup
+      - name: Pull staging configuration
+        run: bunx vercel@55.0.0 pull --yes --environment=production
+      - name: Record staging revision
+        run: printf '%s' "$PSTRACK_GIT_SHA" | bunx vercel@55.0.0 env add PSTRACK_GIT_SHA production --force --yes
+      - name: Refresh staging configuration
+        run: bunx vercel@55.0.0 pull --yes --environment=production
+      - name: Build staging artifact
+        run: bunx vercel@55.0.0 build --prod
+      - name: Deploy staging artifact
+        id: deploy
+        run: |
+          url="$(bunx vercel@55.0.0 deploy --prebuilt --prod)"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+      - name: Run staging smoke checks
+        env:
+          PSTRACK_STAGING_URL: ${{ steps.deploy.outputs.url }}
+          PSTRACK_CANONICAL_STAGING_URL: https://pstrack.vercel.app
+        run: bun run smoke:stage
+      - name: Upload staging evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: staging-evidence-${{ github.sha }}
+          path: staging-smoke-evidence.json
+          retention-days: 30
+          if-no-files-found: warn
+
   docker-changes:
     name: Docker change filter
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
           echo "url=$url" >> "$GITHUB_OUTPUT"
       - name: Run staging smoke checks
         env:
-          PSTRACK_STAGING_URL: ${{ steps.deploy.outputs.url }}
+          PSTRACK_STAGING_URL: https://pstrack.vercel.app
           PSTRACK_CANONICAL_STAGING_URL: https://pstrack.vercel.app
         run: bun run smoke:stage
       - name: Upload staging evidence

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ count.txt
 .vinxi
 __unconfig*
 todos.json
+deploy-evidence.json
+smoke-evidence.json
+staging-smoke-evidence.json
 generated/
 .vercel
 

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -21,4 +21,10 @@ Move changes from `stage` to `main` through a deliberate `stage` to `main` pull 
 
 ## Deployment
 
-No deployment automation is tied to `stage` yet. Coolify staging wiring will be handled separately.
+- A push to `stage` deploys the verified commit to Vercel staging at
+  `https://pstrack.vercel.app` and runs staging smoke checks.
+- A push to `main` builds an immutable OCI image and deploys it to Coolify
+  production after approval through the GitHub `Production` environment.
+- Promotion is a deliberate `stage` to `main` pull request. The Vercel and
+  Coolify runtime artifacts differ, so revision identity and both environment
+  smoke checks are the promotion evidence.

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -1,0 +1,55 @@
+# Staging Operations
+
+PStrack staging runs in the existing Vercel project at
+`https://pstrack.vercel.app`. Vercel's `production` target is application
+staging; application production remains on Coolify.
+
+## Isolation contract
+
+- Neon PostgreSQL and Upstash Redis use staging-only free-tier resources.
+- Google and GitHub OAuth use dedicated staging applications and callbacks.
+- Polar uses its sandbox catalog and webhook.
+- Trigger.dev uses a staging environment and staging-only dispatch secret.
+- Sentry events use the `staging` environment.
+- `EMAIL_TRANSPORT=log` is mandatory and `RESEND_API_KEY` must be absent.
+- Only deterministic synthetic seed users and groups may exist in staging.
+
+Run `bun run env:sync:stage:dry-run` before `bun run env:sync:stage`. The sync
+script accepts only its explicit allowlist; `.env.stage` must remain ignored and
+mode `0600`.
+
+## Reset and reseed
+
+This procedure destroys all staging data. Confirm the target is staging and
+obtain explicit destructive-operation approval before running it.
+
+1. Pull the Vercel staging environment into a temporary ignored file.
+2. Verify `PSTRACK_ENVIRONMENT=staging`, `EMAIL_TRANSPORT=log`, the database host
+   is the dedicated Neon staging project, and no production host is present.
+3. Run `bun run db:reset` against that environment. Prisma reapplies migrations
+   and the deterministic master seed.
+4. Run the staging smoke checks and verify only synthetic `@dev.test` seed
+   accounts are present.
+5. Delete the temporary environment file.
+
+Never restore or clone production data into staging.
+
+## Teardown
+
+1. Disable the `deploy-vercel-staging` workflow job or its Staging environment.
+2. Remove the Vercel deployment aliases and staging environment variables.
+3. Delete the dedicated Neon and Upstash resources only after confirming their
+   identifiers do not match production.
+4. Delete the staging OAuth applications, Polar sandbox webhook, Trigger.dev
+   environment, and staging alert rules.
+5. Retain only sanitized deployment and smoke evidence.
+
+## Promotion model
+
+Vercel Functions cannot execute the OCI image used by Coolify, so one binary
+artifact cannot run in both environments. The approved equivalent is the same
+reviewed source revision and migration set: Vercel records and verifies the
+staging Git SHA; the deliberate `stage` to `main` promotion then builds the
+immutable production image, whose digest and Git SHA are verified by the
+production deployment workflow. Production still requires approval from
+`husamql3`.

--- a/docs/adr/0012-branch-mapped-production-and-staging-domains.md
+++ b/docs/adr/0012-branch-mapped-production-and-staging-domains.md
@@ -1,9 +1,27 @@
-# Production and Staging on Coolify
+# Coolify Production and Vercel Staging
 
 PStrack maps `main` to the production domain `https://pstrack.app` on Coolify.
 
 Production deploys are built from `main` and published as production GHCR images for Coolify. Coolify pulls the GHCR image and runs the application on the VPS.
 
-The earlier Vercel staging setup is retired as part of the full Coolify migration. A future `stage.pstrack.app` environment should be created on Coolify with its own database, Redis, and sandbox/test integrations.
+The existing Vercel project at `https://pstrack.vercel.app` is the staging
+environment. Its Vercel `production` target is application staging and deploys
+only from the repository's `stage` branch. It uses a dedicated Neon database,
+Upstash Redis, OAuth applications, Polar sandbox catalog, Trigger.dev
+environment, staging-tagged Sentry events, and `EMAIL_TRANSPORT=log`.
+
+No Coolify production credential or data may be copied into Vercel. Staging
+configuration is synchronized from the ignored `.env.stage` file through an
+explicit allowlist. The staging database contains synthetic seed data only.
+
+Every `stage` deployment must pass root, database-backed health, anonymous auth,
+revision, environment identity, and log-only email smoke checks. Production
+promotion remains gated by the GitHub `Production` environment, where
+`husamql3` is the required reviewer.
+
+Vercel Functions and Coolify's OCI runtime cannot consume one binary artifact.
+Promotion therefore preserves the reviewed source revision and migration set,
+then records environment-specific immutable deployment evidence. This is the
+portable parity boundary; operational procedures live in `docs/STAGING.md`.
 
 The Coolify admin dashboard uses `https://admin.pstrack.app`.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
 		"env:sync:trigger": "bun run scripts/sync-trigger.ts",
 		"env:sync:gh": "bun run scripts/sync-gh.ts",
 		"env:sync:stage": "bun run scripts/sync-vercel.ts",
+		"env:sync:stage:dry-run": "bun run scripts/sync-vercel.ts --dry-run",
+		"smoke:stage": "bun run scripts/smoke-stage.ts",
 		"jobs:reconcile-mark-missed": "bun run scripts/reconcile-mark-missed.ts",
 		"points:reconcile": "bun run scripts/reconcile-points.ts"
 	},

--- a/prisma/seed-groups.ts
+++ b/prisma/seed-groups.ts
@@ -135,7 +135,7 @@ export async function seedGroups() {
 			where: { email: u.email },
 			update: {},
 			create: {
-				id: crypto.randomUUID(),
+				id: `seed-user-${u.username}`,
 				name: u.name,
 				email: u.email,
 				username: u.username,
@@ -157,6 +157,7 @@ export async function seedGroups() {
 			where: { slug: g.slug },
 			update: {},
 			create: {
+				id: `seed-group-${g.slug}`,
 				slug: g.slug,
 				type: g.type as "PUBLIC" | "PRIVATE",
 				roadmap: g.roadmap,

--- a/scripts/smoke-stage.ts
+++ b/scripts/smoke-stage.ts
@@ -18,8 +18,9 @@ const checkFetch = async (path: string) => {
 
 const main = async () => {
 	const root = await checkFetch("/")
-	if (!(await root.text()).includes("PStrack")) {
-		throw new Error("Root smoke check did not find app marker")
+	const rootHtml = await root.text()
+	if (!rootHtml.startsWith("<!DOCTYPE html>")) {
+		throw new Error("Root smoke check did not find the application shell")
 	}
 
 	const health = await checkFetch("/api/v3/health")

--- a/scripts/smoke-stage.ts
+++ b/scripts/smoke-stage.ts
@@ -1,0 +1,70 @@
+import { writeFile } from "node:fs/promises"
+
+const required = (name: string) => {
+	const value = process.env[name]
+	if (!value) throw new Error(`${name} is not set`)
+	return value
+}
+
+const baseUrl = required("PSTRACK_STAGING_URL").replace(/\/$/, "")
+const canonicalUrl = required("PSTRACK_CANONICAL_STAGING_URL").replace(/\/$/, "")
+const expectedGitSha = required("PSTRACK_GIT_SHA")
+
+const checkFetch = async (path: string) => {
+	const response = await fetch(`${baseUrl}${path}`)
+	if (!response.ok) throw new Error(`${path} returned ${response.status}`)
+	return response
+}
+
+const main = async () => {
+	const root = await checkFetch("/")
+	if (!(await root.text()).includes("PStrack")) {
+		throw new Error("Root smoke check did not find app marker")
+	}
+
+	const health = await checkFetch("/api/v3/health")
+	const healthBody = await health.json()
+	if (healthBody.status !== "ok" || healthBody.db !== "ok") {
+		throw new Error(`Health smoke check failed: ${JSON.stringify(healthBody)}`)
+	}
+	if (healthBody.runtime?.environment !== "staging") {
+		throw new Error("Deployment does not identify itself as staging")
+	}
+	if (healthBody.runtime?.emailTransport !== "log") {
+		throw new Error("Staging email transport is not log-only")
+	}
+	if (healthBody.revision?.gitSha !== expectedGitSha) {
+		throw new Error(`Health git SHA mismatch: ${healthBody.revision?.gitSha}`)
+	}
+
+	const session = await checkFetch("/api/v3/auth/get-session")
+	if ((await session.json()) !== null) {
+		throw new Error("Anonymous auth session check returned a session")
+	}
+
+	const canonicalHealth = await fetch(`${canonicalUrl}/api/v3/health`)
+	if (!canonicalHealth.ok) {
+		throw new Error(`Canonical health returned ${canonicalHealth.status}`)
+	}
+	const canonicalHealthBody = await canonicalHealth.json()
+	if (canonicalHealthBody.revision?.gitSha !== expectedGitSha) {
+		throw new Error(
+			`Canonical staging revision mismatch: ${canonicalHealthBody.revision?.gitSha}`
+		)
+	}
+
+	const evidence = {
+		baseUrl,
+		canonicalUrl,
+		gitSha: expectedGitSha,
+		checkedAt: new Date().toISOString(),
+		health: healthBody,
+	}
+	console.log(JSON.stringify(evidence, null, 2))
+	await writeFile("staging-smoke-evidence.json", `${JSON.stringify(evidence, null, 2)}\n`)
+}
+
+main().catch((error) => {
+	console.error(error)
+	process.exit(1)
+})

--- a/scripts/sync-vercel.ts
+++ b/scripts/sync-vercel.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import { spawn } from "node:child_process"
 import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { parse } from "dotenv"
@@ -7,6 +8,40 @@ const STAGE_ENV_FILE = resolve(import.meta.dirname, "../.env.stage")
 const PROJECT_LINK_FILE = resolve(import.meta.dirname, "../.vercel/project.json")
 const VERCEL_API = process.env.VERCEL_API_URL ?? "https://api.vercel.com"
 const TARGET = "production"
+
+// Vercel's production target is PStrack's staging environment. Keep this list
+// explicit so retired or production-only credentials can never hitch a ride
+// from a developer's local env file.
+const STAGING_KEYS = [
+	"BETTER_AUTH_API_KEY",
+	"BETTER_AUTH_SECRET",
+	"BETTER_AUTH_URL",
+	"DATABASE_URL",
+	"DIRECT_URL",
+	"EMAIL_FROM",
+	"EMAIL_TRANSPORT",
+	"GITHUB_CLIENT_ID",
+	"GITHUB_CLIENT_SECRET",
+	"GOOGLE_CLIENT_ID",
+	"GOOGLE_CLIENT_SECRET",
+	"JOB_DISPATCH_SECRET",
+	"POLAR_ACCESS_TOKEN",
+	"POLAR_PRODUCT_ID",
+	"POLAR_SERVER",
+	"POLAR_SUCCESS_URL",
+	"POLAR_WEBHOOK_SECRET",
+	"PSTRACK_ENVIRONMENT",
+	"SENTRY_DSN",
+	"SENTRY_ENVIRONMENT",
+	"SENTRY_TRACES_SAMPLE_RATE",
+	"UPSTASH_REDIS_REST_TOKEN",
+	"UPSTASH_REDIS_REST_URL",
+	"VITE_BASE_URL",
+	"VITE_SENTRY_DSN",
+	"VITE_SENTRY_REPLAY_ERROR_SAMPLE_RATE",
+	"VITE_SENTRY_REPLAY_SESSION_SAMPLE_RATE",
+	"VITE_SENTRY_TRACES_SAMPLE_RATE",
+]
 
 // Not app config — never pushed to Vercel.
 const SKIP_KEYS = new Set([
@@ -37,52 +72,96 @@ const isUnfilled = (value: string) => !value || value.startsWith("<")
 
 async function main() {
 	const vars = readStageEnv()
+	const dryRun = process.argv.includes("--dry-run")
 
-	const token = vars.VERCEL_TOKEN ?? process.env.VERCEL_TOKEN
-	if (!token || isUnfilled(token)) {
-		console.error("Missing VERCEL_TOKEN in .env.stage or environment")
-		process.exit(1)
+	if (vars.EMAIL_TRANSPORT !== "log") {
+		throw new Error('Staging requires EMAIL_TRANSPORT="log"')
+	}
+	if (vars.PSTRACK_ENVIRONMENT !== "staging") {
+		throw new Error('Staging requires PSTRACK_ENVIRONMENT="staging"')
+	}
+	if (vars.POLAR_SERVER !== "sandbox") {
+		throw new Error('Staging requires POLAR_SERVER="sandbox"')
 	}
 
+	const token = vars.VERCEL_TOKEN ?? process.env.VERCEL_TOKEN
 	const { projectId, orgId } = readProjectLink()
 	const query = new URLSearchParams({ upsert: "true", teamId: orgId })
 	const url = `${VERCEL_API}/v10/projects/${projectId}/env?${query}`
 
-	const entries = Object.entries(vars).filter(([key]) => !SKIP_KEYS.has(key))
+	const entries = STAGING_KEYS.map(
+		(key) => [key, vars[key] ?? ""] satisfies [string, string]
+	)
 	const toSync = entries.filter(([, value]) => !isUnfilled(value))
 	const skipped = entries.filter(([, value]) => isUnfilled(value))
+	const excluded = Object.keys(vars).filter(
+		(key) => !STAGING_KEYS.includes(key) && !SKIP_KEYS.has(key)
+	)
 
 	console.log(
-		`\nSyncing ${toSync.length} variables → Vercel project ${projectId} (${TARGET})\n`
+		`\n${dryRun ? "Would sync" : "Syncing"} ${toSync.length} allowlisted variables → Vercel project ${projectId} (${TARGET})\n`
 	)
 
 	let synced = 0
 	let failed = 0
 
-	for (const [key, value] of toSync) {
-		const res = await fetch(url, {
-			method: "POST",
-			headers: {
-				Authorization: `Bearer ${token}`,
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({ key, value, type: "encrypted", target: [TARGET] }),
-		})
-
-		if (res.ok) {
-			console.log(`  ~ synced   ${key}`)
-			synced++
-		} else {
-			console.error(`  x failed   ${key}: ${res.status} ${await res.text()}`)
-			failed++
+	if (dryRun) {
+		for (const [key] of toSync) {
+			console.log(`  ~ allowed  ${key}`)
 		}
+	} else {
+		let nextIndex = 0
+		const syncNext = async (): Promise<void> => {
+			const entry = toSync[nextIndex]
+			nextIndex++
+			if (!entry) return
+			const [key, value] = entry
+			const ok =
+				token && !isUnfilled(token)
+					? await fetch(url, {
+							method: "POST",
+							headers: {
+								Authorization: `Bearer ${token}`,
+								"Content-Type": "application/json",
+							},
+							body: JSON.stringify({ key, value, type: "encrypted", target: [TARGET] }),
+						}).then(async (res) => {
+							if (!res.ok)
+								console.error(`  x failed   ${key}: ${res.status} ${await res.text()}`)
+							return res.ok
+						})
+					: await new Promise<boolean>((done) => {
+							const child = spawn(
+								"vercel",
+								["env", "add", key, TARGET, "--force", "--sensitive", "--yes"],
+								{ stdio: ["pipe", "ignore", "ignore"] }
+							)
+							child.once("close", (code) => done(code === 0))
+							child.stdin.end(value)
+						})
+
+			if (ok) {
+				console.log(`  ~ synced   ${key}`)
+				synced++
+			} else {
+				console.error(`  x failed   ${key}`)
+				failed++
+			}
+			await syncNext()
+		}
+		await Promise.all(Array.from({ length: Math.min(4, toSync.length) }, syncNext))
 	}
 
 	for (const [key] of skipped) {
 		console.log(`  - skipped  ${key} (unfilled placeholder)`)
 	}
+	for (const key of excluded) {
+		console.log(`  - excluded ${key} (not in staging allowlist)`)
+	}
 
-	console.log(`\nDone - ${synced} synced, ${failed} failed, ${skipped.length} skipped\n`)
+	console.log(
+		`\nDone - ${dryRun ? toSync.length : synced} ${dryRun ? "allowed" : "synced"}, ${failed} failed, ${skipped.length} skipped, ${excluded.length} excluded\n`
+	)
 	if (failed > 0) process.exit(1)
 }
 

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -74,6 +74,30 @@ describe("resolveSkipValidation", () => {
 })
 
 describe("buildEnv fail-fast", () => {
+	it("allows log-only staging without a Resend credential", () => {
+		const env = buildEnv({
+			isServer: true,
+			skipValidation: false,
+			runtimeEnv: {
+				...validServerEnv,
+				EMAIL_TRANSPORT: "log",
+				RESEND_API_KEY: undefined,
+			},
+		})
+		expect(env.EMAIL_TRANSPORT).toBe("log")
+		expect(env.RESEND_API_KEY).toBeUndefined()
+	})
+
+	it("rejects a sending credential in log-only staging", () => {
+		expect(() =>
+			buildEnv({
+				isServer: true,
+				skipValidation: false,
+				runtimeEnv: { ...validServerEnv, EMAIL_TRANSPORT: "log" },
+			})
+		).toThrow("RESEND_API_KEY must be absent when EMAIL_TRANSPORT is log")
+	})
+
 	it("throws when a required server var is missing and validation is not skipped", () => {
 		const spy = vi.spyOn(console, "error").mockImplementation(() => {})
 		expect(() =>

--- a/src/env.ts
+++ b/src/env.ts
@@ -35,7 +35,8 @@ const server = {
 	GITHUB_CLIENT_SECRET: z.string().min(1),
 
 	// email
-	RESEND_API_KEY: z.string().min(1),
+	EMAIL_TRANSPORT: z.enum(["resend", "log"]).default("resend"),
+	RESEND_API_KEY: z.string().min(1).optional(),
 	EMAIL_FROM: z.string().default("PStrack <info@pstrack.app>"),
 
 	// payments
@@ -58,6 +59,9 @@ const server = {
 	// observability
 	AXIOM_TOKEN: z.string().min(1).optional(),
 	AXIOM_DATASET: z.string().min(1).optional(),
+
+	// deployment identity (non-secret; exposed by the health endpoint)
+	PSTRACK_ENVIRONMENT: z.enum(["development", "staging", "production"]).optional(),
 }
 
 const client = {
@@ -105,8 +109,8 @@ export const buildEnv = ({
 	runtimeEnv: Record<string, string | undefined>
 	isServer: boolean
 	skipValidation: boolean
-}) =>
-	createEnv({
+}) => {
+	const validated = createEnv({
 		server,
 		client,
 		clientPrefix: "VITE_",
@@ -114,6 +118,18 @@ export const buildEnv = ({
 		isServer,
 		skipValidation,
 	})
+
+	if (!skipValidation && isServer) {
+		if (validated.EMAIL_TRANSPORT === "resend" && !validated.RESEND_API_KEY) {
+			throw new Error("RESEND_API_KEY is required when EMAIL_TRANSPORT is resend")
+		}
+		if (validated.EMAIL_TRANSPORT === "log" && validated.RESEND_API_KEY) {
+			throw new Error("RESEND_API_KEY must be absent when EMAIL_TRANSPORT is log")
+		}
+	}
+
+	return validated
+}
 
 const isServer = typeof window === "undefined"
 

--- a/src/server/lib/email.test.ts
+++ b/src/server/lib/email.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+	send: vi.fn(),
+	debug: vi.fn(),
+	info: vi.fn(),
+}))
+
+vi.mock("resend", () => ({
+	Resend: class {
+		emails = { send: mocks.send }
+	},
+}))
+
+vi.mock("@/env", () => ({
+	env: {
+		EMAIL_TRANSPORT: "log",
+		RESEND_API_KEY: "unused-in-log-mode",
+	},
+}))
+
+vi.mock("@/server/lib/logger", () => ({
+	logger: { debug: mocks.debug, info: mocks.info },
+}))
+
+import { sendEmail } from "@/server/lib/email"
+
+describe("sendEmail", () => {
+	beforeEach(() => vi.clearAllMocks())
+
+	it("logs metadata without contacting Resend when transport is log", async () => {
+		const result = await sendEmail({
+			from: "PStrack <stage@pstrack.app>",
+			to: "person@example.test",
+			subject: "Staging message",
+			html: "<p>synthetic</p>",
+		})
+
+		expect(result).toBeNull()
+		expect(mocks.send).not.toHaveBeenCalled()
+		expect(mocks.info).toHaveBeenCalledWith(
+			{ recipientCount: 1 },
+			"email suppressed by log transport"
+		)
+	})
+})

--- a/src/server/lib/email.ts
+++ b/src/server/lib/email.ts
@@ -26,6 +26,14 @@ export const resend: Resend = new Proxy({} as Resend, {
 })
 
 export const sendEmail = async (payload: CreateEmailOptions) => {
+	if (env.EMAIL_TRANSPORT === "log") {
+		logger.info(
+			{ recipientCount: Array.isArray(payload.to) ? payload.to.length : 1 },
+			"email suppressed by log transport"
+		)
+		return null
+	}
+
 	const result = await resend.emails.send(payload)
 	if (result.error) {
 		logger.error(

--- a/src/server/modules/health.test.ts
+++ b/src/server/modules/health.test.ts
@@ -15,6 +15,11 @@ const revision = {
 	deployedAt: null,
 }
 
+const runtime = {
+	environment: null,
+	emailTransport: "resend",
+}
+
 describe("GET /health", () => {
 	afterEach(() => vi.clearAllMocks())
 
@@ -25,7 +30,7 @@ describe("GET /health", () => {
 		const body = await res.json()
 
 		expect(res.status).toBe(200)
-		expect(body).toEqual({ status: "ok", db: "ok", revision })
+		expect(body).toEqual({ status: "ok", db: "ok", revision, runtime })
 	})
 
 	it("returns 503 when DB throws", async () => {
@@ -40,6 +45,7 @@ describe("GET /health", () => {
 			db: "error",
 			error: "Connection refused",
 			revision,
+			runtime,
 		})
 	})
 
@@ -58,6 +64,7 @@ describe("GET /health", () => {
 			db: "error",
 			error: "DB timeout",
 			revision,
+			runtime,
 		})
 
 		vi.useRealTimers()

--- a/src/server/modules/health.ts
+++ b/src/server/modules/health.ts
@@ -3,10 +3,15 @@ import { Elysia, status } from "elysia"
 import { db } from "@/server/lib/db"
 
 const revision = {
-	gitSha: process.env.PSTRACK_GIT_SHA ?? null,
+	gitSha: process.env.PSTRACK_GIT_SHA ?? process.env.VERCEL_GIT_COMMIT_SHA ?? null,
 	imageDigest: process.env.PSTRACK_IMAGE_DIGEST ?? null,
 	imageRef: process.env.PSTRACK_IMAGE_REF ?? null,
 	deployedAt: process.env.PSTRACK_DEPLOYED_AT ?? null,
+}
+
+const runtime = {
+	environment: process.env.PSTRACK_ENVIRONMENT ?? null,
+	emailTransport: process.env.EMAIL_TRANSPORT ?? "resend",
 }
 
 async function healthHandler() {
@@ -15,13 +20,14 @@ async function healthHandler() {
 			db.$queryRaw`SELECT 1`,
 			new Promise((_, reject) => setTimeout(() => reject(new Error("DB timeout")), 3000)),
 		])
-		return { status: "ok", db: "ok", revision }
+		return { status: "ok", db: "ok", revision, runtime }
 	} catch (err) {
 		return status(503, {
 			status: "degraded",
 			db: "error",
 			error: err instanceof Error ? err.message : "unknown",
 			revision,
+			runtime,
 		})
 	}
 }


### PR DESCRIPTION
## What changed

- deploy pushes to `stage` into the existing Vercel staging project
- isolate Vercel configuration behind an explicit staging allowlist
- enforce credential-free `EMAIL_TRANSPORT=log` behavior
- add revision, canonical-domain, database, and anonymous-session smoke checks
- make seed user/group identifiers deterministic
- document reset, reseed, teardown, and the Vercel/Coolify promotion boundary

## Why

Issue #287 found that Vercel still carried production-era credentials and had no controlled staging deployment or verification path after production moved to Coolify.

## External staging state

- Vercel Production target now represents application staging
- dedicated Neon, Upstash, OAuth, Polar sandbox, Trigger.dev, and Sentry staging settings are allowlisted
- Resend and 28 other legacy variables were removed from the Vercel Production target
- GitHub `Staging` environment is restricted to the `stage` branch
- GitHub `Production` already requires `husamql3` approval

## Validation

- `bun run typecheck`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run env:sync:stage:dry-run`
- two-axis standards/spec review against #287

`bun run knip` still reports the repository's existing non-blocking baseline tracked by #293.

## Remaining live verification

After merge to `stage`, verify the Vercel deployment and canonical alias, then complete browser, OAuth, Polar, Redis, Trigger.dev, and Sentry sandbox checks before closing #287.

Closes no issue; advances #287.
