### PR TITLE
docs: update Coolify admin URL

### DIFF
--- a/docs/adr/0007-prebuilt-ghcr-images-for-coolify-deployments.md
+++ b/docs/adr/0007-prebuilt-ghcr-images-for-coolify-deployments.md
@@ -30,7 +30,7 @@ Use the last known-good digest from the retained `image-release-*` or `deploy-ev
 ```sh
 PSTRACK_ROLLBACK_IMAGE_REF='ghcr.io/husamql3/pstrack@sha256:...' \
 PSTRACK_ROLLBACK_GIT_SHA='previous-good-sha' \
-COOLIFY_API_URL='https://admin.pstrack.app' \
+COOLIFY_API_URL='https://coolify.pstrack.app' \
 COOLIFY_API_TOKEN='...' \
 COOLIFY_APP_UUID='...' \
 bun run scripts/rollback-coolify.ts

--- a/docs/adr/0012-branch-mapped-production-and-staging-domains.md
+++ b/docs/adr/0012-branch-mapped-production-and-staging-domains.md
@@ -24,4 +24,4 @@ Promotion therefore preserves the reviewed source revision and migration set,
 then records environment-specific immutable deployment evidence. This is the
 portable parity boundary; operational procedures live in `docs/STAGING.md`.
 
-The Coolify admin dashboard uses `https://admin.pstrack.app`.
+The Coolify admin dashboard uses `https://coolify.pstrack.app`.


### PR DESCRIPTION
## Summary

- update Coolify admin dashboard references from `admin.pstrack.app` to `coolify.pstrack.app`
- keep rollback command documentation aligned with the current Coolify host

## Validation

- bun run check
- lefthook pre-push: prisma generate && tsc --noEmit
