### PR TITLE
fix(#334): enable email change via verification code

### DIFF
--- a/src/emails/otp-code.tsx
+++ b/src/emails/otp-code.tsx
@@ -1,0 +1,68 @@
+import { Section, Text } from "@react-email/components"
+
+import { EmailLayout, s } from "./layout"
+
+export type OtpType =
+	| "sign-in"
+	| "email-verification"
+	| "forget-password"
+	| "change-email"
+
+interface OtpCodeEmailProps {
+	otp: string
+	type: OtpType
+}
+
+const COPY: Record<OtpType, { heading: string; para: string; preview: string }> = {
+	"sign-in": {
+		heading: "Your sign-in code",
+		para: "Enter this code to sign in to PStrack. It expires in 5 minutes.",
+		preview: "Your PStrack sign-in code (expires in 5 min)",
+	},
+	"email-verification": {
+		heading: "Confirm it's you",
+		para: "Enter this code to confirm your identity before changing your email. It expires in 5 minutes.",
+		preview: "Your PStrack verification code (expires in 5 min)",
+	},
+	"forget-password": {
+		heading: "Reset your password",
+		para: "Enter this code to reset your PStrack password. It expires in 5 minutes.",
+		preview: "Your PStrack password reset code (expires in 5 min)",
+	},
+	"change-email": {
+		heading: "Verify your new email",
+		para: "Enter this code to confirm this is your new PStrack email address. It expires in 5 minutes.",
+		preview: "Confirm your new PStrack email (code expires in 5 min)",
+	},
+}
+
+export default function OtpCodeEmail({ otp, type }: OtpCodeEmailProps) {
+	const copy = COPY[type] ?? COPY["email-verification"]
+	return (
+		<EmailLayout
+			preview={copy.preview}
+			note="Didn't request this? You can safely ignore this email — nothing will change."
+			footerText="PStrack - Show up. Solve. Repeat."
+		>
+			<Text style={s.heading}>{copy.heading}</Text>
+			<Text style={s.para}>{copy.para}</Text>
+			<Section style={s.ctaSection}>
+				<Text style={code}>{otp}</Text>
+			</Section>
+		</EmailLayout>
+	)
+}
+
+const code = {
+	fontSize: "34px",
+	fontWeight: "700" as const,
+	letterSpacing: "10px",
+	color: "#18181b",
+	fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
+	backgroundColor: "#f4f4f5",
+	borderRadius: "8px",
+	padding: "16px 24px",
+	margin: "0",
+	display: "inline-block",
+	textAlign: "center" as const,
+}

--- a/src/features/settings/components/account/email-section.tsx
+++ b/src/features/settings/components/account/email-section.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
+import { useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 import { useForm } from "react-hook-form"
 import { sileo } from "sileo"
@@ -6,54 +7,160 @@ import { sileo } from "sileo"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { ME_QUERY_KEY } from "@/features/settings/hooks/use-me"
 import { authClient } from "@/lib/auth-client"
 import type { MeResponse } from "@/server/users/users.type"
-import { type EmailFormInput, emailFormSchema } from "@/server/users/users.type"
+import {
+	type ChangeEmailConfirmInput,
+	type ChangeEmailRequestInput,
+	changeEmailConfirmSchema,
+	changeEmailRequestSchema,
+} from "@/server/users/users.type"
 import { errorDescription } from "../../utils"
 import { SectionCard } from "../section-card"
 
-export const EmailSection = ({ me }: { me: MeResponse }) => {
-	const [editing, setEditing] = useState(false)
-	const form = useForm<EmailFormInput>({
-		resolver: zodResolver(emailFormSchema),
-		values: { email: me.email },
-	})
-	const { register, handleSubmit, formState, reset } = form
+type Step = "idle" | "request" | "confirm"
 
-	const onSubmit = handleSubmit(async ({ email }) => {
-		if (email === me.email) {
-			setEditing(false)
-			return
-		}
-		await sileo.promise(
+const otpInputProps = {
+	inputMode: "numeric" as const,
+	autoComplete: "one-time-code",
+	maxLength: 6,
+	placeholder: "000000",
+	className: "max-w-[12rem] tracking-[0.4em]",
+}
+
+export const EmailSection = ({ me }: { me: MeResponse }) => {
+	const queryClient = useQueryClient()
+	const [step, setStep] = useState<Step>("idle")
+	const [pendingEmail, setPendingEmail] = useState("")
+
+	const requestForm = useForm<ChangeEmailRequestInput>({
+		resolver: zodResolver(changeEmailRequestSchema),
+		defaultValues: { newEmail: "", currentOtp: "" },
+	})
+	const confirmForm = useForm<ChangeEmailConfirmInput>({
+		resolver: zodResolver(changeEmailConfirmSchema),
+		defaultValues: { newOtp: "" },
+	})
+
+	// Fire a fresh code to the CURRENT inbox — required before requestEmailChange
+	// because the plugin runs with verifyCurrentEmail: true.
+	const sendCurrentCode = () =>
+		sileo.promise(
 			(async () => {
-				const { error } = await authClient.changeEmail({
-					newEmail: email,
-					callbackURL: "/settings/account",
+				const { error } = await authClient.emailOtp.sendVerificationOtp({
+					email: me.email,
+					type: "email-verification",
 				})
-				if (error) throw new Error(error.message ?? "Couldn't change email")
+				if (error) throw new Error(error.message ?? "Couldn't send the code")
 			})(),
 			{
-				loading: { title: "Sending verification..." },
+				loading: { title: "Sending code..." },
 				success: {
-					title: "Verification sent",
-					description: `Check ${email} to confirm the change.`,
+					title: "Code sent",
+					description: `Check ${me.email} for a 6-digit code.`,
 				},
 				error: (err) => ({
-					title: "Couldn't change email",
+					title: "Couldn't send the code",
 					description: errorDescription(err),
 				}),
 			}
 		)
-		setEditing(false)
+
+	const startChange = async () => {
+		await sendCurrentCode()
+		setStep("request")
+	}
+
+	const cancel = () => {
+		requestForm.reset()
+		confirmForm.reset()
+		setPendingEmail("")
+		setStep("idle")
+	}
+
+	// Step 1 → verify the current inbox, then send a code to the new inbox.
+	const onRequest = requestForm.handleSubmit(async ({ newEmail, currentOtp }) => {
+		if (newEmail === me.email) {
+			requestForm.setError("newEmail", {
+				message: "That's already your email address.",
+			})
+			return
+		}
+		await sileo
+			.promise(
+				(async () => {
+					const { error } = await authClient.emailOtp.requestEmailChange({
+						newEmail,
+						otp: currentOtp,
+					})
+					if (error) throw new Error(error.message ?? "Couldn't verify the code")
+				})(),
+				{
+					loading: { title: "Verifying..." },
+					success: {
+						title: "Code sent to your new email",
+						description: `Enter the code we sent to ${newEmail}.`,
+					},
+					error: (err) => ({
+						title: "Couldn't verify the code",
+						description: errorDescription(err),
+					}),
+				}
+			)
+			.then(() => {
+				setPendingEmail(newEmail)
+				confirmForm.reset()
+				setStep("confirm")
+			})
+			.catch(() => {})
 	})
+
+	// Step 2 → verify the new inbox; on success the address is swapped + verified.
+	const onConfirm = confirmForm.handleSubmit(async ({ newOtp }) => {
+		await sileo
+			.promise(
+				(async () => {
+					const { error } = await authClient.emailOtp.changeEmail({
+						newEmail: pendingEmail,
+						otp: newOtp,
+					})
+					if (error) throw new Error(error.message ?? "Couldn't change email")
+				})(),
+				{
+					loading: { title: "Updating email..." },
+					success: {
+						title: "Email updated",
+						description: `Your email is now ${pendingEmail}.`,
+					},
+					error: (err) => ({
+						title: "Couldn't change email",
+						description: errorDescription(err),
+					}),
+				}
+			)
+			.then(async () => {
+				await queryClient.invalidateQueries({ queryKey: ME_QUERY_KEY })
+				cancel()
+			})
+			.catch(() => {})
+	})
+
+	// Resend the new-inbox code — verifyCurrentEmail consumed the current-inbox
+	// code, so a resend has to restart from step 1 with a fresh one.
+	const startOver = async () => {
+		confirmForm.reset()
+		requestForm.reset({ newEmail: pendingEmail, currentOtp: "" })
+		setStep("request")
+		await sendCurrentCode()
+	}
 
 	return (
 		<SectionCard
 			title="Email"
-			description="Used for sign-in and notifications. Changing it requires re-verification."
+			description="Used for sign-in and notifications. Changing it requires a code sent to both your current and new address."
 		>
-			{!editing ? (
+			{step === "idle" && (
 				<div className="flex items-center justify-between gap-3">
 					<div className="min-w-0">
 						<p className="truncate font-medium text-sm">{me.email}</p>
@@ -61,39 +168,96 @@ export const EmailSection = ({ me }: { me: MeResponse }) => {
 							{me.emailVerified ? "Verified" : "Pending verification"}
 						</p>
 					</div>
-					<Button variant="outline" size="sm" onClick={() => setEditing(true)}>
+					<Button variant="outline" size="sm" onClick={startChange}>
 						Change email
 					</Button>
 				</div>
-			) : (
-				<form onSubmit={onSubmit} className="flex flex-col gap-3">
+			)}
+
+			{step === "request" && (
+				<form onSubmit={onRequest} className="flex flex-col gap-3">
+					<p className="text-muted-foreground text-sm">
+						We sent a 6-digit code to <strong>{me.email}</strong>. Enter it and your new
+						email address.
+					</p>
 					<div className="grid gap-1.5">
-						<Label htmlFor="email">New email address</Label>
+						<Label htmlFor="currentOtp">Code from your current email</Label>
 						<Input
-							id="email"
-							type="email"
-							autoComplete="email"
-							{...register("email")}
-							className="max-w-md"
+							id="currentOtp"
+							{...otpInputProps}
+							{...requestForm.register("currentOtp")}
 						/>
-						{formState.errors.email && (
-							<p className="text-destructive text-xs">{formState.errors.email.message}</p>
+						{requestForm.formState.errors.currentOtp && (
+							<p className="text-destructive text-xs">
+								{requestForm.formState.errors.currentOtp.message}
+							</p>
 						)}
 					</div>
-					<div className="flex gap-2">
-						<Button
-							type="button"
-							variant="outline"
-							size="sm"
-							onClick={() => {
-								reset({ email: me.email })
-								setEditing(false)
-							}}
-						>
+					<div className="grid gap-1.5">
+						<Label htmlFor="newEmail">New email address</Label>
+						<Input
+							id="newEmail"
+							type="email"
+							autoComplete="email"
+							className="max-w-md"
+							{...requestForm.register("newEmail")}
+						/>
+						{requestForm.formState.errors.newEmail && (
+							<p className="text-destructive text-xs">
+								{requestForm.formState.errors.newEmail.message}
+							</p>
+						)}
+					</div>
+					<div className="flex flex-wrap items-center gap-2">
+						<Button type="submit" size="sm" disabled={requestForm.formState.isSubmitting}>
+							Continue
+						</Button>
+						<Button type="button" variant="outline" size="sm" onClick={cancel}>
 							Cancel
 						</Button>
-						<Button type="submit" size="sm" disabled={formState.isSubmitting}>
-							Send verification
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							onClick={sendCurrentCode}
+							disabled={requestForm.formState.isSubmitting}
+						>
+							Resend code
+						</Button>
+					</div>
+				</form>
+			)}
+
+			{step === "confirm" && (
+				<form onSubmit={onConfirm} className="flex flex-col gap-3">
+					<p className="text-muted-foreground text-sm">
+						We sent a 6-digit code to <strong>{pendingEmail}</strong>. Enter it to confirm
+						the change.
+					</p>
+					<div className="grid gap-1.5">
+						<Label htmlFor="newOtp">Code from your new email</Label>
+						<Input id="newOtp" {...otpInputProps} {...confirmForm.register("newOtp")} />
+						{confirmForm.formState.errors.newOtp && (
+							<p className="text-destructive text-xs">
+								{confirmForm.formState.errors.newOtp.message}
+							</p>
+						)}
+					</div>
+					<div className="flex flex-wrap items-center gap-2">
+						<Button type="submit" size="sm" disabled={confirmForm.formState.isSubmitting}>
+							Confirm change
+						</Button>
+						<Button type="button" variant="outline" size="sm" onClick={cancel}>
+							Cancel
+						</Button>
+						<Button
+							type="button"
+							variant="ghost"
+							size="sm"
+							onClick={startOver}
+							disabled={confirmForm.formState.isSubmitting}
+						>
+							Start over
 						</Button>
 					</div>
 				</form>

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -2,6 +2,7 @@ import { dashClient, sentinelClient } from "@better-auth/infra/client"
 import { polarClient } from "@polar-sh/better-auth"
 import {
 	adminClient,
+	emailOTPClient,
 	inferAdditionalFields,
 	magicLinkClient,
 } from "better-auth/client/plugins"
@@ -15,6 +16,7 @@ export const authClient = createAuthClient({
 	basePath: "/api/v3/auth",
 	plugins: [
 		magicLinkClient(),
+		emailOTPClient(),
 		adminClient(),
 		polarClient(),
 		inferAdditionalFields<Auth>(),

--- a/src/server/lib/auth.ts
+++ b/src/server/lib/auth.ts
@@ -2,7 +2,7 @@ import { dash } from "@better-auth/infra"
 import { checkout, polar, webhooks } from "@polar-sh/better-auth"
 import { betterAuth } from "better-auth"
 import { prismaAdapter } from "better-auth/adapters/prisma"
-import { admin, magicLink } from "better-auth/plugins"
+import { admin, emailOTP, magicLink } from "better-auth/plugins"
 
 import WelcomeEmail from "@/emails/welcome"
 import { env } from "@/env"
@@ -11,6 +11,7 @@ import { db } from "@/server/lib/db"
 import { sendEmail } from "@/server/lib/email"
 import { logger } from "@/server/lib/logger"
 import { sendMagicLinkEmail } from "@/server/lib/magic-link-email"
+import { sendOtpEmail } from "@/server/lib/otp-email"
 import { polarClient } from "@/server/lib/polar"
 import { grantProFromPurchase, revokeProFromRefund } from "@/server/lib/pro"
 
@@ -102,6 +103,20 @@ export const auth = betterAuth({
 		magicLink({
 			sendMagicLink: async ({ email, url }) => {
 				await sendMagicLinkEmail({ email, url })
+			},
+		}),
+		// Enables the change-email flow (issue #334). The core changeEmail plugin
+		// is link-based; we use OTP codes instead. verifyCurrentEmail requires the
+		// user to prove the CURRENT inbox (a code) before a code is sent to the NEW
+		// inbox — so an account move needs control of both addresses.
+		emailOTP({
+			otpLength: 6,
+			expiresIn: 300,
+			storeOTP: "hashed",
+			allowedAttempts: 3,
+			changeEmail: { enabled: true, verifyCurrentEmail: true },
+			sendVerificationOTP: async ({ email, otp, type }) => {
+				await sendOtpEmail({ email, otp, type })
 			},
 		}),
 		admin(),

--- a/src/server/lib/otp-email.test.ts
+++ b/src/server/lib/otp-email.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+	env: {
+		EMAIL_FROM: "PStrack <test@example.com>",
+		NODE_ENV: "development",
+	},
+	loggerDebug: vi.fn(),
+	loggerError: vi.fn(),
+	loggerWarn: vi.fn(),
+	sendEmail: vi.fn(),
+}))
+
+vi.mock("@/env", () => ({ env: mocks.env }))
+vi.mock("@/server/lib/email", () => ({ sendEmail: mocks.sendEmail }))
+vi.mock("@/server/lib/logger", () => ({
+	logger: {
+		debug: mocks.loggerDebug,
+		error: mocks.loggerError,
+		warn: mocks.loggerWarn,
+	},
+}))
+vi.mock("@/emails/otp-code", () => ({
+	default: ({ otp, type }: { otp: string; type: string }) => ({
+		type: "OtpCodeEmail",
+		props: { otp, type },
+	}),
+}))
+
+import { sendOtpEmail } from "./otp-email"
+
+describe("sendOtpEmail", () => {
+	beforeEach(() => {
+		mocks.env.NODE_ENV = "development"
+		mocks.sendEmail.mockReset()
+		mocks.loggerDebug.mockReset()
+		mocks.loggerError.mockReset()
+		mocks.loggerWarn.mockReset()
+	})
+
+	it("sends the code with the type-specific subject", async () => {
+		mocks.sendEmail.mockResolvedValueOnce({ id: "1" })
+
+		await sendOtpEmail({
+			email: "new@example.com",
+			otp: "123456",
+			type: "change-email",
+		})
+
+		expect(mocks.sendEmail).toHaveBeenCalledWith(
+			expect.objectContaining({
+				to: "new@example.com",
+				subject: "Confirm your new PStrack email",
+			})
+		)
+	})
+
+	it("does not throw in development when Resend cannot send", async () => {
+		mocks.sendEmail.mockRejectedValueOnce(new Error("Resend unavailable"))
+
+		await expect(
+			sendOtpEmail({
+				email: "user@example.com",
+				otp: "654321",
+				type: "email-verification",
+			})
+		).resolves.toBeUndefined()
+
+		expect(mocks.loggerWarn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				email: "user@example.com",
+				otp: "654321",
+				type: "email-verification",
+			}),
+			"otp email failed in development; using logged code fallback"
+		)
+	})
+
+	it("rethrows email failures outside development", async () => {
+		mocks.env.NODE_ENV = "production"
+		mocks.sendEmail.mockRejectedValueOnce(new Error("Resend unavailable"))
+
+		await expect(
+			sendOtpEmail({
+				email: "user@example.com",
+				otp: "654321",
+				type: "change-email",
+			})
+		).rejects.toThrow("Resend unavailable")
+	})
+})

--- a/src/server/lib/otp-email.ts
+++ b/src/server/lib/otp-email.ts
@@ -1,0 +1,49 @@
+import OtpCodeEmail, { type OtpType } from "@/emails/otp-code"
+import { env } from "@/env"
+import { sendEmail } from "@/server/lib/email"
+import { logger } from "@/server/lib/logger"
+
+const SUBJECTS: Record<OtpType, string> = {
+	"sign-in": "Your PStrack sign-in code",
+	"email-verification": "Your PStrack verification code",
+	"forget-password": "Your PStrack password reset code",
+	"change-email": "Confirm your new PStrack email",
+}
+
+/**
+ * Send a one-time verification code. Used by the Better Auth emailOTP plugin's
+ * `sendVerificationOTP` callback — the change-email flow sends two codes through
+ * here: one to the current inbox (`email-verification`) and one to the new inbox
+ * (`change-email`).
+ *
+ * Mirrors `sendMagicLinkEmail`: in development a Resend failure logs the code and
+ * resolves (so the flow is testable without email creds); in production it rethrows.
+ */
+export const sendOtpEmail = async ({
+	email,
+	otp,
+	type,
+}: {
+	email: string
+	otp: string
+	type: OtpType
+}) => {
+	try {
+		await sendEmail({
+			from: env.EMAIL_FROM,
+			to: email,
+			subject: SUBJECTS[type] ?? "Your PStrack code",
+			react: OtpCodeEmail({ otp, type }),
+		})
+	} catch (err) {
+		logger.error({ err, email, type }, "otp email failed")
+		if (env.NODE_ENV === "development") {
+			logger.warn(
+				{ err, email, otp, type },
+				"otp email failed in development; using logged code fallback"
+			)
+			return
+		}
+		throw err
+	}
+}

--- a/src/server/users/users.type.ts
+++ b/src/server/users/users.type.ts
@@ -156,8 +156,24 @@ export const notificationsFormSchema = z.object({
 
 export type NotificationsFormInput = z.infer<typeof notificationsFormSchema>
 
-export const emailFormSchema = z.object({
-	email: z.string().trim().email({ error: "Invalid email address" }),
+// ─── Change email (OTP flow) ──────────────────────────────────────────────────
+// Step 1: prove the current inbox + name the new address. Step 2: prove the new
+// inbox. Codes are 6 numeric digits (Better Auth emailOTP default otpLength).
+
+const OTP_CODE = z
+	.string()
+	.trim()
+	.regex(/^\d{6}$/, { error: "Enter the 6-digit code" })
+
+export const changeEmailRequestSchema = z.object({
+	newEmail: z.string().trim().email({ error: "Invalid email address" }),
+	currentOtp: OTP_CODE,
 })
 
-export type EmailFormInput = z.infer<typeof emailFormSchema>
+export type ChangeEmailRequestInput = z.infer<typeof changeEmailRequestSchema>
+
+export const changeEmailConfirmSchema = z.object({
+	newOtp: OTP_CODE,
+})
+
+export type ChangeEmailConfirmInput = z.infer<typeof changeEmailConfirmSchema>


### PR DESCRIPTION
## Summary
- **Fixes the 400 on `POST /api/v3/auth/change-email`** (#334) — Better Auth ships the change-email feature disabled by default, so the endpoint rejected every request with `"Change email is disabled"`. The account settings UI was already wired correctly; the server simply never enabled the flow.
- **Enables it via the `emailOTP` plugin with a two-inbox code flow**, not magic links — `changeEmail: { enabled: true, verifyCurrentEmail: true }`. The user proves control of the **current** inbox with a 6-digit code, then the **new** inbox with a second code before the address is swapped. This protects against a hijacked session silently moving the account to an attacker's address.
- **Rebuilt `EmailSection` into a two-step inline wizard** — step 1 takes the current-email code + the new address; step 2 takes the new-email code. On success it invalidates the `me` query so the settings page reflects the new address immediately. Includes resend / start-over affordances and inline error surfacing for invalid/expired/too-many-attempts.
- **New parametrized OTP email template + `sendOtpEmail` helper** — one `EmailLayout`-based template renders the code (branching subject/copy per OTP type); the helper mirrors `sendMagicLinkEmail`, logging the code in development when Resend is unavailable so the flow is testable without email creds. Unit-tested.
- **6-digit / 5-min / hashed OTP storage; no DB migration** — reuses the existing `Verification` table.

## Testing
1. `bun run typecheck` · `bun run check` · `bun run build` — all green.
2. `bun run test` — 78 unit tests pass, including the new `sendOtpEmail` suite. (The pre-existing `daily-loop.integration.test.ts` fails locally on missing `DATABASE_URL`; unchanged by this PR.)
3. Manual: Settings → Account → Change email → enter the code sent to the current inbox + a new address → enter the code sent to the new address → email updates and shows Verified. In dev, both codes are printed to the server log if Resend isn't configured.

Closes #334

---

## Glossary
| Term | Definition |
|------|------------|
| OTP | One-Time Password — a short single-use numeric code emailed to the user and typed back in, as opposed to a click-through magic link. |
| `emailOTP` plugin | Better Auth plugin providing code-based email verification, sign-in, and the change-email endpoints (`/email-otp/request-email-change`, `/email-otp/change-email`). |
| `verifyCurrentEmail` | Plugin option that requires proving the current inbox (via a code) before a code is sent to the new inbox — the two-inbox guarantee. |
| `Verification` table | Better Auth's existing token/OTP storage table; reused here, so no schema migration is needed. |
| `sensitiveSessionMiddleware` | Better Auth middleware guarding the change-email endpoints — requires a logged-in session checked against the DB (not the cookie cache). Note: no session-freshness requirement. |