### PR TITLE
feat(staging): add guarded reset and seed verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ todos.json
 deploy-evidence.json
 smoke-evidence.json
 staging-smoke-evidence.json
+staging-reset-evidence.json
 generated/
 .vercel
 

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -24,13 +24,21 @@ This procedure destroys all staging data. Confirm the target is staging and
 obtain explicit destructive-operation approval before running it.
 
 1. Pull the Vercel staging environment into a temporary ignored file.
-2. Verify `PSTRACK_ENVIRONMENT=staging`, `EMAIL_TRANSPORT=log`, the database host
-   is the dedicated Neon staging project, and no production host is present.
-3. Run `bun run db:reset` against that environment. Prisma reapplies migrations
-   and the deterministic master seed.
-4. Run the staging smoke checks and verify only synthetic `@dev.test` seed
-   accounts are present.
-5. Delete the temporary environment file.
+2. Load the staging environment. The command compares the complete normalized
+   database identities (hostname plus database name) with repository-controlled
+   SHA-256 fingerprints; operators cannot override the approved targets.
+3. After obtaining explicit destructive-operation approval, run
+   `bun run db:reset:staging --confirm-staging-reset`. The command fails closed
+   unless both Prisma URLs match the approved Neon host, the runtime identifies
+   itself as staging, log-only email is active, and outbound email credentials
+   are absent.
+4. The command explicitly resets migrations, runs the deterministic master seed,
+   and writes aggregate-only `staging-reset-evidence.json`. A healthy result
+   requires the exact canonical 50 synthetic identities and 9 group identities,
+   creators, and membership counts, plus exactly 315 daily problems. Evidence
+   contains only aggregate mismatch counts, never account identifiers.
+5. Run the staging smoke checks, retain the sanitized evidence, and delete the
+   temporary environment file.
 
 Never restore or clone production data into staging.
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"db:seed-groups": "bun run prisma/seed-groups.ts",
 		"db:seed-daily-problems": "bun run prisma/seed-daily-problems.ts",
 		"db:reset": "prisma migrate reset",
+		"db:reset:staging": "bun run scripts/reset-staging.ts",
 		"db:studio": "bunx db-studio@latest --database-url \"$DATABASE_URL\"",
 		"prisma:generate": "prisma generate",
 		"test": "vitest run",

