### PR TITLE
fix(email): redact delivery logs and errors

### DIFF
--- a/src/server/jobs/jobs.service.test.ts
+++ b/src/server/jobs/jobs.service.test.ts
@@ -5,6 +5,11 @@ const mocks = vi.hoisted(() => ({
 	logSystemEvent: vi.fn(),
 	auditCachedTotals: vi.fn(),
 	notifyAdmin: vi.fn(),
+	sendEmail: vi.fn(),
+	captureServerException: vi.fn(),
+	getDailyDigestRecipients: vi.fn(),
+	assignDailyProblems: vi.fn(),
+	getDailySolveStats: vi.fn(),
 }))
 
 vi.mock("@/env", () => ({
@@ -22,14 +27,19 @@ vi.mock("@/server/groups/groups.notifications", () => ({
 }))
 vi.mock("@/server/lib/bot", () => ({ notifyAdmin: mocks.notifyAdmin }))
 vi.mock("@/server/lib/db", () => ({ db: {} }))
-vi.mock("@/server/lib/email", () => ({ resend: { batch: { send: vi.fn() } } }))
-vi.mock("@/server/lib/sentry", () => ({ captureServerException: vi.fn() }))
+vi.mock("@/server/lib/email", () => ({ sendEmail: mocks.sendEmail }))
+vi.mock("@/server/lib/sentry", () => ({
+	captureServerException: mocks.captureServerException,
+}))
 vi.mock("@/server/points/points.reconciliation", () => ({
 	auditCachedTotals: mocks.auditCachedTotals,
 }))
 vi.mock("@/server/problems/problems.dao", () => ({
 	problemsDao: {
 		markMissedForDate: mocks.markMissedForDate,
+		getDailyDigestRecipients: mocks.getDailyDigestRecipients,
+		assignDailyProblems: mocks.assignDailyProblems,
+		getDailySolveStats: mocks.getDailySolveStats,
 	},
 }))
 vi.mock("@/server/system-events/system-events.dao", () => ({
@@ -46,6 +56,7 @@ describe("app-owned jobs", () => {
 		mocks.markMissedForDate.mockResolvedValue({ missed: 2, warned: 1, removed: 0 })
 		mocks.logSystemEvent.mockResolvedValue(undefined)
 		mocks.notifyAdmin.mockResolvedValue(undefined)
+		mocks.sendEmail.mockResolvedValue(undefined)
 	})
 
 	it("reconciles only the explicitly requested missed day", async () => {
@@ -111,5 +122,40 @@ describe("app-owned jobs", () => {
 		expect(mocks.notifyAdmin).toHaveBeenCalledWith("points.reconciliation_failed", {
 			occurredAt: expect.any(String),
 		})
+	})
+
+	it("captures daily digest failures without recipient identity", async () => {
+		mocks.assignDailyProblems.mockResolvedValue({ assigned: 1 })
+		mocks.getDailyDigestRecipients.mockResolvedValue([
+			{
+				email: "recipient-sentinel@example.test",
+				name: "Recipient Sentinel",
+				groupSlug: "sentinel-group",
+				problemTitle: "Sentinel Problem",
+				difficulty: "EASY",
+				topic: "Arrays",
+				problemSlug: "sentinel-problem",
+			},
+		])
+		mocks.getDailySolveStats.mockResolvedValue({
+			totalSolves: 0,
+			activeUsers: 1,
+			newUsers: 0,
+			pausesUsed: 0,
+			handleChanges: 0,
+		})
+		mocks.sendEmail.mockRejectedValueOnce(new Error("Email send failed"))
+
+		await executeJob("assign-daily-problem", new Date("2026-07-14T00:00:00.000Z"))
+
+		expect(mocks.captureServerException).toHaveBeenCalledWith(expect.any(Error), {
+			tag: "email:daily-digest",
+			dateKey: "2026-07-14",
+			batchIndex: 0,
+			recipientCount: 1,
+		})
+		expect(JSON.stringify(mocks.captureServerException.mock.calls)).not.toContain(
+			"recipient-sentinel@example.test"
+		)
 	})
 })

--- a/src/server/jobs/jobs.service.ts
+++ b/src/server/jobs/jobs.service.ts
@@ -52,9 +52,9 @@ const sendDailyDigest = async (date: Date) => {
 				sendEmail(email).catch((err) =>
 					captureServerException(err, {
 						tag: "email:daily-digest",
-						email: email.to,
 						dateKey,
 						batchIndex,
+						recipientCount: 1,
 					})
 				)
 			)

--- a/src/server/lib/email.test.ts
+++ b/src/server/lib/email.test.ts
@@ -84,6 +84,10 @@ describe("sendEmail", () => {
 			})
 		)
 		expect(result).toEqual({ id: "abc" })
+		expect(mocks.debug).toHaveBeenCalledWith({ recipientCount: 1 }, "smtp send ok")
+		expect(JSON.stringify(mocks.debug.mock.calls)).not.toContain("person@example.test")
+		expect(JSON.stringify(mocks.debug.mock.calls)).not.toContain("SMTP message")
+		expect(JSON.stringify(mocks.debug.mock.calls)).not.toContain("abc")
 	})
 
 	it("throws when SMTP rejects the recipient", async () => {
@@ -101,6 +105,123 @@ describe("sendEmail", () => {
 				subject: "SMTP message",
 				react: createElement("div"),
 			})
-		).rejects.toThrow("SMTP rejected: bad@example.test")
+		).rejects.toThrow("SMTP rejected 1 recipient")
+		expect(mocks.error).toHaveBeenCalledWith(
+			{ rejectedCount: 1, recipientCount: 1 },
+			"smtp send rejected"
+		)
+		expect(JSON.stringify(mocks.error.mock.calls)).not.toContain("bad@example.test")
+		expect(JSON.stringify(mocks.error.mock.calls)).not.toContain("SMTP message")
+	})
+
+	it("redacts errors thrown by the SMTP transport", async () => {
+		mocks.env.EMAIL_TRANSPORT = "smtp"
+		mocks.render.mockResolvedValue("<p>private body sentinel</p>")
+		mocks.sendMail.mockRejectedValueOnce(
+			new Error(
+				"SMTP failure recipient-sentinel sender-sentinel subject-sentinel provider-id-sentinel"
+			)
+		)
+
+		await expect(
+			sendEmail({
+				from: "sender-sentinel@example.test",
+				to: "recipient-sentinel@example.test",
+				subject: "subject-sentinel",
+				html: "private body sentinel",
+			})
+		).rejects.toThrow("SMTP send failed")
+		expect(mocks.error).toHaveBeenCalledWith({ recipientCount: 1 }, "smtp send failed")
+		const logged = JSON.stringify(mocks.error.mock.calls)
+		expect(logged).not.toContain("sentinel")
+		expect(logged).not.toContain("private body")
+	})
+
+	it("redacts errors thrown while rendering SMTP templates", async () => {
+		mocks.env.EMAIL_TRANSPORT = "smtp"
+		mocks.render.mockRejectedValueOnce(
+			new Error(
+				"Render failure recipient-sentinel token-sentinel subject-sentinel body-sentinel"
+			)
+		)
+
+		await expect(
+			sendEmail({
+				from: "sender-sentinel@example.test",
+				to: "recipient-sentinel@example.test",
+				subject: "subject-sentinel",
+				react: createElement("div"),
+			})
+		).rejects.toThrow("SMTP send failed")
+		expect(mocks.error).toHaveBeenCalledWith({ recipientCount: 1 }, "smtp send failed")
+		expect(JSON.stringify(mocks.error.mock.calls)).not.toContain("sentinel")
+		expect(mocks.sendMail).not.toHaveBeenCalled()
+	})
+
+	it("redacts recipient content from Resend logs and errors", async () => {
+		mocks.env.EMAIL_TRANSPORT = "resend"
+		mocks.send.mockResolvedValueOnce({
+			data: null,
+			error: {
+				name: "validation_error",
+				message: "Rejected person@example.test for Sensitive subject",
+			},
+		})
+
+		await expect(
+			sendEmail({
+				from: "PStrack <info@pstrack.app>",
+				to: "person@example.test",
+				subject: "Sensitive subject",
+				html: "<p>private content</p>",
+			})
+		).rejects.toThrow("Resend send failed (validation_error)")
+		expect(mocks.error).toHaveBeenCalledWith(
+			{ errorName: "validation_error", recipientCount: 1 },
+			"resend send failed"
+		)
+		const logged = JSON.stringify(mocks.error.mock.calls)
+		expect(logged).not.toContain("person@example.test")
+		expect(logged).not.toContain("Sensitive subject")
+		expect(logged).not.toContain("private content")
+	})
+
+	it("redacts errors thrown by the Resend transport", async () => {
+		mocks.env.EMAIL_TRANSPORT = "resend"
+		mocks.send.mockRejectedValueOnce(
+			new Error(
+				"Provider failure recipient-sentinel subject-sentinel token-sentinel provider-id-sentinel"
+			)
+		)
+
+		await expect(
+			sendEmail({
+				from: "sender-sentinel@example.test",
+				to: "recipient-sentinel@example.test",
+				subject: "subject-sentinel",
+				html: "token-sentinel",
+			})
+		).rejects.toThrow("Resend send failed")
+		expect(mocks.error).toHaveBeenCalledWith({ recipientCount: 1 }, "resend send failed")
+		expect(JSON.stringify(mocks.error.mock.calls)).not.toContain("sentinel")
+	})
+
+	it("redacts recipient content from successful Resend logs", async () => {
+		mocks.env.EMAIL_TRANSPORT = "resend"
+		mocks.send.mockResolvedValueOnce({ data: { id: "provider-message-id" }, error: null })
+
+		const result = await sendEmail({
+			from: "PStrack <info@pstrack.app>",
+			to: ["one@example.test", "two@example.test"],
+			subject: "Sensitive subject",
+			html: "<p>private content</p>",
+		})
+
+		expect(result).toEqual({ id: "provider-message-id" })
+		expect(mocks.debug).toHaveBeenCalledWith({ recipientCount: 2 }, "resend send ok")
+		const logged = JSON.stringify(mocks.debug.mock.calls)
+		expect(logged).not.toContain("example.test")
+		expect(logged).not.toContain("Sensitive subject")
+		expect(logged).not.toContain("provider-message-id")
 	})
 })

