### PR TITLE
feat(pro): email users after admin Pro grants

### DIFF
--- a/src/emails/pro-unlocked-by-admin.tsx
+++ b/src/emails/pro-unlocked-by-admin.tsx
@@ -1,0 +1,39 @@
+import { Button, Section, Text } from "@react-email/components"
+
+import { EmailLayout, s } from "./layout"
+
+interface ProUnlockedByAdminEmailProps {
+	name: string
+	dashboardUrl: string
+	expiresAt: string | null
+}
+
+export default function ProUnlockedByAdminEmail({
+	name,
+	dashboardUrl,
+	expiresAt,
+}: ProUnlockedByAdminEmailProps) {
+	return (
+		<EmailLayout
+			preview="You're a PStrack Pro user now"
+			note="You're receiving this because PStrack upgraded your account."
+			footerText="Keep showing up."
+		>
+			<Text style={s.heading}>You&apos;re Pro now.</Text>
+			<Text style={s.para}>
+				Hey {name} - we&apos;ve upgraded your account to Pro in recognition of your
+				contribution and performance.
+			</Text>
+			{expiresAt && (
+				<Text style={s.para}>
+					Your Pro access is active until <strong>{expiresAt}</strong>.
+				</Text>
+			)}
+			<Section style={s.ctaSection}>
+				<Button href={dashboardUrl} style={s.ctaGreen}>
+					Go to Dashboard
+				</Button>
+			</Section>
+		</EmailLayout>
+	)
+}

--- a/src/server/admin/admin.emails.ts
+++ b/src/server/admin/admin.emails.ts
@@ -7,6 +7,7 @@ import JoinExpiredEmail from "@/emails/join-expired"
 import JoinRejectedEmail from "@/emails/join-rejected"
 import JoinRequestEmail from "@/emails/join-request"
 import MagicLinkEmail from "@/emails/magic-link"
+import ProUnlockedByAdminEmail from "@/emails/pro-unlocked-by-admin"
 import ProUnlockedByPointsEmail from "@/emails/pro-unlocked-by-points"
 import RemovedFromGroupEmail from "@/emails/removed-from-group"
 import StreakMilestoneEmail from "@/emails/streak-milestone"
@@ -82,6 +83,17 @@ export const EMAIL_TEMPLATES: TemplateMeta[] = [
 		subject: () => "You unlocked PStrack Pro",
 		render: (props) => ProUnlockedByPointsEmail(cast(props)),
 		exampleProps: { name: "Alex", dashboardUrl: "https://pstrack.app/dashboard" },
+	},
+	{
+		key: "pro-unlocked-by-admin",
+		label: "Pro unlocked (admin grant)",
+		subject: () => "You're a PStrack Pro user now",
+		render: (props) => ProUnlockedByAdminEmail(cast(props)),
+		exampleProps: {
+			name: "Alex",
+			dashboardUrl: "https://pstrack.app/dashboard",
+			expiresAt: "July 30, 2026 at 12:00 PM UTC",
+		},
 	},
 	{
 		key: "join-request",

--- a/src/server/users/users.admin.controller.ts
+++ b/src/server/users/users.admin.controller.ts
@@ -5,6 +5,7 @@ import { ADMIN_LIST_LIMIT_DEFAULT } from "@/server/admin/admin.type"
 import { adminAuditDao } from "@/server/admin/admin-audit.dao"
 import { requirePlatformAdmin } from "@/server/lib/session"
 import { usersAdminDao } from "./users.admin.dao"
+import { usersAdminNotifications } from "./users.admin.notifications"
 
 export const usersAdminController = new Elysia({
 	prefix: "/admin/users",
@@ -92,6 +93,13 @@ export const usersAdminController = new Elysia({
 					error:
 						"Cannot revoke Pro for a Polar customer. Issue a refund in Polar instead.",
 				})
+			}
+			if (result.becamePro) {
+				usersAdminNotifications.proGranted(
+					result.user.email,
+					result.user.name,
+					result.user.proExpiresAt
+				)
 			}
 			return result.user
 		},

--- a/src/server/users/users.admin.dao.test.ts
+++ b/src/server/users/users.admin.dao.test.ts
@@ -1,0 +1,70 @@
+// @ts-nocheck
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/server/admin/admin-audit.dao", () => ({
+	adminAuditDao: { log: vi.fn() },
+}))
+
+vi.mock("@/server/lib/db", () => ({
+	db: {
+		user: { findUnique: vi.fn() },
+		$transaction: vi.fn(),
+	},
+}))
+
+vi.mock("@/server/points/points.dao", () => ({
+	pointsDao: { applyPointsDelta: vi.fn() },
+}))
+
+import { ProSource } from "@/generated/prisma/enums"
+import { db } from "@/server/lib/db"
+import { usersAdminDao } from "./users.admin.dao"
+
+const updatedUser = {
+	id: "user-1",
+	name: "Ada",
+	email: "ada@example.com",
+	isPro: true,
+	proSource: ProSource.ADMIN_GRANT,
+	proExpiresAt: null,
+}
+
+describe("usersAdminDao.setPro", () => {
+	afterEach(() => vi.clearAllMocks())
+
+	const arrangeTransaction = () => {
+		const tx = {
+			user: { update: vi.fn().mockResolvedValue(updatedUser) },
+		}
+		db.$transaction.mockImplementation((callback) => callback(tx))
+	}
+
+	it("marks a Free to Pro admin grant as a transition", async () => {
+		db.user.findUnique.mockResolvedValue({ isPro: false, proSource: null })
+		arrangeTransaction()
+
+		const result = await usersAdminDao.setPro("admin-1", "user-1", {
+			grant: true,
+			expiresAt: null,
+			reason: "Great performance",
+		})
+
+		expect(result).toMatchObject({ ok: true, becamePro: true })
+	})
+
+	it("does not mark an existing Pro re-grant as a transition", async () => {
+		db.user.findUnique.mockResolvedValue({
+			isPro: true,
+			proSource: ProSource.ADMIN_GRANT,
+		})
+		arrangeTransaction()
+
+		const result = await usersAdminDao.setPro("admin-1", "user-1", {
+			grant: true,
+			expiresAt: new Date("2026-07-30T12:00:00.000Z"),
+			reason: "Extend grant",
+		})
+
+		expect(result).toMatchObject({ ok: true, becamePro: false })
+	})
+})

