### PR TITLE
docs: reconcile architecture and operations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,9 @@
 NODE_ENV="development"
 
-# Database (Neon — pooled connection for app, direct for migrations)
-DATABASE_URL="postgresql://USER:PASSWORD@HOST-pooler.REGION.aws.neon.tech/neondb?sslmode=require&channel_binding=require"
-DIRECT_URL="postgresql://USER:PASSWORD@HOST.REGION.aws.neon.tech/neondb?sslmode=require"
+# Database. Local and Coolify may use the same direct PostgreSQL URL for both
+# values. Vercel staging uses its isolated Neon pooled/direct URL pair.
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/pstrack"
+DIRECT_URL="postgresql://USER:PASSWORD@HOST:5432/pstrack"
 
 # Local Docker Compose database (used by Makefile aliases)
 # DATABASE_URL="postgresql://pstrack:pstrack@127.0.0.1:5433/pstrack?schema=public"
@@ -34,9 +35,10 @@ GITHUB_CLIENT_SECRET=""
 # EMAIL_TRANSPORT: "resend" | "smtp" (self-hosted Stalwart) | "log" (render + log,
 # never send). "resend" requires RESEND_API_KEY; "log" requires it be ABSENT;
 # "smtp" requires SMTP_HOST/USER/PASS. Prod validates and fails fast on mismatch.
-EMAIL_TRANSPORT="resend"
-RESEND_API_KEY="re_xxx"
-EMAIL_FROM="PStrack <onboarding@resend.dev>"
+EMAIL_TRANSPORT="log"
+# Legacy rollback transport only. Leave absent unless EMAIL_TRANSPORT="resend".
+# RESEND_API_KEY="re_xxx"
+EMAIL_FROM="PStrack <hello@pstrack.app>"
 # Self-hosted SMTP (Stalwart) — only used when EMAIL_TRANSPORT="smtp".
 # Port 465 = implicit TLS. In prod, SMTP_HOST is the internal Coolify service
 # alias for the Stalwart container (both are on the shared `coolify` network).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Runtime is **Bun** (≥1.2.2).
 | `bun run test` | Vitest, single run (no watch). |
 | `bun run test -- src/path/to/file.test.ts` | Run one test file. Append `-t "name"` to filter by test name. |
 
-### Database (Prisma → Neon)
+### Database (Prisma → PostgreSQL)
 
 | Command | What it does |
 |---|---|
@@ -85,7 +85,9 @@ Runtime is **Bun** (≥1.2.2).
 
 | Command | What it does |
 |---|---|
-| `bun run env:sync` | Sync `.env` to Vercel. |
+| `bun run env:sync:prod` | Sync `.env.prod` to the Coolify production app. |
+| `bun run env:sync:stage:dry-run` | Preview the allowlisted `.env.stage` → Vercel staging sync. |
+| `bun run env:sync:stage` | Sync the allowlisted `.env.stage` to Vercel staging. |
 | `bun run env:sync:trigger` | Sync env vars to Trigger.dev. |
 | `bun run env:sync:gh` | Sync env vars to GitHub Actions secrets. |
 
@@ -108,20 +110,20 @@ Runtime is **Bun** (≥1.2.2).
 | Server          | Elysia (mounted inside TanStack Start middleware)   |
 | API contract    | Eden Treaty (end-to-end type safety, no codegen)    |
 | Auth + Payments | Better Auth + Polar plugin                          |
-| ORM             | Prisma → Neon (PostgreSQL)                          |
+| ORM             | Prisma → PostgreSQL (Coolify prod; Neon staging)    |
 | Validation      | TypeBox (server) + Zod (client forms)               |
 | UI              | ShadCN + Tailwind + Motion                          |
 | Background jobs | Trigger.dev                                         |
-| Email           | Resend + React Email                                |
+| Email           | React Email + Stalwart SMTP (Resend rollback path)  |
 | Error tracking  | Sentry                                              |
 | Avatars         | hashvatar (deterministic from username, no uploads) |
 | Runtime         | Bun                                                 |