--- a/src/server/lib/email.ts
+++ b/src/server/lib/email.ts
@@ -56,38 +56,53 @@ const getTransporter = (): Transporter => {
 }
 
 const sendViaSmtp = async (payload: CreateEmailOptions) => {
-	// React Email templates are rendered to HTML + text in-app (Resend does this
-	// server-side; SMTP needs the rendered strings). `react` is always a JSX
-	// element at the call sites, but CreateEmailOptions types it as ReactNode.
-	const element = payload.react as ReactElement | undefined
-	const html = payload.html ?? (element ? await render(element) : undefined)
-	const text =
-		payload.text ?? (element ? await render(element, { plainText: true }) : undefined)
-
-	const info = await getTransporter().sendMail({
-		from: payload.from,
-		to: payload.to,
-		subject: payload.subject,
-		html,
-		text,
-		...(payload.replyTo
-			? {
-					replyTo: Array.isArray(payload.replyTo)
-						? payload.replyTo.join(", ")
-						: payload.replyTo,
-				}
-			: {}),
-	})
+	const info = await (async () => {
+		try {
+			// React Email templates are rendered to HTML + text in-app (Resend does
+			// this server-side; SMTP needs the rendered strings). Keep rendering in
+			// the same sanitizing boundary as transport execution because template
+			// errors can contain message content.
+			const element = payload.react as ReactElement | undefined
+			const html = payload.html ?? (element ? await render(element) : undefined)
+			const text =
+				payload.text ?? (element ? await render(element, { plainText: true }) : undefined)
+			return await getTransporter().sendMail({
+				from: payload.from,
+				to: payload.to,
+				subject: payload.subject,
+				html,
+				text,
+				...(payload.replyTo
+					? {
+							replyTo: Array.isArray(payload.replyTo)
+								? payload.replyTo.join(", ")
+								: payload.replyTo,
+						}
+					: {}),
+			})
+		} catch {
+			logger.error(
+				{ recipientCount: Array.isArray(payload.to) ? payload.to.length : 1 },
+				"smtp send failed"
+			)
+			throw new Error("SMTP send failed")
+		}
+	})()
 
 	if (info.rejected && info.rejected.length > 0) {
 		logger.error(
-			{ rejected: info.rejected, to: payload.to, subject: payload.subject },
+			{
+				rejectedCount: info.rejected.length,
+				recipientCount: Array.isArray(payload.to) ? payload.to.length : 1,
+			},
 			"smtp send rejected"
 		)
-		throw new Error(`SMTP rejected: ${info.rejected.join(", ")}`)
+		throw new Error(
+			`SMTP rejected ${info.rejected.length} recipient${info.rejected.length === 1 ? "" : "s"}`
+		)
 	}
 	logger.debug(
-		{ id: info.messageId, to: payload.to, subject: payload.subject },
+		{ recipientCount: Array.isArray(payload.to) ? payload.to.length : 1 },
 		"smtp send ok"
 	)
 	return { id: info.messageId }
@@ -108,16 +123,29 @@ export const sendEmail = async (payload: CreateEmailOptions) => {
 		return sendViaSmtp(payload)
 	}
 
-	const result = await resend.emails.send(payload)
+	const result = await (async () => {
+		try {
+			return await resend.emails.send(payload)
+		} catch {
+			logger.error(
+				{ recipientCount: Array.isArray(payload.to) ? payload.to.length : 1 },
+				"resend send failed"
+			)
+			throw new Error("Resend send failed")
+		}
+	})()
 	if (result.error) {
 		logger.error(
-			{ err: result.error, to: payload.to, subject: payload.subject, from: payload.from },
+			{
+				errorName: result.error.name,
+				recipientCount: Array.isArray(payload.to) ? payload.to.length : 1,
+			},
 			"resend send failed"
 		)
-		throw new Error(`Resend: ${result.error.name} - ${result.error.message}`)
+		throw new Error(`Resend send failed (${result.error.name})`)
 	}
 	logger.debug(
-		{ id: result.data?.id, to: payload.to, subject: payload.subject },
+		{ recipientCount: Array.isArray(payload.to) ? payload.to.length : 1 },
 		"resend send ok"
 	)
 	return result.data

--- a/src/server/lib/magic-link-email.test.ts
+++ b/src/server/lib/magic-link-email.test.ts
@@ -45,13 +45,19 @@ describe("sendMagicLinkEmail", () => {
 			})
 		).resolves.toBeUndefined()
 
