### PR TITLE
feat: tee server errors to admin bot + hourly ops digest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,7 @@ if (dbUser?.role !== "admin") return error(403, { error: "Admin access required"
 | `expire-join-requests` | Every hour | Marks `GroupJoinRequest` rows older than 1 day with status `PENDING` as `EXPIRED` |
 | `reset-monthly-pauses` | `0 0 1 * *` | Resets `User.pausesUsedThisMonth = 0` |
 | `reset-monthly-counters` | `0 0 1 * *` | Resets `User.verificationFailuresThisMonth = 0` |
+| `send-hourly-digest` | `0 * * * *` | Fires `digest.hourly` to the admin bot with last-hour activity + stale-job health (bot enriches with the hour's error count and skips empty hours) |
 
 `mark-missed` and `assign-daily-problem` both run at midnight UTC. The assign job runs first (sorted by `scheduleId`); `mark-missed` operates on the previous day's rows so there is no ordering conflict.
 
@@ -225,6 +226,14 @@ groupNotifications.joinRequested(groupId, userId).catch(() => {})
 ```
 
 This prevents email delivery failures from blocking the user's request. Users can opt out per category from `/settings/notifications`.
+
+## Admin Bot (husam-bot)
+
+Operator-facing telemetry goes to the external **husam-bot** Telegram service via `notifyAdmin(event, payload)` in `src/server/lib/bot.ts` (POSTs `{event, payload}` to `${BOT_URL}/api/notify` with a bearer secret; no-op when `BOT_URL` is unset). The bot validates every event against a Zod discriminated union — **there is no generic fallback, so a new event must be registered on the bot side too**, or it 400s. Contract lives in husam-bot `docs/adr/0002` + `0003`.
+
+Events fired today: `user.created`, `purchase.pro`, `purchase.pro.refunded`, `feedback.submitted`, `join.requested`, `pro.expired`, `points.reconciliation_drift`, `points.reconciliation_failed`, `digest.daily`, `digest.hourly`, `digest.weekly`, `streak.milestone`, `badge.earned`, `error.captured`, and `system.event` (a curated subset of `SystemEventType` — see AgDR-0001 in `system-events.dao.ts`).
+
+**Error tee (`error.captured`):** `captureServerException` mirrors every server-side capture to the bot in **production only**, fire-and-forget, with a redacted payload (type, truncated message, culprit frame, route, `userId`, fingerprint). The bot bounds volume with Redis-backed dedup + per-hour rate limiting, so an error storm can't flood the channel. Client/browser errors are **not** teed — they stay in Sentry.io.
 
 ## Routes Summary
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -50,7 +50,7 @@ const api = new Elysia({ prefix: "/api/v3" })
 		const { pathname } = new URL(request.url)
 		logger.error({ err: error, path: pathname }, "[api-error]")
 		console.error("[api-error]", pathname, error)
-		captureServerException(error)
+		captureServerException(error, { route: pathname, method: request.method })
 		await ServerSentry.flush(2000)
 	})
 

--- a/src/server/jobs/job-runs.service.ts
+++ b/src/server/jobs/job-runs.service.ts
@@ -1,9 +1,26 @@
 import { Prisma } from "@/generated/prisma/client"
 import { JobRunStatus } from "@/generated/prisma/enums"
 import { db } from "@/server/lib/db"
-import type { JobName } from "./jobs.types"
+import { JOB_NAMES, type JobName } from "./jobs.types"
 
 const STALE_RUN_MS = 15 * 60 * 1000
+
+// How long after a successful run a job is still considered "fresh". Beyond this
+// it's reported as stale by /freshness and flagged in the hourly ops digest.
+// Single source of truth shared by the freshness endpoint and getStaleJobNames.
+export const FRESHNESS_MS: Record<JobName, number> = {
+	"assign-daily-problem": 26 * 60 * 60 * 1000,
+	"mark-missed": 26 * 60 * 60 * 1000,
+	"expire-join-requests": 2 * 60 * 60 * 1000,
+	"reset-monthly-counters": 32 * 24 * 60 * 60 * 1000,
+	"expire-admin-pro-grants": 26 * 60 * 60 * 1000,
+	"purge-system-events": 32 * 24 * 60 * 60 * 1000,
+	"send-weekly-digest": 8 * 24 * 60 * 60 * 1000,
+	"send-hourly-digest": 90 * 60 * 1000,
+	"reconcile-points": 26 * 60 * 60 * 1000,
+	"reset-today-problems": Number.POSITIVE_INFINITY,
+	"reconcile-mark-missed": Number.POSITIVE_INFINITY,
+}
 
 type JobResult = Record<string, unknown>
 
@@ -107,4 +124,21 @@ export const getJobFreshness = async () => {
 		select: { jobName: true, finishedAt: true, idempotencyKey: true },
 	})
 	return rows
+}
+
+// Scheduled jobs whose last success is older than their freshness window.
+// Jobs that have never run are NOT flagged (avoids false alarms on a fresh
+// deploy before each cron's first tick); manual/on-demand jobs (Infinity
+// threshold) are excluded entirely.
+export const getStaleJobNames = async (now: Date): Promise<JobName[]> => {
+	const latest = await getJobFreshness()
+	const finishedByName = new Map(latest.map((run) => [run.jobName, run.finishedAt]))
+	const nowMs = now.getTime()
+	return JOB_NAMES.filter((jobName) => {
+		const threshold = FRESHNESS_MS[jobName]
+		if (!Number.isFinite(threshold)) return false
+		const finishedAt = finishedByName.get(jobName)
+		if (!finishedAt) return false
+		return nowMs - finishedAt.getTime() > threshold
+	})
 }

--- a/src/server/jobs/jobs.controller.ts
+++ b/src/server/jobs/jobs.controller.ts
@@ -2,7 +2,7 @@ import { timingSafeEqual } from "node:crypto"
 import { Elysia, status, t } from "elysia"
 
 import { env } from "@/env"
-import { executeJobRun, getJobFreshness } from "./job-runs.service"
+import { executeJobRun, FRESHNESS_MS, getJobFreshness } from "./job-runs.service"
 import { executeJob } from "./jobs.service"
 import { isJobName, JOB_NAMES } from "./jobs.types"
 
@@ -17,19 +17,6 @@ const isAuthorized = (request: Request) => {
 		actualBuffer.length === expectedBuffer.length &&
 		timingSafeEqual(actualBuffer, expectedBuffer)
 	)
-}
-
-const FRESHNESS_MS: Record<(typeof JOB_NAMES)[number], number> = {
-	"assign-daily-problem": 26 * 60 * 60 * 1000,
-	"mark-missed": 26 * 60 * 60 * 1000,
-	"expire-join-requests": 2 * 60 * 60 * 1000,
-	"reset-monthly-counters": 32 * 24 * 60 * 60 * 1000,
-	"expire-admin-pro-grants": 26 * 60 * 60 * 1000,
-	"purge-system-events": 32 * 24 * 60 * 60 * 1000,
-	"send-weekly-digest": 8 * 24 * 60 * 60 * 1000,
-	"reconcile-points": 26 * 60 * 60 * 1000,
-	"reset-today-problems": Number.POSITIVE_INFINITY,
-	"reconcile-mark-missed": Number.POSITIVE_INFINITY,
 }
 
 export const jobsController = new Elysia({ prefix: "/internal/jobs" })

--- a/src/server/jobs/jobs.service.ts
+++ b/src/server/jobs/jobs.service.ts
@@ -10,9 +10,11 @@ import { captureServerException } from "@/server/lib/sentry"
 import { auditCachedTotals } from "@/server/points/points.reconciliation"
 import { problemsDao } from "@/server/problems/problems.dao"
 import { systemEventsDao } from "@/server/system-events/system-events.dao"
+import { getStaleJobNames } from "./job-runs.service"
 import type { JobName } from "./jobs.types"
 
 const DAY_MS = 86_400_000
+const HOUR_MS = 60 * 60 * 1000
 const CATCH_UP_DAYS = 14
 const DIGEST_BATCH_SIZE = 100
 const SYSTEM_EVENT_RETENTION_DAYS = 90
@@ -77,8 +79,32 @@ const assignDailyProblem = async (scheduledAt: Date) => {
 		newUsers: stats.newUsers,
 		pausesUsed: stats.pausesUsed,
 		handleChanges: stats.handleChanges,
+		misses: stats.misses,
+		verificationFailures: stats.verificationFailures,
 	})
 	return { ...result, ...delivery }
+}
+
+// Hourly ops pulse: last-hour app activity + stale-job health. The bot enriches
+// this with the last-hour error count (from its Redis counter) and makes the
+// final skip-empty decision, so a silent hour that still had errors is sent.
+const sendHourlyDigest = async (scheduledAt: Date) => {
+	const to = scheduledAt
+	const from = new Date(to.getTime() - HOUR_MS)
+	const stats = await problemsDao.getActivityStats(from, to)
+	const staleJobs = await getStaleJobNames(scheduledAt)
+	await notifyAdmin("digest.hourly", {
+		hourStart: from.toISOString(),
+		hourEnd: to.toISOString(),
+		solves: stats.solves,
+		activeUsers: stats.activeUsers,
+		newUsers: stats.newUsers,
+		pauses: stats.pauses,
+		misses: stats.misses,
+		verificationFailures: stats.verificationFailures,
+		staleJobs,
+	})
+	return { ...stats, staleJobs: staleJobs.length }
 }
 
 const markMissed = async (scheduledAt: Date) => {
@@ -259,6 +285,8 @@ export const executeJob = async (
 			return purgeSystemEvents()
 		case "send-weekly-digest":
 			return sendWeeklyDigest(scheduledAt)
+		case "send-hourly-digest":
+			return sendHourlyDigest(scheduledAt)
 		case "reconcile-points":
 			return reconcilePoints()
 		case "reset-today-problems":

--- a/src/server/jobs/jobs.types.ts
+++ b/src/server/jobs/jobs.types.ts
@@ -6,6 +6,7 @@ export const JOB_NAMES = [
 	"expire-admin-pro-grants",
 	"purge-system-events",
 	"send-weekly-digest",
+	"send-hourly-digest",
 	"reconcile-points",
 	"reset-today-problems",
 	"reconcile-mark-missed",

--- a/src/server/lib/sentry.ts
+++ b/src/server/lib/sentry.ts
@@ -2,6 +2,7 @@ import type { User } from "@sentry/node"
 import * as Sentry from "@sentry/node"
 
 import { env } from "@/env"
+import { notifyAdmin } from "@/server/lib/bot"
 
 let isInitialized = false
 
@@ -26,6 +27,67 @@ export function initServerSentry() {
 	})
 }
 
+const ERROR_MESSAGE_MAX = 300
+
+// Strip anything email- or token-shaped before it heads to the (plain-text)
+// Telegram channel. The unredacted detail still lands fully in Sentry.
+const redactForBot = (value: string): string =>
+	value
+		.replace(/[\w.+-]+@[\w-]+\.[\w.-]+/g, "[email]")
+		.replace(/\b[A-Za-z0-9_-]{24,}\b/g, "[token]")
+
+// Pull the first "at … (path:line:col)" frame out of a stack trace and shorten
+// the path to its last two segments so the culprit stays readable in a chat.
+const topStackFrame = (stack: string | undefined): string | undefined => {
+	if (!stack) return undefined
+	for (const line of stack.split("\n")) {
+		const match = line.match(/\(?([^\s()]+:\d+:\d+)\)?\s*$/)
+		if (match && /[/\\]/.test(match[1])) {
+			return match[1].split(/[/\\]/).slice(-2).join("/")
+		}
+	}
+	return undefined
+}
+
+const currentUserId = (): string | undefined => {
+	try {
+		const id = Sentry.getCurrentScope().getUser()?.id
+		return id == null ? undefined : String(id)
+	} catch {
+		return undefined
+	}
+}
+
+// Mirror a server-side capture to the admin Telegram bot as `error.captured`.
+// Production-only (dev/stage churn would dilute the channel) and fire-and-forget
+// — the bot side owns dedup + rate-limiting so an error storm can't flood chat.
+function teeErrorToBot(error: unknown, context?: Record<string, unknown>) {
+	if (env.NODE_ENV !== "production") return
+
+	const err = error instanceof Error ? error : undefined
+	const errorType = err?.name ?? "UnknownError"
+	const message = redactForBot(err?.message ?? String(error)).slice(0, ERROR_MESSAGE_MAX)
+	const culprit = topStackFrame(err?.stack)
+	const route = typeof context?.route === "string" ? context.route : undefined
+	const method = typeof context?.method === "string" ? context.method : undefined
+	const tag = typeof context?.tag === "string" ? context.tag : undefined
+	const userId =
+		(typeof context?.userId === "string" ? context.userId : undefined) ?? currentUserId()
+
+	void notifyAdmin("error.captured", {
+		errorType,
+		message,
+		culprit,
+		route,
+		method,
+		tag,
+		userId,
+		environment: env.SENTRY_ENVIRONMENT ?? env.NODE_ENV,
+		fingerprint: `${errorType}:${culprit ?? "unknown"}`,
+		occurredAt: new Date().toISOString(),
+	})
+}
+
 export function captureServerException(
 	error: unknown,
 	context?: Record<string, unknown>
@@ -38,6 +100,7 @@ export function captureServerException(
 	} else {
 		Sentry.captureException(error)
 	}
+	teeErrorToBot(error, context)
 }
 
 export function captureServerMessage(message: string, context: Record<string, unknown>) {

--- a/src/server/problems/problems.dao.ts
+++ b/src/server/problems/problems.dao.ts
@@ -415,47 +415,104 @@ export const problemsDao = {
 
 	getDailySolveStats: async (date: Date) => {
 		const yesterday = new Date(date.getTime() - 86_400_000)
-		const [totalSolves, solvers, newUsers, pausesUsed, handleChanges] = await Promise.all(
-			[
-				db.userSolve.count({
-					where: {
-						status: SolveStatus.SOLVED,
-						dailyProblem: { assignedDate: yesterday },
+		const [
+			totalSolves,
+			solvers,
+			newUsers,
+			pausesUsed,
+			handleChanges,
+			misses,
+			verificationFailures,
+		] = await Promise.all([
+			db.userSolve.count({
+				where: {
+					status: SolveStatus.SOLVED,
+					dailyProblem: { assignedDate: yesterday },
+				},
+			}),
+			db.userSolve.findMany({
+				where: {
+					status: SolveStatus.SOLVED,
+					dailyProblem: { assignedDate: yesterday },
+				},
+				select: { userId: true },
+				distinct: ["userId"],
+			}),
+			db.user.count({
+				where: { createdAt: { gte: yesterday, lt: date } },
+			}),
+			db.systemEventLog.count({
+				where: {
+					eventType: SystemEventType.PAUSE_USED,
+					createdAt: { gte: yesterday, lt: date },
+				},
+			}),
+			db.systemEventLog.count({
+				where: {
+					eventType: {
+						in: [SystemEventType.HANDLE_CHANGED, SystemEventType.USERNAME_CHANGED],
 					},
-				}),
-				db.userSolve.findMany({
-					where: {
-						status: SolveStatus.SOLVED,
-						dailyProblem: { assignedDate: yesterday },
-					},
-					select: { userId: true },
-					distinct: ["userId"],
-				}),
-				db.user.count({
-					where: { createdAt: { gte: yesterday, lt: date } },
-				}),
-				db.systemEventLog.count({
-					where: {
-						eventType: SystemEventType.PAUSE_USED,
-						createdAt: { gte: yesterday, lt: date },
-					},
-				}),
-				db.systemEventLog.count({
-					where: {
-						eventType: {
-							in: [SystemEventType.HANDLE_CHANGED, SystemEventType.USERNAME_CHANGED],
-						},
-						createdAt: { gte: yesterday, lt: date },
-					},
-				}),
-			]
-		)
+					createdAt: { gte: yesterday, lt: date },
+				},
+			}),
+			db.userSolve.count({
+				where: {
+					status: SolveStatus.MISSED,
+					dailyProblem: { assignedDate: yesterday },
+				},
+			}),
+			db.systemEventLog.count({
+				where: {
+					eventType: SystemEventType.SOLVE_FAILED,
+					createdAt: { gte: yesterday, lt: date },
+				},
+			}),
+		])
 		return {
 			totalSolves,
 			activeUsers: solvers.length,
 			newUsers,
 			pausesUsed,
 			handleChanges,
+			misses,
+			verificationFailures,
+		}
+	},
+
+	// Activity within an arbitrary [from, to) window — powers the hourly digest.
+	// Solves are windowed on `verifiedAt` (the moment verification succeeded);
+	// misses on `updatedAt` (set by the midnight mark-missed batch, so hourly
+	// misses read 0 outside the 00:00 tick — accurate, not a bug).
+	getActivityStats: async (from: Date, to: Date) => {
+		const [solvers, newUsers, pauses, misses, verificationFailures] = await Promise.all([
+			db.userSolve.findMany({
+				where: { status: SolveStatus.SOLVED, verifiedAt: { gte: from, lt: to } },
+				select: { userId: true },
+			}),
+			db.user.count({ where: { createdAt: { gte: from, lt: to } } }),
+			db.systemEventLog.count({
+				where: {
+					eventType: SystemEventType.PAUSE_USED,
+					createdAt: { gte: from, lt: to },
+				},
+			}),
+			db.userSolve.count({
+				where: { status: SolveStatus.MISSED, updatedAt: { gte: from, lt: to } },
+			}),
+			db.systemEventLog.count({
+				where: {
+					eventType: SystemEventType.SOLVE_FAILED,
+					createdAt: { gte: from, lt: to },
+				},
+			}),
+		])
+		return {
+			solves: solvers.length,
+			activeUsers: new Set(solvers.map((solve) => solve.userId)).size,
+			newUsers,
+			pauses,
+			misses,
+			verificationFailures,
 		}
 	},
 

--- a/src/server/problems/problems.notifications.ts
+++ b/src/server/problems/problems.notifications.ts
@@ -2,6 +2,8 @@ import BadgeEarnedEmail from "@/emails/badge-earned"
 import ProUnlockedByPointsEmail from "@/emails/pro-unlocked-by-points"
 import StreakMilestoneEmail from "@/emails/streak-milestone"
 import { env } from "@/env"
+import { BadgeType } from "@/generated/prisma/enums"
+import { notifyAdmin } from "@/server/lib/bot"
 import { db } from "@/server/lib/db"
 import { sendEmail } from "@/server/lib/email"
 import { captureServerException } from "@/server/lib/sentry"
@@ -12,6 +14,18 @@ import { captureServerException } from "@/server/lib/sentry"
 const BASE_URL = (env.BETTER_AUTH_URL ?? "https://pstrack.localhost").replace(/\/$/, "")
 
 const STREAK_MILESTONES = [7, 30, 100] as const
+
+// Rare, high-signal badges surfaced to the admin bot in realtime. Common badges
+// (STREAK_7/30, SOLVED_*, FIRST_SOLVER_1/10, CONSISTENT_30) are intentionally
+// left to roll into the daily digest, per AgDR-0001's curation principle.
+const NOTABLE_BADGES = new Set<string>([
+	BadgeType.STREAK_100,
+	BadgeType.STREAK_365,
+	BadgeType.FIRST_SOLVER_50,
+	BadgeType.NC250_COMPLETE,
+	BadgeType.NC150_COMPLETE,
+	BadgeType.BLIND75_COMPLETE,
+])
 
 export const problemNotifications = {
 	sendSolveAchievementEmails: async (
@@ -28,6 +42,18 @@ export const problemNotifications = {
 		const isStreakMilestone = (STREAK_MILESTONES as readonly number[]).includes(newStreak)
 
 		if (!crossedProThreshold && newBadges.length === 0 && !isStreakMilestone) return
+
+		// Admin-bot pings fire regardless of the user's own notification prefs —
+		// this is an operator observability channel, not a user-facing email, so
+		// it sits ahead of the notifyAchievements opt-out gate below.
+		const at = new Date().toISOString()
+		if (isStreakMilestone) {
+			void notifyAdmin("streak.milestone", { name, streak: newStreak, at })
+		}
+		const notableBadges = newBadges.filter((badge) => NOTABLE_BADGES.has(badge))
+		if (notableBadges.length > 0) {
+			void notifyAdmin("badge.earned", { name, badges: notableBadges, at })
+		}
 
 		const user = await db.user.findUnique({
 			where: { id: userId },

--- a/src/server/system-events/system-events.dao.ts
+++ b/src/server/system-events/system-events.dao.ts
@@ -14,10 +14,12 @@ export type SystemEventWriteInput = {
 }
 
 // AgDR-0001 — realtime-classed events forwarded to husam-bot as `system.event`.
-// Everything else (SOLVE_VERIFIED, MISS_BATCH, PAUSE_USED, *_CHANGED, and
-// JOIN_REQUEST_SENT which has its own dedicated buttoned emit) is intentionally
-// NOT forwarded here — those are ignored or rolled into the daily digest.
+// Everything else (SOLVE_VERIFIED, SOLVE_FAILED, MISS_BATCH, PAUSE_USED,
+// *_CHANGED, and JOIN_REQUEST_SENT which has its own dedicated buttoned emit) is
+// intentionally NOT forwarded here — those are ignored or rolled into a digest.
+// GROUP_CREATED joined this set as a low-volume growth signal for the beta.
 const REALTIME_EVENTS = new Set<SystemEventType>([
+	"GROUP_CREATED",
 	"GROUP_LEFT",
 	"MEMBER_REMOVED",
 	"GROUP_JOINED",

--- a/src/server/trigger/send-hourly-digest.ts
+++ b/src/server/trigger/send-hourly-digest.ts
@@ -1,0 +1,15 @@
+import { schedules } from "@trigger.dev/sdk/v3"
+
+import { dispatchJob, hourlyKey } from "./dispatch-job"
+
+export const sendHourlyDigestTask = schedules.task({
+	id: "send-hourly-digest",
+	cron: "0 * * * *",
+	maxDuration: 120,
+	run: async ({ timestamp }) =>
+		dispatchJob(
+			"send-hourly-digest",
+			timestamp,
+			hourlyKey("send-hourly-digest", timestamp)
+		),
+})

--- a/src/test/stress-manifest.ts
+++ b/src/test/stress-manifest.ts
@@ -562,6 +562,11 @@ export const STRESS_BACKGROUND_MODULES: StressBackgroundModule[] = [
 		dimensions: ["idempotency", "side-effect"],
 	},
 	{
+		file: "send-hourly-digest.ts",
+		module: "trigger",
+		dimensions: ["read", "side-effect"],
+	},
+	{
 		file: "send-weekly-digest.ts",
 		module: "trigger",
 		dimensions: ["read", "side-effect"],


### PR DESCRIPTION
## Summary

pstrack side of the error-tee + expanded-events work. The husam-bot counterpart (ADR 0003) is already on `main`, so every new event is registered on the bot's Zod union — no 400s.

- **`sentry.ts`** — `captureServerException` now mirrors server-side captures to the admin bot as `error.captured`: **production-only**, fire-and-forget, with a **redacted** payload (email/token-shaped strings stripped, message truncated to 300 chars, culprit frame shortened to the last two path segments, `route`/`method`/`userId`/`fingerprint`). Client/browser errors stay in Sentry.io. The bot bounds volume (Redis dedup + per-hour rate limit), so an error storm can't flood the channel.
- **`send-hourly-digest` trigger** (`0 * * * *`) — fires `digest.hourly` with the last hour's activity + stale-job health; the bot enriches with the error count and skips empty hours.
- **`job-runs` / `jobs`** — expose stale-job health for the digest.
- **`problems.dao`** — hourly activity roll-ups (solves, pauses, misses, verification failures, active/new users).
- **`problems.notifications`** — `streak.milestone` + `badge.earned` events.
- **`stress-manifest`** — classify the new trigger module.
- **`AGENTS.md`** — document the admin-bot contract, error tee, and the new job.

## Validation

- `bun run typecheck` ✓
- `bun run test` — 36 files, 165 tests ✓
- `bun run check` (biome) ✓

## Dependencies

Requires husam-bot `main` (commit `cc97951`) to be deployed first so the bot accepts `error.captured` / `digest.hourly` / `streak.milestone` / `badge.earned` / `purchase.pro.refunded` / points-reconciliation events. ✅ Already pushed.