-| Deployment      | Vercel                                              |
+| Deployment      | Coolify production; Vercel isolated staging        |
 
 ## Architecture
 
 ```
-TanStack Start (Vercel)
+TanStack Start (Coolify production / Vercel staging)
 ├── client: TanStack Router SPA
 └── server: Elysia middleware
     ├── /api/v3/auth/*  → Better Auth (+ Polar plugin)
@@ -136,7 +138,7 @@ TanStack Start's `api.$.ts` catch-all route forwards every `/api/*` request to t
 pstrack/
 ├── src/
 │   ├── components/          # Shared UI (shadcn primitives + app-level shells)
-│   ├── emails/              # React Email templates (Resend)
+│   ├── emails/              # React Email templates (transport-independent)
 │   ├── features/            # Feature modules (components + hooks per domain)
 │   ├── hooks/               # Global custom hooks
 │   ├── lib/                 # Client-side utilities, API client, query client
@@ -205,9 +207,12 @@ if (dbUser?.role !== "admin") return error(403, { error: "Admin access required"
 
 See `docs/FLOWS.md` for the full Daily Solve lifecycle, and `docs/POINTS.md` for clawback mechanics.
 
-## Email Notifications (Resend)
+## Email Notifications
 
-Transactional emails use **Resend** with **React Email** templates. Templates live in `src/emails/`.
+Transactional emails use **React Email** templates from `src/emails/`. Private
+Stalwart SMTP is the production target tracked by #289, staging is log-only,
+and the Resend transport remains until its retirement gate is proven.
+See `docs/OPERATIONS.md` for environment boundaries and runbooks.
 
 Notification triggers are co-located with the resource that owns the event:
 - `src/server/groups/groups.notifications.ts` - join request, approval, rejection, expiry, removal

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ Stay consistent with LeetCode — solve one problem a day, earn points, and comp
 
 ## Stack
 
-TanStack Start · Elysia · Eden Treaty · Better Auth · Prisma + Neon · Trigger.dev · Resend · Polar · Bun
+TanStack Start · Elysia · Eden Treaty · Better Auth · Prisma + PostgreSQL · Trigger.dev · Polar · Bun
+
+Production runs as a Bun container on Coolify with private PostgreSQL; private
+SMTP is the rollout target tracked by #289. Vercel is retained only for the
+isolated `stage` environment. See
+[`docs/OPERATIONS.md`](./docs/OPERATIONS.md) for environment ownership, data
+boundaries, deployment, recovery, and incident procedures.
 
 ## Develop
 

--- a/TODO.md
+++ b/TODO.md
@@ -349,12 +349,12 @@ No child remediation issue (#279–#294) is fully resolved and closed yet.
 
 ### Architecture and legacy cleanup — [#294](https://github.com/husamql3/pstrack/issues/294)
 
-- [ ] Reconcile README, AGENTS, stack docs, runbooks, ADRs, and environment examples with the actual Coolify architecture.
-- [ ] Document local, staging, and production environment ownership and data-flow boundaries.
-- [ ] Document deploy, rollback, backup, restore, reconciliation, credential rotation, and incident procedures.
+- [ ] Reconcile README, AGENTS, stack docs, runbooks, ADRs, and environment examples with the actual Coolify architecture. — _Implemented in the PR for #294; check only after review/merge and a fresh production evidence comparison._
+- [ ] Document local, staging, and production environment ownership and data-flow boundaries. — _Implemented in `docs/OPERATIONS.md`; awaiting the same verification gate._
+- [ ] Document deploy, rollback, backup, restore, reconciliation, credential rotation, and incident procedures. — _Implemented in `docs/OPERATIONS.md`; awaiting the same verification gate._
 - [ ] Remove obsolete Vercel deployment code/config/secrets after confirming it has no remaining role.
 - [ ] Remove retired Trigger.dev database access, Upstash, Resend, and legacy Neon references after each migration completes.
-- [ ] Audit duplicated or contradictory env-sync scripts and docs.
+- [ ] Audit duplicated or contradictory env-sync scripts and docs. — _Repository audit implemented: canonical commands are `env:sync:prod|stage|trigger|gh`; check after live destination-name comparison._
 - [ ] Keep this file synchronized with issue closure and production verification.
 
 ## Local environment follow-up
@@ -364,23 +364,28 @@ No child remediation issue (#279–#294) is fully resolved and closed yet.
 - [ ] Restrict `.env` from `0644` to `0600`.
 - [ ] Add an isolated local test database/bootstrap command and document destructive reset boundaries.
 - [ ] Standardize local/CI/production PostgreSQL major versions.
-- [ ] Decide whether Vercel tooling is being retired. If retained, upgrade the local CLI from 54.20.1 to 55.0.0 or newer.
+- [x] Decide whether Vercel tooling is being retired. — _Retained for isolated application staging; see ADR 0012 and `docs/STAGING.md`._
+- [ ] Upgrade the local Vercel CLI from 54.20.1 to the current supported release.
 
-## Architecture snapshot for the next agent
+## Architecture evidence pointer
 
-### Application and deployment path
+Required boundaries and procedures live in `docs/OPERATIONS.md`; current proof
+and residual migration state live in #278 and the child issues. The diagram
+below is a target topology, not proof that every migration is deployed.
+
+### Target application and deployment path
 
 ```text
 Browser
   -> HTTPS / canonical pstrack.app origin
   -> Coolify Traefik proxy
-  -> PStrack container (TanStack Start SPA + Elysia API, Node runtime)
+  -> PStrack container (TanStack Start SPA + Elysia API, Bun runtime)
        -> private PostgreSQL 18 container through Prisma
-       -> Upstash Redis REST (migration target: private Redis)
+       -> private Redis after the #288 rollout; no cache dependency before it
        -> Better Auth + Google/GitHub/Magic Link
        -> Polar checkout/webhooks
-       -> Resend today; Stalwart migration is open in PR #277
-       -> Trigger.dev scheduled tasks today
+       -> private Stalwart SMTP; Resend remains a rollback transport pending retirement
+       -> app-owned durable jobs dispatched by Trigger.dev Cloud over authenticated HTTP
 
 Private VPS services
   -> Coolify control plane and proxy
@@ -389,10 +394,10 @@ Private VPS services
   -> Stalwart
 ```
 
-The deployed application is currently selected through the mutable `main` image
-tag. CI also publishes a SHA tag, but Coolify is not yet instructed to deploy that
-immutable tag/digest. The deploy workflow returns after triggering Coolify rather
-than polling deployment completion or running end-to-end smoke checks.
+The environment boundaries and current deploy/rollback procedures are canonical
+in `docs/OPERATIONS.md`. Migration-specific production proof remains on the
+individual remediation issues; do not infer deployment from an open PR or this
+repository snapshot.
 
 ### Core correctness invariants
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -133,7 +133,7 @@
 - One-time payment: $14 standard, $9 sale
 - Promo codes supported natively in Polar
 
-### 8. Email Notifications (Resend)
+### 8. Email Notifications
 
 See [notifications.md](./notifications.md) for full event list.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,131 @@
+# Environment and Operations
+
+This is the source of truth for PStrack's required environment boundaries and
+operating procedures. ADRs record decisions at the time they were made; issue
+#278 and `TODO.md` remain the evidence ledger for what is production-verified.
+When an ADR conflicts with this file, add an amendment to the ADR. Never copy
+credential values into logs, issues, commits, or evidence.
+
+## Ownership and boundaries
+
+| Environment | Owner and source | Data boundary | External effects |
+|---|---|---|---|
+| Local | Developer; ignored `.env` | Local PostgreSQL and Redis only | Email defaults to `log`; use provider sandboxes |
+| Staging | `stage`; Vercel project | Dedicated Neon project with synthetic data; no production credentials or Redis | Dedicated OAuth apps, Polar sandbox, Trigger.dev staging, Sentry `staging`, email forced to `log` |
+| Production | `main`; GHCR image on Coolify | Private PostgreSQL and service network on the VPS | Production OAuth/Polar and Sentry; Trigger/Stalwart/Redis rollout proof stays on their remediation issues |
+
+The browser reaches Coolify's proxy, then the Bun application container. Only
+the application and operator-approved migration/backup paths may reach the
+production database. The required Trigger.dev design is scheduler-only:
+authenticated app dispatch with `JOB_DISPATCH_SECRET`, without database
+credentials. Consult #279/#290 before treating every production job as migrated.
+PointsHistory is the immutable points authority; cached totals are repaired
+from it, never the reverse.
+
+Vercel has one current role: application staging. `pstrack.vercel.app` is not
+production even though Vercel calls its deployment target “production.” Do not
+remove `scripts/sync-vercel.ts`, the staging workflow, Neon adapter, or Vercel
+configuration while ADR 0012 and `docs/STAGING.md` remain active.
+
+## Configuration ownership
+
+Ignored local files are inputs; platform stores are the runtime authorities.
+Run every sync in dry-run/list-names mode first where supported.
+
+| Command | Input | Destination | Allowed purpose |
+|---|---|---|---|
+| `bun run env:sync:prod` | `.env.prod` | Coolify production app | Production application variables |
+| `bun run env:sync:stage:dry-run` / `env:sync:stage` | `.env.stage` | Vercel staging | Explicit staging allowlist only |
+| `bun run env:sync:trigger` | `.env` | Trigger.dev | Dispatch URL/secret and scheduler configuration; never database URLs |
+| `bun run env:sync:gh` | `.env` | GitHub Actions | CI/deployment variables required by workflows; never production DB access for tests |
+
+Keep secret files ignored and mode `0600`. `.env.example` documents names and
+safe placeholders only. Rotate or delete a platform secret only after a usage
+search, platform variable-name inventory, successful replacement verification,
+and rollback decision.
+
+## Required deploy and promotion procedure
+
+1. Merge reviewed changes into `stage`; CI and the Vercel staging deployment
+   must pass the smoke contract in `docs/STAGING.md`.
+2. Promote the reviewed source revision to `main` through the protected release
+   path. Never rebuild unreviewed source for production.
+3. GitHub Actions must build the production OCI image, publish its immutable SHA
+   identity to GHCR, apply migrations through the approved release step, and
+   ask Coolify to deploy it. Issue #286 tracks production proof of this path.
+4. The deploy operation must poll to a terminal state, then verify revision,
+   environment identity, root, database-backed health, auth, and critical APIs.
+5. Record sanitized commit/image identity and smoke results. An open PR or green
+   build alone is not production verification.
+
+## Rollback
+
+For an application-only regression, select the last known-good immutable image,
+deploy it with `bun run scripts/rollback-coolify.ts`, wait for Coolify to finish,
+and rerun production smoke checks. Prefer forward fixes after additive database
+migrations; never roll application code back across an incompatible migration.
+If schema compatibility is uncertain, stop writes and escalate instead of
+guessing. Record the rollback target and verification without secret values.
+
+## Backup and restore
+
+The production backup service has created encrypted hourly PostgreSQL dumps in
+its separate repository. Fresh files prove backup creation, not recoverability;
+#283 tracks deployment of retention changes and a real isolated restore drill.
+
+Restore drills must use the newest completed dump, an isolated non-production
+database and storage path, and non-production provider credentials. Verify
+decryption, `pg_restore`, migration status, aggregate table counts, auth/session
+isolation, and points-ledger invariants; measure recovery time and data-loss
+window. Never restore over production or treat `pg_restore --list` as a drill.
+The detailed retention decision is in ADR 0006.
+
+## Reconciliation
+
+- Scheduled jobs: inspect the durable JobRun ledger by logical window and use
+  the authenticated reconciliation command for missing windows. Replays must
+  remain idempotent.
+- Points: run `bun run points:reconcile` read-only first. A repair requires a
+  fresh verified backup, expected mismatch count, and the procedure in
+  `docs/POINTS.md`; it updates cached totals only.
+- Staging: follow `docs/STAGING.md`; destructive reset/reseed requires explicit
+  approval and the fail-closed target checks.
+
+## Credential rotation
+
+Inventory variable names and consumers, create a replacement alongside the old
+credential, update the narrowest consumer set, verify authentication/signatures,
+then revoke the old credential and record owner/date. Rotate deploy, database,
+auth, and webhook credentials before telemetry credentials. OAuth and Polar
+rotations require callback/webhook tests. Backup keys require a fresh backup and
+isolated restore proof before revocation. Never rotate all sides simultaneously.
+
+## Incident response
+
+1. Declare the affected environment, user impact, start time, and incident owner.
+2. Preserve evidence: revision/digest, health status, sanitized logs, JobRun
+   windows, backup freshness, and aggregate database invariants.
+3. Contain the smallest surface. Disable a failing scheduler/provider or roll
+   back the app; do not reset databases or rewrite PointsHistory.
+4. Recover using the rollback or isolated-restore procedure, then verify the
+   complete browser → API → data → response path and provider callbacks.
+5. Reconcile skipped jobs and cached points after correctness is stable.
+6. Rotate credentials if exposure is plausible, document the timeline/root
+   cause/follow-ups, and update TODO/issue evidence only for proven outcomes.
+
+## Retirement gates
+
+Legacy integration code is intentionally retained until all gates pass:
+
+| Candidate | Current reason retained | Removal gate |
+|---|---|---|
+| Vercel + Neon adapter | Isolated staging | Replacement staging is live and ADR 0012 is superseded |
+| Resend transport | Email rollback path while Stalwart rollout completes | Stalwart canary/observation and rollback-retirement evidence |
+| Trigger.dev SDK | Active scheduler/dispatcher | A replacement scheduler is deployed and missed-window recovery proven |
+| Upstash references | Historical docs/post-MVP wording or migration tracking | Code/config usage search and private Redis production verification |
+
+For each retirement, search tracked code and history-facing docs, inventory live
+variable names in Coolify/Vercel/GitHub/Trigger.dev, remove code/config in one
+reviewable change, run all repository gates, deploy, observe, and only then
+delete provider credentials. Mark historical ADR text as superseded; do not
+silently rewrite it.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ A competitive programming accountability platform. Users join groups, solve one 
 | Validation | TypeBox (server) + Zod (client forms) |
 | Runtime | Bun |
 | Deployment | Coolify + GHCR |
-| Email | Resend |
+| Email | Stalwart SMTP production target (#289); log-only staging |
 | Background Jobs | Trigger.dev |
 | Payments | Polar ($5 one-time) |
 | Error Tracking | Sentry |
@@ -41,6 +41,7 @@ A competitive programming accountability platform. Users join groups, solve one 
 
 ## Docs
 
+- [Environment and Operations](./OPERATIONS.md)
 - [Stack](./stack.md)
 - [Schema](./schema.md)
 - [Features](./features.md)

--- a/docs/adr/0001-self-hosted-vps-deployment.md
+++ b/docs/adr/0001-self-hosted-vps-deployment.md
@@ -3,6 +3,14 @@
 **Date:** 2026-06-29  
 **Status:** Accepted
 
+> **2026-07 amendment:** The production-compute decision remains accepted, but
+> several implementation details below are historical. Production is amd64,
+> Stalwart replaced the proposed Postal service, backups run hourly, and Vercel
+> is intentionally retained as isolated application staging. ADRs 0006–0013
+> and `docs/OPERATIONS.md` supersede conflicting operational details. Managed
+> adapters/transports are removed only after their rollout and rollback gates
+> are proven; they must not be deleted merely because this ADR names a target.
+
 ---
 
 ## Context

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -2,7 +2,10 @@
 
 ## MVP: Email Only
 
-All notifications sent via **Resend** using **React Email** templates. No in-app inbox in v3 - that ships post-MVP alongside community features.
+Notifications are rendered with **React Email** templates. Private Stalwart SMTP
+is the production target tracked by #289, staging renders and logs metadata
+without sending, and Resend is retained until the retirement gate in
+[`OPERATIONS.md`](./OPERATIONS.md) is proven. No in-app inbox ships in v3.
 
 ## Events
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,7 +1,8 @@
 # Database Schema
 
 ORM: **Prisma**
-Database: **Neon (PostgreSQL)**
+Database: **PostgreSQL** — private Coolify service in production; isolated Neon
+project in Vercel staging
 
 ## Design Principles
 

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -68,11 +68,11 @@ pstrack/
 | API contract | Eden Treaty |
 | Auth | Better Auth + Polar plugin |
 | ORM | Prisma |
-| DB driver | @prisma/adapter-pg + pg |
+| DB driver | `@prisma/adapter-pg` for PostgreSQL; Neon adapter retained for Vercel staging |
 | Database | PostgreSQL on Coolify |
 | Schema validation | TypeBox (Elysia native) |
 | Background jobs | Trigger.dev |
-| Email | Resend (default) or self-hosted SMTP / Stalwart — see ADR 0013 |
+| Email | Stalwart SMTP production target (#289); log-only staging; Resend retained pending retirement |
 | Error tracking | Sentry |
 | Payments | Polar (via Better Auth plugin) |
 | Logging | pino |
@@ -88,9 +88,9 @@ pstrack/
 
 ## Trigger.dev Jobs
 
-Trigger.dev owns schedules only. Each task dispatches an authenticated request
-to the app, where the job runs beside the private database and is guarded by the
-durable `JobRun` idempotency ledger.
+The #279/#290 target keeps Trigger.dev schedule-only. Tasks dispatch authenticated
+requests to the app, where jobs run beside the private database and use the
+durable `JobRun` idempotency ledger; consult those issues for deployment proof.
 
 | Job | Trigger | Description |
 |---|---|---|
@@ -102,6 +102,18 @@ durable `JobRun` idempotency ledger.
 | `purge-system-events` | Cron: monthly | Applies event and JobRun retention policies |
 | `reconcile-points` | Cron: daily at 00:30 UTC | Checks ordered-ledger/cache equality and sends aggregate-only drift alerts |
 | `send-weekly-digest` | Cron: Monday | Sends the weekly admin digest |
+
+## Environment topology
+
+| Environment | Compute | Database | Redis | Email |
+|---|---|---|---|---|
+| Local | Bun/portless | local PostgreSQL | local Redis | log by default |
+| Staging (`stage`) | Vercel Node runtime | isolated Neon | absent; CI + production canary | log only |
+| Production (`main`) | Bun OCI image on Coolify | private PostgreSQL | target: private Redis; deployment proof tracked in #288 | target: private Stalwart SMTP; rollout proof tracked in #289 |
+
+The required Trigger.dev design is schedule-only authenticated HTTP dispatch
+without production database credentials; deployment proof remains on #279/#290.
+Detailed boundaries and runbooks live in [`OPERATIONS.md`](./OPERATIONS.md).
 
 ## Post-MVP Services (not in v3)
 
@@ -156,4 +168,7 @@ durable `JobRun` idempotency ledger.
 - sentry: upload source maps (SENTRY_AUTH_TOKEN)
 ```
 
-Vercel auto-deploys via its GitHub integration - no deploy job needed.
+Vercel deploys only application staging from `stage`. Production images are
+built from `main`, published to GHCR, and deployed through Coolify. See
+[`BRANCHING.md`](./BRANCHING.md), [`STAGING.md`](./STAGING.md), and
+[`OPERATIONS.md`](./OPERATIONS.md).


### PR DESCRIPTION
## What changed

- Reconcile README, AGENTS, stack, schema, notification, ADR, and environment guidance with Coolify production and isolated Vercel staging.
- Add a canonical operations runbook covering environment ownership, data boundaries, deploy/rollback, backup/restore, reconciliation, credential rotation, incidents, and retirement gates.
- Audit and document the distinct Coolify, Vercel, Trigger.dev, and GitHub environment sync targets.
- Update TODO without claiming production completion from repository-only evidence.

## Why

Issue #294 requires the repository to describe the actual hybrid architecture while preventing premature deletion of integrations that still serve staging, rollback, scheduling, or migrations.

## Impact

Operators and agents now have one boundary/runbook source and explicit proof gates before deleting Vercel/Neon, Resend, Trigger.dev, or Upstash-related configuration.

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run test` (127 tests)
- `bun run build`
- Two-axis standards/spec review
- `bun run knip` remains blocked by the pre-existing #293 unused-code baseline

## Residual gates

- Vercel remains required for staging, so its tooling is not retired.
- The local Vercel CLI is still 54.20.1 and should be upgraded to the current release.
- Managed-service code/secrets remain until their linked migration and production verification gates pass.
- This PR addresses #294 but intentionally does not close it from documentation evidence alone.

Refs #294
