### PR TITLE
Fix auto PR token fallback

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -28,11 +28,32 @@ jobs:
 
       - name: Open or update the stage -> main PR
         env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN || github.token }}
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           BASE: main
           HEAD: stage
         run: |
           set -euo pipefail
+
+          run_gh() {
+            local token="$1"
+            shift
+            GH_TOKEN="$token" gh "$@"
+          }
+
+          try_gh() {
+            local label="$1"
+            local token="$2"
+            shift 2
+
+            if [ -z "$token" ]; then
+              echo "::notice::Skipping ${label}; token is not configured."
+              return 1
+            fi
+
+            echo "Trying ${label}."
+            run_gh "$token" "$@"
+          }
 
           git fetch origin "$BASE" --quiet
 
@@ -50,26 +71,30 @@ jobs:
             printf '_Opened or updated automatically from `%s`._\n' "$HEAD"
           } > pr-body.md
 
-          gh auth status
-
-          existing=$(gh pr list --base "$BASE" --head "$HEAD" --state open \
+          pr_token="${PAT_TOKEN:-$GITHUB_TOKEN}"
+          existing=$(run_gh "$pr_token" pr list --base "$BASE" --head "$HEAD" --state open \
             --json number --jq '.[0].number // empty')
 
           if [ -n "$existing" ]; then
-            gh pr edit "$existing" --body-file pr-body.md
+            run_gh "$pr_token" pr edit "$existing" --body-file pr-body.md
             echo "Updated existing PR #${existing}"
           else
-            if ! create_output=$(gh pr create --base "$BASE" --head "$HEAD" \
+            if try_gh "PAT_TOKEN" "$PAT_TOKEN" pr create --base "$BASE" --head "$HEAD" \
               --title "Auto PR: stage -> main" \
-              --body-file pr-body.md 2>&1); then
-              printf '%s\n' "$create_output"
-              if printf '%s\n' "$create_output" | grep -q "GitHub Actions is not permitted to create or approve pull requests"; then
-                {
-                  echo "::error::GitHub blocked the default GITHUB_TOKEN from creating pull requests."
-                  echo "Enable Settings -> Actions -> General -> Workflow permissions -> Allow GitHub Actions to create and approve pull requests, or add a PAT_TOKEN secret with pull request creation permissions."
-                } >&2
-              fi
-              exit 1
+              --body-file pr-body.md; then
+              echo "Created new stage -> main PR with PAT_TOKEN"
+              exit 0
             fi
-            echo "Created new stage -> main PR"
+
+            if try_gh "GITHUB_TOKEN" "$GITHUB_TOKEN" pr create --base "$BASE" --head "$HEAD" \
+              --title "Auto PR: stage -> main" \
+              --body-file pr-body.md; then
+              echo "Created new stage -> main PR with GITHUB_TOKEN"
+              exit 0
+            fi
+
+            {
+              echo "::warning::Could not create the stage -> main PR automatically."
+              echo "Fix by either updating PAT_TOKEN with pull request creation access to husamql3/pstrack, or enabling Settings -> Actions -> General -> Workflow permissions -> Allow GitHub Actions to create and approve pull requests."
+            } >&2
           fi

--- a/docs/agdr/AgDR-0003-auto-pr-stage-to-main.md
+++ b/docs/agdr/AgDR-0003-auto-pr-stage-to-main.md
@@ -4,7 +4,7 @@
 
 ## Correction
 
-The first implementation depended only on the default `github.token` and failed when repository settings blocked GitHub Actions from creating pull requests. The workflow now prefers `secrets.PAT_TOKEN`, falls back to `github.token`, and supports `workflow_dispatch` for manual runs.
+The first implementation depended only on the default `github.token` and failed when repository settings blocked GitHub Actions from creating pull requests. The workflow now tries `secrets.PAT_TOKEN`, falls back to `github.token`, warns when both tokens are blocked, and supports `workflow_dispatch` for manual runs.
 
 The automatic `push: stage` trigger remains enabled.
 
@@ -34,7 +34,8 @@ Chosen: **`gh`-CLI workflow, `push: stage` trigger, `PAT_TOKEN` auth, changelog 
 ## Consequences
 
 - Every push to `stage` opens or refreshes one `Auto PR: stage -> main`; pstrack CI runs on it.
-- The workflow uses `PAT_TOKEN` when present, otherwise `GITHUB_TOKEN` with explicit `pull-requests: write` permission.
+- The workflow tries `PAT_TOKEN` first, then `GITHUB_TOKEN` with explicit `pull-requests: write` permission.
+- If both tokens are blocked, the workflow emits setup guidance as a warning instead of failing every push to `stage`.
 - The workflow can be run manually from GitHub Actions.
 - The `stage → main` PR is never auto-merged; merge still requires human review.
 


### PR DESCRIPTION
## Summary
- try PAT_TOKEN and then GITHUB_TOKEN when creating the automated stage-to-main PR
- warn instead of failing every stage push when both tokens are blocked by GitHub permissions
- document the token fallback and warning behavior

## Verification
- git diff --check
- YAML parse check
- pre-push typecheck