--- a/prisma/seed-daily-problems.ts
+++ b/prisma/seed-daily-problems.ts
@@ -54,11 +54,15 @@ export async function seedDailyProblems() {
 	const seedSlugs = groupsData.map((g) => g.slug)
 	const groups = await db.group.findMany({
 		where: { slug: { in: seedSlugs } },
+		orderBy: { slug: "asc" },
 		select: {
 			id: true,
 			slug: true,
 			roadmap: true,
-			members: { select: { id: true, userId: true, joinedAt: true } },
+			members: {
+				orderBy: { userId: "asc" },
+				select: { id: true, userId: true, joinedAt: true },
+			},
 		},
 	})
 

--- a/scripts/lib/staging-seed-evidence.ts
+++ b/scripts/lib/staging-seed-evidence.ts
@@ -1,0 +1,125 @@
+import groups from "../../prisma/data/groups.json"
+
+export const SEED_USERNAMES = [
+	"alexchen",
+	"mariasantos",
+	"jamesokafor",
+	"sarahkim",
+	"davidzhang",
+	"emmawilson",
+	"carlosmendez",
+	"ninapatel",
+	"oliverbrooks",
+	"sofiagarcia",
+	"ryanliu",
+	"avanakamura",
+	"ethanross",
+	"miapark",
+	"noahfischer",
+	"lilywu",
+	"lucasahmed",
+	"chloemiranda",
+	"masonjones",
+	"isabellabrown",
+	"jacksontaylor",
+	"gracefisher",
+	"aidengrant",
+	"abigailharris",
+	"elijahjackson",
+	"harperwhite",
+	"sebastianmoran",
+	"evelynmoore",
+	"mateoclark",
+	"ameliarodriguez",
+	"liamdavis",
+	"charlottehall",
+	"henryallen",
+	"aurorayoung",
+	"samuelking",
+	"scarlettwright",
+	"gabrielscott",
+	"hazelgreen",
+	"nathanbaker",
+	"lilycarter",
+	"julianperez",
+	"violetrob",
+	"leoevans",
+	"lunaturner",
+	"calebphillips",
+	"rubycampbell",
+	"ryanmurphy",
+	"stellaparker",
+	"finnprice",
+	"zarabennett",
+]
+const EXPECTED_USERS = new Set(
+	SEED_USERNAMES.map((username) => `seed-user-${username}\0seed.${username}@dev.test`)
+)
+export const SEED_GROUPS = groups.map((group, index) => ({
+	id: `seed-group-${group.slug}`,
+	creatorId: `seed-user-${SEED_USERNAMES[index]}`,
+	memberCount: group.memberCount,
+	dailyProblemCount: 35,
+}))
+const EXPECTED_GROUPS = new Set(
+	SEED_GROUPS.map(
+		(group) =>
+			`${group.id}\0${group.creatorId}\0${group.memberCount}\0${group.dailyProblemCount}`
+	)
+)
+const EXPECTED_USER_COUNT = EXPECTED_USERS.size
+const EXPECTED_GROUP_COUNT = EXPECTED_GROUPS.size
+const EXPECTED_DAILY_PROBLEM_COUNT = EXPECTED_GROUP_COUNT * 35
+
+export const buildStagingSeedEvidence = ({
+	users,
+	groups,
+	dailyProblemCount,
+}: {
+	users: { id: string; email: string }[]
+	groups: {
+		id: string
+		creatorId: string
+		memberCount: number
+		dailyProblemCount: number
+	}[]
+	dailyProblemCount: number
+}) => {
+	const actualUsers = new Set(users.map((user) => `${user.id}\0${user.email}`))
+	const actualGroups = new Set(
+		groups.map(
+			(group) =>
+				`${group.id}\0${group.creatorId}\0${group.memberCount}\0${group.dailyProblemCount}`
+		)
+	)
+	const unexpectedUserCount = [...actualUsers].filter(
+		(value) => !EXPECTED_USERS.has(value)
+	).length
+	const missingUserCount = [...EXPECTED_USERS].filter(
+		(value) => !actualUsers.has(value)
+	).length
+	const unexpectedGroupCount = [...actualGroups].filter(
+		(value) => !EXPECTED_GROUPS.has(value)
+	).length
+	const missingGroupCount = [...EXPECTED_GROUPS].filter(
+		(value) => !actualGroups.has(value)
+	).length
+
+	return {
+		healthy:
+			users.length === EXPECTED_USER_COUNT &&
+			unexpectedUserCount === 0 &&
+			missingUserCount === 0 &&
+			groups.length === EXPECTED_GROUP_COUNT &&
+			unexpectedGroupCount === 0 &&
+			missingGroupCount === 0 &&
+			dailyProblemCount === EXPECTED_DAILY_PROBLEM_COUNT,
+		userCount: users.length,
+		groupCount: groups.length,
+		dailyProblemCount,
+		unexpectedUserCount,
+		missingUserCount,
+		unexpectedGroupCount,
+		missingGroupCount,
+	}
+}

--- a/scripts/reset-staging.ts
+++ b/scripts/reset-staging.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env bun
+
+import { spawn } from "node:child_process"
+import { createHash } from "node:crypto"
+import { writeFile } from "node:fs/promises"
+
+import { buildStagingSeedEvidence } from "./lib/staging-seed-evidence"
+
+type StagingResetEnvironment = Record<string, string | undefined>
+
+type StagingSeedEvidence = {
+	healthy: boolean
+	userCount: number
+	groupCount: number
+	dailyProblemCount: number
+	unexpectedUserCount: number
+	missingUserCount: number
+	unexpectedGroupCount: number
+	missingGroupCount: number
+}
+
+const APPROVED_STAGING_IDENTITIES = {
+	database: "9869b04020201187d0a9d07f7a38ddd84cd0726d7daae188a5b7fe7b4636db8f",
+	direct: "862cd682b6754e3d04bc6351a8bce62924a61f908687ddd3771e480b9e040090",
+}
+
+const OUTBOUND_EMAIL_KEYS = ["RESEND_API_KEY", "SMTP_HOST", "SMTP_USER", "SMTP_PASS"]
+
+export const databaseIdentityFingerprint = (value: string | undefined) => {
+	if (!value) throw new Error("DATABASE_URL and DIRECT_URL are required")
+	try {
+		const url = new URL(value)
+		if (url.protocol !== "postgres:" && url.protocol !== "postgresql:") {
+			throw new Error("invalid protocol")
+		}
+		if (!url.hostname.toLowerCase().endsWith(".neon.tech") || url.pathname === "/") {
+			throw new Error("invalid staging target")
+		}
+		const schemas = url.searchParams.getAll("schema")
+		if (schemas.length > 1 || schemas[0]?.includes(",")) {
+			throw new Error("invalid staging target")
+		}
+		const schema = schemas[0] ?? "public"
+		return createHash("sha256")
+			.update(
+				`${url.hostname.toLowerCase()}:${url.port || "5432"}${url.pathname}?schema=${schema}`
+			)
+			.digest("hex")
+	} catch {
+		throw new Error("DATABASE_URL and DIRECT_URL must be valid PostgreSQL URLs")
+	}
+}
+
+export const validateStagingResetConfig = (
+	environment: StagingResetEnvironment,
+	args: string[],
+	approvedIdentities = APPROVED_STAGING_IDENTITIES
+) => {
+	if (environment.PSTRACK_ENVIRONMENT !== "staging") {
+		throw new Error("PSTRACK_ENVIRONMENT must be staging")
+	}
+	if (!args.includes("--confirm-staging-reset")) {
+		throw new Error("Pass --confirm-staging-reset after approval")
+	}
+	if (environment.EMAIL_TRANSPORT !== "log") {
+		throw new Error("EMAIL_TRANSPORT must be log")
+	}
+	if (OUTBOUND_EMAIL_KEYS.some((key) => Boolean(environment[key]))) {
+		throw new Error("Outbound email credentials must be absent")
+	}
+
+	const databaseIdentity = databaseIdentityFingerprint(environment.DATABASE_URL)
+	const directIdentity = databaseIdentityFingerprint(environment.DIRECT_URL)
+	if (
+		databaseIdentity !== approvedIdentities.database ||
+		directIdentity !== approvedIdentities.direct
+	) {
+		throw new Error("Database URLs do not match approved staging database identities")
+	}
+
+	return { environment: "staging", confirmed: true }
+}
+
+export const executeStagingReset = async (
+	environment: StagingResetEnvironment,
+	args: string[],
+	{
+		runCommand,
+		verifySeed,
+		now,
+		approvedIdentities = APPROVED_STAGING_IDENTITIES,
+	}: {
+		runCommand: (command: string[]) => Promise<number>
+		verifySeed: () => Promise<StagingSeedEvidence>
+		now: () => Date
+		approvedIdentities?: { database: string; direct: string }
+	}
+) => {
+	validateStagingResetConfig(environment, args, approvedIdentities)
+	const resetExitCode = await runCommand(["bun", "run", "db:reset", "--force"])
+	if (resetExitCode !== 0) throw new Error("Staging database reset failed")
+	const seedExitCode = await runCommand(["bun", "run", "db:seed"])
+	if (seedExitCode !== 0) throw new Error("Staging database seed failed")
+	const seed = await verifySeed()
+
+	return {
+		checkedAt: now().toISOString(),
+		environment: "staging",
+		databaseHostMatched: true,
+		emailTransport: "log",
+		seed,
+	}
+}
+
+const runCommand = async (command: string[]) => {
+	const [executable, ...args] = command
+	if (!executable) return 1
+	return new Promise<number>((resolve, reject) => {
+		const child = spawn(executable, args, { env: process.env, stdio: "inherit" })
+		child.once("error", reject)
+		child.once("exit", (code) => resolve(code ?? 1))
+	})
+}
+
+const verifySeed = async (): Promise<StagingSeedEvidence> => {
+	const { db } = await import("@/server/lib/db")
+	try {
+		const [users, groups, dailyProblemCount] = await Promise.all([
+			db.user.findMany({ select: { id: true, email: true } }),
+			db.group.findMany({
+				select: {
+					id: true,
+					creatorId: true,
+					_count: { select: { members: true, dailyProblems: true } },
+				},
+			}),
+			db.dailyProblem.count(),
+		])
+		return buildStagingSeedEvidence({
+			users,
+			groups: groups.map((group) => ({
+				id: group.id,
+				creatorId: group.creatorId,
+				memberCount: group._count.members,
+				dailyProblemCount: group._count.dailyProblems,
+			})),
+			dailyProblemCount,
+		})
+	} finally {
+		await db.$disconnect()
+	}
+}
+
+if (import.meta.main) {
+	executeStagingReset(process.env, process.argv.slice(2), {
+		runCommand,
+		verifySeed,
+		now: () => new Date(),
+	})
+		.then(async (evidence) => {
+			await writeFile(
+				"staging-reset-evidence.json",
+				`${JSON.stringify(evidence, null, 2)}\n`
+			)
+			console.log(JSON.stringify(evidence, null, 2))
+			if (!evidence.seed.healthy) throw new Error("Seed verification failed")
+		})
+		.catch(() => {
+			console.error("Staging reset failed; inspect sanitized evidence if present")
+			process.exit(1)
+		})
+}

--- a/src/test/reset-staging.test.ts
+++ b/src/test/reset-staging.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest"
+
+import {
+	buildStagingSeedEvidence,
+	SEED_GROUPS,
+	SEED_USERNAMES,
+} from "../../scripts/lib/staging-seed-evidence"
+import {
+	databaseIdentityFingerprint,
+	executeStagingReset,
+	validateStagingResetConfig,
+} from "../../scripts/reset-staging"
+
+const canonicalUsers = () =>
+	SEED_USERNAMES.map((username) => ({
+		id: `seed-user-${username}`,
+		email: `seed.${username}@dev.test`,
+	}))
+
+describe("staging reset preflight", () => {
+	const stagingEnvironment = {
+		PSTRACK_ENVIRONMENT: "staging",
+		EMAIL_TRANSPORT: "log",
+		DATABASE_URL: "postgresql://user:secret@stage-pooler.example.neon.tech/app",
+		DIRECT_URL: "postgresql://user:secret@stage-direct.example.neon.tech/app",
+	}
+	const approvedIdentities = {
+		database: databaseIdentityFingerprint(stagingEnvironment.DATABASE_URL),
+		direct: databaseIdentityFingerprint(stagingEnvironment.DIRECT_URL),
+	}
+
+	it("rejects a production environment before reset execution", () => {
+		expect(() =>
+			validateStagingResetConfig(
+				{ ...stagingEnvironment, PSTRACK_ENVIRONMENT: "production" },
+				["--confirm-staging-reset"],
+				approvedIdentities
+			)
+		).toThrow("PSTRACK_ENVIRONMENT must be staging")
+	})
+
+	it("requires explicit destructive-operation confirmation", () => {
+		expect(() =>
+			validateStagingResetConfig(stagingEnvironment, [], approvedIdentities)
+		).toThrow("Pass --confirm-staging-reset")
+	})
+
+	it.each([
+		[
+			"non-log email",
+			{ ...stagingEnvironment, EMAIL_TRANSPORT: "resend" },
+			"EMAIL_TRANSPORT must be log",
+		],
+		[
+			"outbound email credentials",
+			{ ...stagingEnvironment, RESEND_API_KEY: "configured" },
+			"Outbound email credentials must be absent",
+		],
+		[
+			"different host",
+			{
+				...stagingEnvironment,
+				DATABASE_URL: "postgresql://user:secret@other.example.neon.tech/app",
+			},
+			"Database URLs do not match approved staging database identities",
+		],
+		[
+			"same host but different database",
+			{
+				...stagingEnvironment,
+				DATABASE_URL: "postgresql://user:secret@stage-pooler.example.neon.tech/other",
+			},
+			"Database URLs do not match approved staging database identities",
+		],
+		[
+			"same database but different schema",
+			{
+				...stagingEnvironment,
+				DATABASE_URL: `${stagingEnvironment.DATABASE_URL}?schema=other`,
+			},
+			"Database URLs do not match approved staging database identities",
+		],
+	])("rejects %s", (_case, environment, expectedMessage) => {
+		expect(() =>
+			validateStagingResetConfig(
+				environment,
+				["--confirm-staging-reset"],
+				approvedIdentities
+			)
+		).toThrow(expectedMessage)
+	})
+
+	it("runs reset then the master seed before verification", async () => {
+		const commands: string[][] = []
+		const seed = {
+			healthy: true,
+			userCount: 50,
+			groupCount: 9,
+			dailyProblemCount: 315,
+			unexpectedUserCount: 0,
+			missingUserCount: 0,
+			unexpectedGroupCount: 0,
+			missingGroupCount: 0,
+		}
+		const evidence = await executeStagingReset(
+			stagingEnvironment,
+			["--confirm-staging-reset"],
+			{
+				runCommand: async (command) => {
+					commands.push(command)
+					return 0
+				},
+				verifySeed: async () => seed,
+				now: () => new Date("2026-07-14T18:00:00.000Z"),
+				approvedIdentities,
+			}
+		)
+		expect(commands).toEqual([
+			["bun", "run", "db:reset", "--force"],
+			["bun", "run", "db:seed"],
+		])
+		expect(evidence.seed).toEqual(seed)
+	})
+
+	it.each([
+		[
+			"alternate port",
+			`${stagingEnvironment.DATABASE_URL.replace(".neon.tech", ".neon.tech:5433")}`,
+		],
+		["duplicate schema", `${stagingEnvironment.DATABASE_URL}?schema=public&schema=other`],
+		["comma-delimited schema", `${stagingEnvironment.DATABASE_URL}?schema=public,other`],
+	])("does not execute reset for %s", async (_case, databaseUrl) => {
+		const commands: string[][] = []
+		await expect(
+			executeStagingReset(
+				{ ...stagingEnvironment, DATABASE_URL: databaseUrl },
+				["--confirm-staging-reset"],
+				{
+					runCommand: async (command) => {
+						commands.push(command)
+						return 0
+					},
+					verifySeed: async () => {
+						throw new Error("must not verify")
+					},
+					now: () => new Date("2026-07-14T18:00:00.000Z"),
+					approvedIdentities,
+				}
+			)
+		).rejects.toThrow()
+		expect(commands).toEqual([])
+	})
+
+	it("stops before seeding or verification when reset fails", async () => {
+		const commands: string[][] = []
+		let verified = false
+		await expect(
+			executeStagingReset(stagingEnvironment, ["--confirm-staging-reset"], {
+				runCommand: async (command) => {
+					commands.push(command)
+					return 1
+				},
+				verifySeed: async () => {
+					verified = true
+					throw new Error("must not verify")
+				},
+				now: () => new Date("2026-07-14T18:00:00.000Z"),
+				approvedIdentities,
+			})
+		).rejects.toThrow("Staging database reset failed")
+		expect(commands).toEqual([["bun", "run", "db:reset", "--force"]])
+		expect(verified).toBe(false)
+	})
+})
+
+describe("staging seed evidence", () => {
+	it("rejects a plausible replacement for a canonical account", () => {
+		const users = canonicalUsers()
+		users[0] = { id: "seed-user-impostor", email: "seed.impostor@dev.test" }
+		const evidence = buildStagingSeedEvidence({
+			users,
+			groups: SEED_GROUPS,
+			dailyProblemCount: 315,
+		})
+		expect(evidence).toMatchObject({
+			healthy: false,
+			unexpectedUserCount: 1,
+			missingUserCount: 1,
+		})
+		expect(JSON.stringify(evidence)).not.toContain("impostor")
+	})
+
+	it("rejects a plausible replacement for a canonical group", () => {
+		const groups = SEED_GROUPS.map((group) => ({ ...group }))
+		groups[0] = { ...groups[0], creatorId: "seed-user-impostor" }
+		const evidence = buildStagingSeedEvidence({
+			users: canonicalUsers(),
+			groups,
+			dailyProblemCount: 315,
+		})
+		expect(evidence).toMatchObject({
+			healthy: false,
+			unexpectedGroupCount: 1,
+			missingGroupCount: 1,
+		})
+		expect(JSON.stringify(evidence)).not.toContain("impostor")
+	})
+})


### PR DESCRIPTION
## What changed

- adds an explicitly confirmed staging reset/reseed command
- binds destructive access to repository-controlled database target fingerprints
- verifies exact sanitized users, group relationships, and daily problem counts
- makes daily seed ordering deterministic and emits aggregate-only evidence

## Why

Issue #287 requires a reproducible sanitized staging dataset without any path to production data. Prisma reset does not run the master seed automatically in this repository.

## Verification

- focused reset tests
- full Vitest suite
- typecheck and Biome
- production build
- independent Standards and Spec reviews

## Rollout

The live destructive staging reset remains intentionally pending explicit approval. No acceptance box should close until retained aggregate evidence exists.

Refs #287