+		expect(mocks.loggerError).toHaveBeenCalledWith({}, "magic link email failed")
 		expect(mocks.loggerWarn).toHaveBeenCalledWith(
-			expect.objectContaining({
-				email: "user@example.com",
-				url: "https://pstrack.localhost/api/v3/magic-link?token=abc",
-			}),
-			"magic link email failed in development; using logged link fallback"
+			{},
+			"magic link email failure suppressed in development"
 		)
+		const logged = JSON.stringify([
+			...mocks.loggerDebug.mock.calls,
+			...mocks.loggerError.mock.calls,
+			...mocks.loggerWarn.mock.calls,
+		])
+		expect(logged).not.toContain("user@example.com")
+		expect(logged).not.toContain("token=abc")
+		expect(logged).not.toContain("Resend unavailable")
 	})
 
 	it("rethrows email failures outside development", async () => {
@@ -63,6 +69,7 @@ describe("sendMagicLinkEmail", () => {
 				email: "user@example.com",
 				url: "https://pstrack.localhost/api/v3/auth/magic-link/verify?token=abc",
 			})
-		).rejects.toThrow("Resend unavailable")
+		).rejects.toThrow("Magic link email failed")
+		expect(mocks.loggerError).toHaveBeenCalledWith({}, "magic link email failed")
 	})
 })