--- a/src/server/users/users.admin.dao.ts
+++ b/src/server/users/users.admin.dao.ts
@@ -156,7 +156,7 @@ export const usersAdminDao = {
 		userId: string,
 		input: { grant: boolean; expiresAt: Date | null; reason: string }
 	): Promise<
-		| { ok: true; user: AdminUserDetailResponse }
+		| { ok: true; user: AdminUserDetailResponse; becamePro: boolean }
 		| { ok: false; error: "USER_NOT_FOUND" | "POLAR_PRO_LOCKED" }
 	> => {
 		const user = await db.user.findUnique({
@@ -198,6 +198,6 @@ export const usersAdminDao = {
 			return next
 		})
 
-		return { ok: true, user: updated }
+		return { ok: true, user: updated, becamePro: input.grant && !user.isPro }
 	},
 }

--- a/src/server/users/users.admin.notifications.test.ts
+++ b/src/server/users/users.admin.notifications.test.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/env", () => ({
+	env: {
+		BETTER_AUTH_URL: "https://pstrack.localhost/",
+		EMAIL_FROM: "PStrack <pro@pstrack.localhost>",
+	},
+}))
+
+vi.mock("@/emails/pro-unlocked-by-admin", () => ({
+	default: vi.fn((props) => ({ type: "ProUnlockedByAdminEmail", props })),
+}))
+
+vi.mock("@/server/lib/email", () => ({
+	sendEmail: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("@/server/lib/sentry", () => ({
+	captureServerException: vi.fn(),
+}))
+
+import ProUnlockedByAdminEmail from "@/emails/pro-unlocked-by-admin"
+import { sendEmail } from "@/server/lib/email"
+import { usersAdminNotifications } from "./users.admin.notifications"
+
+describe("usersAdminNotifications.proGranted", () => {
+	afterEach(() => vi.clearAllMocks())
+
+	it("sends a permanent admin grant without an expiry", () => {
+		usersAdminNotifications.proGranted("ada@example.com", "Ada", null)
+
+		expect(ProUnlockedByAdminEmail).toHaveBeenCalledWith({
+			name: "Ada",
+			dashboardUrl: "https://pstrack.localhost/dashboard",
+			expiresAt: null,
+		})
+		expect(sendEmail).toHaveBeenCalledTimes(1)
+	})
+
+	it("formats a temporary grant expiry in UTC", () => {
+		usersAdminNotifications.proGranted(
+			"ada@example.com",
+			"Ada",
+			new Date("2026-07-30T12:00:00.000Z")
+		)
+
+		expect(ProUnlockedByAdminEmail).toHaveBeenCalledWith(
+			expect.objectContaining({ expiresAt: "July 30, 2026 at 12:00 PM UTC" })
+		)
+	})
+})

--- a/src/server/users/users.admin.notifications.ts
+++ b/src/server/users/users.admin.notifications.ts
@@ -1,0 +1,32 @@
+import ProUnlockedByAdminEmail from "@/emails/pro-unlocked-by-admin"
+import { env } from "@/env"
+import { sendEmail } from "@/server/lib/email"
+import { captureServerException } from "@/server/lib/sentry"
+
+const BASE_URL = (env.BETTER_AUTH_URL ?? "https://pstrack.localhost").replace(/\/$/, "")
+
+const formatExpiry = (expiresAt: Date | null): string | null =>
+	expiresAt?.toLocaleString("en-US", {
+		timeZone: "UTC",
+		month: "long",
+		day: "numeric",
+		year: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+		timeZoneName: "short",
+	}) ?? null
+
+export const usersAdminNotifications = {
+	proGranted: (email: string, name: string, expiresAt: Date | null): void => {
+		sendEmail({
+			from: env.EMAIL_FROM,
+			to: email,
+			subject: "You're a PStrack Pro user now",
+			react: ProUnlockedByAdminEmail({
+				name,
+				dashboardUrl: `${BASE_URL}/dashboard`,
+				expiresAt: formatExpiry(expiresAt),
+			}),
+		}).catch((err) => captureServerException(err, { tag: "email:pro-unlocked-admin" }))
+	},
+}


### PR DESCRIPTION
## Summary

- add a recognition-focused email for admin-granted Pro access
- send only when a user transitions from Free to Pro
- show temporary grant expirations in UTC and register the template in the admin email console
- add focused coverage for transition detection and email props

## Verification

- `bun run test -- src/server/users/users.admin.dao.test.ts src/server/users/users.admin.notifications.test.ts` — passed (4 tests)
- `bun run check` — passed
- `bun run typecheck` — blocked by existing `stage` errors in `scripts/verify-redis.ts` and `src/server/lib/redis.ts` where Bun types are unresolved and callback parameters are implicitly `any`