--- a/src/server/lib/magic-link-email.ts
+++ b/src/server/lib/magic-link-email.ts
@@ -15,7 +15,6 @@ export const sendMagicLinkEmail = async ({
 	// Gmail) don't execute JS so the one-time token isn't consumed early.
 	const redirectUrl = new URL(url)
 	redirectUrl.pathname = "/api/v3/magic-link"
-	logger.debug({ redirectUrl: redirectUrl.toString() }, "magic link redirect")
 
 	try {
 		await sendEmail({
@@ -24,15 +23,12 @@ export const sendMagicLinkEmail = async ({
 			subject: "Sign in to PStrack",
 			react: MagicLinkEmail({ url: redirectUrl.toString() }),
 		})
-	} catch (err) {
-		logger.error({ err, email }, "magic link email failed")
+	} catch {
+		logger.error({}, "magic link email failed")
 		if (env.NODE_ENV === "development") {
-			logger.warn(
-				{ err, email, url: redirectUrl.toString() },
-				"magic link email failed in development; using logged link fallback"
-			)
+			logger.warn({}, "magic link email failure suppressed in development")
 			return
 		}
-		throw err
+		throw new Error("Magic link email failed")
 	}
 }


### PR DESCRIPTION
## What changed

- restricts SMTP and Resend delivery logs to allowlisted aggregate fields
- replaces provider/template errors at the public boundary without leaking raw causes
- removes magic-link recipient, URL/token, and raw error logging
- removes recipient identity from daily-digest Sentry context
- adds sentinel regressions for recipient, sender, subject, body, token, and provider-message leakage

## Why

Issue #289 requires observable mail canaries without placing transactional content or identity data in logs and error telemetry.

## Verification

- 15 focused tests
- typecheck, Biome, full Vitest, build
- independent Standards and Spec reviews

## Rollout

MX/DKIM, trusted SMTP certificate, provider canaries, queue/bounce evidence, and magic-link migration remain infrastructure acceptance work.

Refs #289