### PR TITLE
feat(redis): self-hosted Redis migration on Bun native client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,12 +8,11 @@ DIRECT_URL="postgresql://USER:PASSWORD@HOST.REGION.aws.neon.tech/neondb?sslmode=
 # DATABASE_URL="postgresql://pstrack:pstrack@127.0.0.1:5433/pstrack?schema=public"
 # DIRECT_URL="postgresql://pstrack:pstrack@127.0.0.1:5433/pstrack?schema=public"
 
-# Redis (Upstash REST)
-UPSTASH_REDIS_REST_URL="https://your-redis.upstash.io"
-UPSTASH_REDIS_REST_TOKEN="your-token-here"
-
-# Local Docker Compose Redis (standard Redis URL, reserved for local Redis-backed features)
-# REDIS_URL="redis://127.0.0.1:6379"
+# Redis (self-hosted; Bun native client — ADR 0011)
+# Local: docker compose service (`make up`). Production: private Coolify Redis;
+# use rediss://default:PASSWORD@HOST:PORT for TLS-authenticated deployments.
+# Leave unset where Redis is not provisioned (e.g. Vercel staging).
+REDIS_URL="redis://127.0.0.1:6379"
 
 # Auth (Better Auth)
 # Generate a 32+ char secret: openssl rand -base64 32

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,9 @@ jobs:
     services:
       redis:
         image: redis:7-alpine
+        command: redis-server --requirepass ci_redis_password
         options: >-
-          --health-cmd "redis-cli ping"
+          --health-cmd "redis-cli -a ci_redis_password ping"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
@@ -93,8 +94,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - uses: ./.github/actions/setup
-      - name: Require Redis authentication
-        run: redis-cli CONFIG SET requirepass ci_redis_password
       - name: Verify authenticated Redis behavior (TTL, sets, concurrency, reconnect)
         run: REDIS_URL=redis://default:ci_redis_password@127.0.0.1:6379 bun run verify:redis
       - name: Verify bounded failure when Redis is unavailable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,34 @@ jobs:
         run: bunx prisma migrate deploy
       - run: bun run test
 
+  redis-verify:
+    name: Redis verification
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+        ports:
+          - 6379:6379
+    env:
+      # The harness only needs REDIS_URL; skip the full env schema like Vitest.
+      SKIP_ENV_VALIDATION: "1"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: ./.github/actions/setup
+      - name: Require Redis authentication
+        run: redis-cli CONFIG SET requirepass ci_redis_password
+      - name: Verify authenticated Redis behavior (TTL, sets, concurrency, reconnect)
+        run: REDIS_URL=redis://default:ci_redis_password@127.0.0.1:6379 bun run verify:redis
+      - name: Verify bounded failure when Redis is unavailable
+        run: REDIS_URL=redis://127.0.0.1:59321 bun run verify:redis --unavailable
+      - name: Verify bounded failure after an established connection is lost
+        run: REDIS_URL=redis://default:ci_redis_password@127.0.0.1:6379 bun run verify:redis --outage-after-connect
+
   validate-schema:
     name: Validate Prisma schema
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
   deploy-vercel-staging:
     name: Deploy Vercel staging
     runs-on: ubuntu-latest
-    needs: [typecheck, lint, knip, test, validate-schema, build]
+    needs: [typecheck, lint, knip, test, redis-verify, validate-schema, build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/stage'
     environment:
       name: Staging
@@ -268,7 +268,8 @@ jobs:
   publish-docker-image:
     name: Build and push Docker image
     runs-on: ubuntu-latest
-    needs: [typecheck, lint, knip, test, validate-schema, build, docker-changes]
+    needs:
+      [typecheck, lint, knip, test, redis-verify, validate-schema, build, docker-changes]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.docker-changes.outputs.publish == 'true'
     outputs:
       image_ref: ${{ steps.image.outputs.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,7 @@ This prevents email delivery failures from blocking the user's request. Users ca
 - Activity feed (group-scoped, poll-based)
 - Resources hub
 - In-app notification inbox (Upstash Realtime + WebSocket)
-- Redis leaderboard cache (Upstash)
+- Redis leaderboard cache (self-hosted Redis, ADR 0011)
 - PostHog analytics
 - Custom roadmaps (Pro admin perk)
 - Mobile app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ── builder ───────────────────────────────────────────────────────────────────
 # Optional target for building entirely inside Docker (e.g. local builds).
 # CI builds the app first and uses the runtime-prebuilt target below.
-FROM oven/bun:1.2-slim AS builder
+FROM oven/bun:1.3-slim AS builder
 WORKDIR /app
 
 COPY bun.lock package.json ./
@@ -27,9 +27,11 @@ RUN bun run build
 
 # ── runtime-prebuilt ─────────────────────────────────────────────────────────
 # Stage used by CI: the app is already built outside Docker (.output/ present),
-# we just copy it in. Uses node:22-slim (glibc) to match the linux-x64-gnu
-# native binaries that @resvg/resvg-js traces into .output/server/node_modules.
-FROM node:22-slim AS runtime-prebuilt
+# we just copy it in. Runs on Bun (ADR 0011) - the native Redis client ships
+# with the Bun runtime. oven/bun slim is Debian/glibc, so the linux-x64-gnu
+# native binaries @resvg/resvg-js traces into .output/server/node_modules
+# still load.
+FROM oven/bun:1.3-slim AS runtime-prebuilt
 WORKDIR /app
 
 RUN apt-get update \
@@ -49,4 +51,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
     CMD curl -fsS http://localhost:3000/api/v3/health || exit 1
 
-CMD ["node", ".output/server/index.mjs"]
+CMD ["bun", ".output/server/index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,12 +25,20 @@ ENV VITE_BASE_URL=$VITE_BASE_URL \
 
 RUN bun run build
 
+# Install only production packages in an isolated stage so the runtime image
+# can copy the native Resvg packages that Nitro leaves external. Copying just
+# this scope keeps the otherwise self-contained .output image minimal.
+FROM oven/bun:1.3-slim AS runtime-deps
+WORKDIR /app
+
+COPY bun.lock package.json ./
+RUN bun install --frozen-lockfile --production --ignore-scripts
+
 # ── runtime-prebuilt ─────────────────────────────────────────────────────────
 # Stage used by CI: the app is already built outside Docker (.output/ present),
 # we just copy it in. Runs on Bun (ADR 0011) - the native Redis client ships
 # with the Bun runtime. oven/bun slim is Debian/glibc, so the linux-x64-gnu
-# native binaries @resvg/resvg-js traces into .output/server/node_modules
-# still load.
+# native binaries copied from runtime-deps still load.
 FROM oven/bun:1.3-slim AS runtime-prebuilt
 WORKDIR /app
 
@@ -38,7 +46,13 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
+COPY --from=runtime-deps /app/node_modules/@resvg ./node_modules/@resvg
 COPY .output/ ./.output/
+
+# Regression guard for the OG route: resolution starts from the bundled
+# .output tree, so the native package must exist in the final image rather
+# than only in Bun's build cache.
+RUN bun -e 'const { Resvg } = await import("@resvg/resvg-js"); const png = new Resvg("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"/>").render().asPng(); if (png.length === 0) process.exit(1)'
 
 ENV NODE_ENV=production
 ENV PORT=3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,10 @@ ENV PORT=3000
 
 EXPOSE 3000
 
+# The Bun base image provides numeric UID/GID 1000. Runtime files are
+# read-only, and the application does not need privileged filesystem access.
+USER 1000:1000
+
 # Lets Coolify gate the rolling swap on real readiness: it waits for the new
 # container to report healthy before routing traffic to it and stopping the old
 # one. Without this, Coolify falls back to stop-then-start (= downtime).

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,6 @@
         "@tanstack/react-virtual": "^3.13.26",
         "@trigger.dev/sdk": "4.4.6",
         "@types/canvas-confetti": "^1.9.0",
-        "@upstash/redis": "^1.38.0",
         "better-auth": "1.6.13",
         "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.1",
@@ -76,6 +75,7 @@
         "@biomejs/biome": "^2.4.15",
         "@tanstack/devtools-vite": "^0.6.0",
         "@trigger.dev/build": "4.4.6",
+        "@types/bun": "^1.3.14",
         "@types/mdx": "^2.0.14",
         "@types/node": "^22.19.15",
         "@types/nodemailer": "^8.0.1",
@@ -1126,6 +1126,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/canvas-confetti": ["@types/canvas-confetti@1.9.0", "", {}, "sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -1283,6 +1285,8 @@
     "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/docs/STAGING.md
+++ b/docs/STAGING.md
@@ -6,7 +6,10 @@ staging; application production remains on Coolify.
 
 ## Isolation contract
 
-- Neon PostgreSQL and Upstash Redis use staging-only free-tier resources.
+- Neon PostgreSQL uses a staging-only free-tier project. Staging has no Redis
+  service (`REDIS_URL` unset): the approved staging-equivalent validation uses
+  an authenticated disposable Redis in CI, followed by a production canary on
+  the private Coolify network (ADR 0011 amendment, #288).
 - Google and GitHub OAuth use dedicated staging applications and callbacks.
 - Polar uses its sandbox catalog and webhook.
 - Trigger.dev uses a staging environment and staging-only dispatch secret.
@@ -38,7 +41,7 @@ Never restore or clone production data into staging.
 
 1. Disable the `deploy-vercel-staging` workflow job or its Staging environment.
 2. Remove the Vercel deployment aliases and staging environment variables.
-3. Delete the dedicated Neon and Upstash resources only after confirming their
+3. Delete the dedicated Neon resources only after confirming their
    identifiers do not match production.
 4. Delete the staging OAuth applications, Polar sandbox webhook, Trigger.dev
    environment, and staging alert rules.

--- a/docs/adr/0005-husam-bot-telegram-admin-notifications.md
+++ b/docs/adr/0005-husam-bot-telegram-admin-notifications.md
@@ -130,8 +130,7 @@ TELEGRAM_CHAT_ID=            # chat ID to send all notifications to
 
 BOT_NOTIFY_SECRET=           # shared with PStrack
 
-UPSTASH_REDIS_REST_URL=      # for metric snapshots + milestone tracking
-UPSTASH_REDIS_REST_TOKEN=
+REDIS_URL=                   # future metric snapshots + milestone tracking
 
 VERCEL_WEBHOOK_SECRET=
 SENTRY_WEBHOOK_SECRET=

--- a/docs/adr/0011-bun-runtime-and-native-redis-client.md
+++ b/docs/adr/0011-bun-runtime-and-native-redis-client.md
@@ -5,3 +5,38 @@ PStrack production runs on the Bun runtime, and Redis access uses Bun's native R
 The project already uses Bun for local development, scripts, dependency installation, tests, and builds. Running the production container with Bun keeps the runtime consistent across development, CI, and production. Using Bun's native Redis client also avoids adding `redis` or `ioredis` when PStrack only needs straightforward Redis operations such as `get`, `set`, `del`, and TTL-backed cache writes.
 
 This means the production Docker image must use a Bun version that includes the native Redis client, and the Redis service must be compatible with Bun's Redis client requirements.
+
+## Amendment (2026-07-12, #288)
+
+When this decision was recorded, the CI runtime image still ran `node:22-slim`
+(chosen to match the glibc `@resvg/resvg-js` binaries) and Redis access still
+used the `@upstash/redis` REST client. Issue #288 completed the decision:
+
+- `src/server/lib/redis.ts` now uses Bun's native `RedisClient` against
+  `REDIS_URL`: lazy singleton, 5s connection timeout, bounded reconnect
+  retries, offline queue only across the retry window, error-level `onclose`
+  logging, and close on SIGTERM. `UPSTASH_REDIS_REST_URL/TOKEN` are removed
+  from the env schema, `.env.example`, and the staging sync allowlist.
+- The `runtime-prebuilt` Docker stage runs `oven/bun:1.3-slim` with
+  `CMD ["bun", ...]`. The image is Debian/glibc, so the `linux-x64-gnu`
+  binaries traced for `@resvg/resvg-js` still load; verified by rendering
+  through `@resvg/resvg-js` under Bun on Linux and by a container smoke of
+  the built artifact (DB-backed health plus the `/api/v3/og` render).
+- The `"bun"` module is dynamically imported and marked external in both the
+  Vite and Nitro rollup passes. Node-based runtimes (Vitest, the Vercel
+  staging functions) still load the server bundle; only an actual Redis call
+  fails there, observably, without killing the process.
+- Vercel staging intentionally has **no Redis**: its Node functions cannot run
+  Bun's client, a private Coolify Redis is unreachable from Vercel, and no
+  feature currently reads Redis. Redis behavior (authenticated connections,
+  TTL expiry, set membership, duplicate and concurrent writes, reconnect after
+  `CLIENT KILL`, bounded initial failure, and bounded queued-command failure
+  after an established connection dies) is verified by `bun run verify:redis`
+  in CI against a disposable `redis:7` service container, then by a production
+  canary after cutover. Transport encryption is optional for a private Docker
+  network; deployments that cross an untrusted network must use `rediss://`
+  and verify the certificate during the canary.
+- Existing Upstash keys are inventoried as aggregate counts on #288 and
+  intentionally discarded, not migrated: nothing on `stage` reads Redis, and
+  the historical keys were digest-dedupe sets from the abandoned Postal
+  branch. No session or auth data ever lived in Redis.

--- a/docs/adr/0011-bun-runtime-and-native-redis-client.md
+++ b/docs/adr/0011-bun-runtime-and-native-redis-client.md
@@ -19,9 +19,11 @@ used the `@upstash/redis` REST client. Issue #288 completed the decision:
   from the env schema, `.env.example`, and the staging sync allowlist.
 - The `runtime-prebuilt` Docker stage runs `oven/bun:1.3-slim` with
   `CMD ["bun", ...]`. The image is Debian/glibc, so the `linux-x64-gnu`
-  binaries traced for `@resvg/resvg-js` still load; verified by rendering
-  through `@resvg/resvg-js` under Bun on Linux and by a container smoke of
-  the built artifact (DB-backed health plus the `/api/v3/og` render).
+  `@resvg/resvg-js` binaries still load. Nitro leaves the dynamic package
+  external, so a dedicated production-dependency stage copies only the
+  `@resvg` scope into the final image and runs a build-time native-render
+  guard. This is verified again by a container smoke of the built artifact
+  (DB-backed health plus the `/api/v3/og` render).
 - The `"bun"` module is dynamically imported and marked external in both the
   Vite and Nitro rollup passes. Node-based runtimes (Vitest, the Vercel
   staging functions) still load the server bundle; only an actual Redis call

--- a/docs/adr/0012-branch-mapped-production-and-staging-domains.md
+++ b/docs/adr/0012-branch-mapped-production-and-staging-domains.md
@@ -7,8 +7,11 @@ Production deploys are built from `main` and published as production GHCR images
 The existing Vercel project at `https://pstrack.vercel.app` is the staging
 environment. Its Vercel `production` target is application staging and deploys
 only from the repository's `stage` branch. It uses a dedicated Neon database,
-Upstash Redis, OAuth applications, Polar sandbox catalog, Trigger.dev
-environment, staging-tagged Sentry events, and `EMAIL_TRANSPORT=log`.
+OAuth applications, Polar sandbox catalog, Trigger.dev environment,
+staging-tagged Sentry events, and `EMAIL_TRANSPORT=log`. Staging has no Redis
+service: the Vercel Node runtime cannot run Bun's native Redis client, so
+Redis behavior is verified in CI and by production canary instead (ADR 0011
+amendment, #288).
 
 No Coolify production credential or data may be copied into Vercel. Staging
 configuration is synchronized from the ignored `.env.stage` file through an

--- a/docs/stack.md
+++ b/docs/stack.md
@@ -105,7 +105,7 @@ durable `JobRun` idempotency ledger.
 
 ## Post-MVP Services (not in v3)
 
-- **Upstash Redis** - leaderboard caching, rate limiting
+- **Redis** (self-hosted, Bun native client - ADR 0011) - leaderboard caching, rate limiting
 - **Upstash Realtime** - in-app notification inbox, WebSocket feed
 - **PostHog** - product analytics
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"env:sync:stage": "bun run scripts/sync-vercel.ts",
 		"env:sync:stage:dry-run": "bun run scripts/sync-vercel.ts --dry-run",
 		"smoke:stage": "bun run scripts/smoke-stage.ts",
+		"verify:redis": "bun run scripts/verify-redis.ts",
 		"jobs:reconcile-mark-missed": "bun run scripts/reconcile-mark-missed.ts",
 		"points:reconcile": "bun run scripts/reconcile-points.ts"
 	},
@@ -81,7 +82,6 @@
 		"@tanstack/react-virtual": "^3.13.26",
 		"@trigger.dev/sdk": "4.4.6",
 		"@types/canvas-confetti": "^1.9.0",
-		"@upstash/redis": "^1.38.0",
 		"better-auth": "1.6.13",
 		"canvas-confetti": "^1.9.4",
 		"class-variance-authority": "^0.7.1",
@@ -118,6 +118,7 @@
 		"@biomejs/biome": "^2.4.15",
 		"@tanstack/devtools-vite": "^0.6.0",
 		"@trigger.dev/build": "4.4.6",
+		"@types/bun": "^1.3.14",
 		"@types/mdx": "^2.0.14",
 		"@types/node": "^22.19.15",
 		"@types/nodemailer": "^8.0.1",

--- a/scripts/smoke-http.ts
+++ b/scripts/smoke-http.ts
@@ -1,6 +1,11 @@
 const defaultSleep = (milliseconds: number) =>
 	new Promise<void>((resolve) => setTimeout(resolve, milliseconds))
 
+export type SmokeFetcher = (
+	input: RequestInfo | URL,
+	init?: RequestInit
+) => Promise<Response>
+
 export const fetchWhenReady = async (
 	url: string,
 	{
@@ -9,7 +14,7 @@ export const fetchWhenReady = async (
 		retryDelayMs = 5000,
 		sleep = defaultSleep,
 	}: {
-		fetcher?: typeof fetch
+		fetcher?: SmokeFetcher
 		maxAttempts?: number
 		retryDelayMs?: number
 		sleep?: (milliseconds: number) => Promise<void>

--- a/scripts/smoke-prod.ts
+++ b/scripts/smoke-prod.ts
@@ -48,6 +48,16 @@ const main = async () => {
 	if (sessionBody !== null)
 		throw new Error("Anonymous auth session check returned a session")
 
+	const og = await checkFetch("/api/v3/og?title=Production%20Smoke")
+	if (og.headers.get("content-type") !== "image/png") {
+		throw new Error("OpenGraph smoke check did not return image/png")
+	}
+	const png = new Uint8Array(await og.arrayBuffer())
+	const pngSignature = [137, 80, 78, 71, 13, 10, 26, 10]
+	if (!pngSignature.every((byte, index) => png[index] === byte)) {
+		throw new Error("OpenGraph smoke check returned an invalid PNG")
+	}
+
 	if (jobSecret) {
 		const freshness = await checkFetch("/api/v3/internal/jobs/freshness", {
 			headers: { Authorization: `Bearer ${jobSecret}` },

--- a/scripts/sync-vercel.ts
+++ b/scripts/sync-vercel.ts
@@ -34,8 +34,10 @@ const STAGING_KEYS = [
 	"SENTRY_DSN",
 	"SENTRY_ENVIRONMENT",
 	"SENTRY_TRACES_SAMPLE_RATE",
-	"UPSTASH_REDIS_REST_TOKEN",
-	"UPSTASH_REDIS_REST_URL",
+	// REDIS_URL is deliberately absent: staging runs on Vercel's Node runtime,
+	// which cannot run Bun's native Redis client, and no feature requires Redis
+	// there. Redis behavior is verified by CI's harness and a production canary
+	// (#288, ADR 0011).
 	"VITE_BASE_URL",
 	"VITE_SENTRY_DSN",
 	"VITE_SENTRY_REPLAY_ERROR_SAMPLE_RATE",

--- a/scripts/verify-redis.ts
+++ b/scripts/verify-redis.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env bun
+/**
+ * Redis behavior verification harness (#288).
+ *
+ * Exercises the app's Redis helpers under the Bun runtime - the same runtime
+ * the production container uses - against a disposable Redis: TTL expiry, set
+ * membership, duplicate and concurrent writes, and transparent reconnect after
+ * the server kills the connection.
+ *
+ *   REDIS_URL=redis://127.0.0.1:6379 bun run verify:redis
+ *
+ * With --unavailable, REDIS_URL must point at a closed port; the harness then
+ * asserts the helpers reject in bounded time instead of hanging:
+ *
+ *   REDIS_URL=redis://127.0.0.1:59321 bun run verify:redis --unavailable
+ *
+ * With --outage-after-connect, the harness establishes the app connection,
+ * stops the disposable Redis with SHUTDOWN, and asserts queued concurrent
+ * commands reject within the retry window. Run this mode last because it
+ * intentionally stops Redis:
+ *
+ *   REDIS_URL=redis://127.0.0.1:6379 bun run verify:redis --outage-after-connect
+ *
+ * Never point it at a Redis holding data you care about: it writes and
+ * deletes keys under the pstrack:verify:* namespace.
+ */
+import { env } from "@/env"
+import {
+	closeRedis,
+	createRedisKey,
+	getRedis,
+	redisDel,
+	redisExpire,
+	redisGet,
+	redisSAdd,
+	redisSet,
+	redisSIsMember,
+} from "@/server/lib/redis"
+
+const CONCURRENCY = 50
+const BOUNDED_FAILURE_LIMIT_MS = 10_000
+
+let failures = 0
+
+const check = (condition: boolean, label: string) => {
+	if (condition) {
+		console.log(`  ok ${label}`)
+	} else {
+		failures += 1
+		console.error(`  FAIL ${label}`)
+	}
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const finish = () => {
+	if (failures > 0) {
+		console.error(`\n${failures} Redis behavior check(s) failed`)
+		process.exit(1)
+	}
+	console.log("\nAll Redis behavior checks passed")
+}
+
+const runUnavailableScenario = async () => {
+	console.log("Unavailable Redis fails bounded and observably")
+	const startedAt = Date.now()
+	const outcome = await redisGet("pstrack:verify:unavailable").then(
+		() => null,
+		(error: Error) => error.message
+	)
+	const elapsedMs = Date.now() - startedAt
+	check(outcome !== null, `helper rejected (${outcome})`)
+	check(
+		elapsedMs < BOUNDED_FAILURE_LIMIT_MS,
+		`failure bounded at ${elapsedMs}ms (< ${BOUNDED_FAILURE_LIMIT_MS}ms)`
+	)
+	finish()
+}
+
+const runEstablishedOutageScenario = async () => {
+	if (!env.REDIS_URL) throw new Error("REDIS_URL is required")
+
+	console.log("Established Redis outage fails queued commands bounded and observably")
+	await redisSet("pstrack:verify:outage", "connected")
+
+	const { RedisClient } = await import("bun")
+	const controller = new RedisClient(env.REDIS_URL)
+	await controller.connect()
+	await controller.send("SHUTDOWN", ["NOSAVE"]).catch(() => null)
+	controller.close()
+
+	const startedAt = Date.now()
+	const outcomes = await Promise.allSettled(
+		Array.from({ length: CONCURRENCY }, () => redisGet("pstrack:verify:outage"))
+	)
+	const elapsedMs = Date.now() - startedAt
+
+	check(
+		outcomes.every((outcome) => outcome.status === "rejected"),
+		`${CONCURRENCY} queued commands rejected after the established connection died`
+	)
+	check(
+		elapsedMs < BOUNDED_FAILURE_LIMIT_MS,
+		`established outage bounded at ${elapsedMs}ms (< ${BOUNDED_FAILURE_LIMIT_MS}ms)`
+	)
+	await closeRedis()
+	finish()
+}
+
+const runId = crypto.randomUUID().slice(0, 8)
+const key = (...parts: Array<number | string>) =>
+	createRedisKey("verify", runId, ...parts)
+
+const runMainSuite = async () => {
+	console.log(`Verifying Redis behavior (namespace pstrack:verify:${runId})`)
+
+	console.log("1. JSON round-trip")
+	await redisSet(key("json"), { count: 3, tag: "alpha" })
+	const roundTrip = await redisGet<{ count: number; tag: string }>(key("json"))
+	check(roundTrip?.count === 3 && roundTrip?.tag === "alpha", "object survives set/get")
+	check((await redisGet(key("missing"))) === null, "missing key reads as null")
+
+	console.log("2. TTL")
+	await redisSet(key("ttl"), "short-lived", { ttlSeconds: 2 })
+	const client = await getRedis()
+	const ttl = await client.ttl(key("ttl"))
+	check(ttl > 0 && ttl <= 2, `ttl reported within bounds (${ttl}s)`)
+	check((await redisGet(key("ttl"))) === "short-lived", "value readable before expiry")
+
+	console.log("3. Set membership and duplicate writes")
+	check((await redisSAdd(key("set"), "a", "b")) === 2, "sadd adds two members")
+	check((await redisSAdd(key("set"), "a")) === 0, "duplicate sadd is a no-op")
+	check(await redisSIsMember(key("set"), "a"), "member found")
+	check(!(await redisSIsMember(key("set"), "zzz")), "non-member not found")
+	check((await redisExpire(key("set"), 2)) === 1, "expire applies to the set")
+
+	console.log("4. Concurrent operations")
+	const additions = await Promise.all(
+		Array.from({ length: CONCURRENCY }, () =>
+			redisSAdd(key("concurrent-set"), "same-member")
+		)
+	)
+	check(
+		additions.reduce((sum, added) => sum + added, 0) === 1,
+		`${CONCURRENCY} concurrent duplicate sadds add exactly one member`
+	)
+	const writes = await Promise.all(
+		Array.from({ length: CONCURRENCY }, (_, index) => redisSet(key("kv", index), index))
+	)
+	check(
+		writes.every((result) => result === "OK"),
+		`${CONCURRENCY} concurrent sets acknowledged`
+	)
+	const reads = await Promise.all(
+		Array.from({ length: CONCURRENCY }, (_, index) => redisGet<number>(key("kv", index)))
+	)
+	check(
+		reads.every((value, index) => value === index),
+		`${CONCURRENCY} concurrent reads round-trip`
+	)
+
+	console.log("5. TTL expiry removes keys")
+	await sleep(2_500)
+	check((await redisGet(key("ttl"))) === null, "TTL key expired")
+	check(!(await redisSIsMember(key("set"), "a")), "expired set dropped its members")
+
+	console.log("6. Reconnect after server-side kill")
+	if (!env.REDIS_URL) throw new Error("REDIS_URL is required")
+	const { RedisClient } = await import("bun")
+	const killer = new RedisClient(env.REDIS_URL)
+	const ownId = await client.send("CLIENT", ["ID"])
+	const killedCount = await killer.send("CLIENT", ["KILL", "ID", String(ownId)])
+	check(String(killedCount) === "1", "server killed the app connection")
+	await sleep(200)
+	const afterReconnect = await redisGet<{ count: number; tag: string }>(key("json"))
+	check(
+		afterReconnect?.tag === "alpha",
+		"helper call succeeds after transparent reconnect"
+	)
+	killer.close()
+
+	console.log("7. Cleanup")
+	const cleanupKeys = [
+		key("json"),
+		key("set"),
+		key("concurrent-set"),
+		...Array.from({ length: CONCURRENCY }, (_, index) => key("kv", index)),
+	]
+	check((await redisDel(...cleanupKeys)) >= 3, "namespaced keys deleted")
+	await closeRedis()
+
+	finish()
+}
+
+if (process.argv.includes("--outage-after-connect")) {
+	await runEstablishedOutageScenario()
+} else if (process.argv.includes("--unavailable")) {
+	await runUnavailableScenario()
+} else {
+	await runMainSuite()
+}

--- a/scripts/verify-redis.ts
+++ b/scripts/verify-redis.ts
@@ -78,6 +78,7 @@ const finish = () => {
 		process.exit(1)
 	}
 	console.log("\nAll Redis behavior checks passed")
+	process.exit(0)
 }
 
 const runUnavailableScenario = async () => {

--- a/scripts/verify-redis.ts
+++ b/scripts/verify-redis.ts
@@ -39,6 +39,7 @@ import {
 
 const CONCURRENCY = 50
 const BOUNDED_FAILURE_LIMIT_MS = 10_000
+const OPERATION_DEADLINE_MS = 9_000
 
 let failures = 0
 
@@ -53,6 +54,24 @@ const check = (condition: boolean, label: string) => {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+const rejectAfter = async <TValue>(operation: Promise<TValue>): Promise<TValue> => {
+	let deadline: ReturnType<typeof setTimeout> | undefined
+
+	try {
+		return await Promise.race([
+			operation,
+			new Promise<never>((_, reject) => {
+				deadline = setTimeout(
+					() => reject(new Error("Redis operation deadline exceeded")),
+					OPERATION_DEADLINE_MS
+				)
+			}),
+		])
+	} finally {
+		if (deadline) clearTimeout(deadline)
+	}
+}
+
 const finish = () => {
 	if (failures > 0) {
 		console.error(`\n${failures} Redis behavior check(s) failed`)
@@ -64,11 +83,12 @@ const finish = () => {
 const runUnavailableScenario = async () => {
 	console.log("Unavailable Redis fails bounded and observably")
 	const startedAt = Date.now()
-	const outcome = await redisGet("pstrack:verify:unavailable").then(
+	const outcome = await rejectAfter(redisGet("pstrack:verify:unavailable")).then(
 		() => null,
 		(error: Error) => error.message
 	)
 	const elapsedMs = Date.now() - startedAt
+	await closeRedis()
 	check(outcome !== null, `helper rejected (${outcome})`)
 	check(
 		elapsedMs < BOUNDED_FAILURE_LIMIT_MS,

--- a/src/env.ts
+++ b/src/env.ts
@@ -15,9 +15,7 @@ const server = {
 	DATABASE_URL: z.string().min(1),
 	DIRECT_URL: z.string().min(1),
 
-	// redis
-	UPSTASH_REDIS_REST_URL: z.string().min(1).optional(),
-	UPSTASH_REDIS_REST_TOKEN: z.string().min(1).optional(),
+	// redis (self-hosted, Bun native client - ADR 0011)
 	REDIS_URL: z.url().optional(),
 
 	// error tracking

--- a/src/server/lib/redis.test.ts
+++ b/src/server/lib/redis.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+
+// Importing "@/server/lib/redis" loads "@/env" at module scope, so set the
+// escape hatch before the dynamic import - the same way CI runs
+// (SKIP_ENV_VALIDATION=1). Redis network behavior is covered by
+// scripts/verify-redis.ts under the Bun runtime, not by this suite.
+process.env.SKIP_ENV_VALIDATION = "1"
+const { createRedisKey } = await import("@/server/lib/redis")
+
+describe("createRedisKey", () => {
+	it("prefixes parts with the app namespace", () => {
+		expect(createRedisKey("digest", 42)).toBe("pstrack:digest:42")
+	})
+
+	it("trims whitespace and drops empty parts", () => {
+		expect(createRedisKey(" a ", "", "b")).toBe("pstrack:a:b")
+	})
+})

--- a/src/server/lib/redis.ts
+++ b/src/server/lib/redis.ts
@@ -1,10 +1,16 @@
-import { Redis } from "@upstash/redis"
+import type { RedisClient } from "bun"
 
 import { env } from "@/env"
 
 const REDIS_KEY_PREFIX = "pstrack"
 
-let redisClient: Redis | null = null
+// Bounded so commands against a dead Redis fail fast and observably instead of
+// queueing forever; the offline queue only bridges the reconnect retry window.
+const CONNECTION_TIMEOUT_MS = 5_000
+const MAX_RECONNECT_ATTEMPTS = 5
+
+let clientPromise: Promise<RedisClient> | null = null
+let shutdownHookRegistered = false
 
 export type RedisSetOptions = {
 	ttlSeconds?: number
@@ -15,23 +21,68 @@ export const createRedisKey = (...parts: Array<number | string>) =>
 		":"
 	)
 
-export const getRedis = () => {
-	if (redisClient) return redisClient
-
-	if (!env.UPSTASH_REDIS_REST_URL || !env.UPSTASH_REDIS_REST_TOKEN) {
-		throw new Error("Upstash Redis is not configured")
+// The "bun" module is imported lazily: this file must stay importable under
+// Node-based tooling (Vitest, the Vercel staging runtime) where Redis is
+// intentionally not configured. Redis-backed features require the Bun runtime
+// (ADR 0011) and a REDIS_URL.
+const createClient = async (): Promise<RedisClient> => {
+	if (!env.REDIS_URL) {
+		throw new Error("Redis is not configured (REDIS_URL is unset)")
 	}
 
-	redisClient = new Redis({
-		url: env.UPSTASH_REDIS_REST_URL,
-		token: env.UPSTASH_REDIS_REST_TOKEN,
+	const { RedisClient } = await import("bun")
+
+	const client = new RedisClient(env.REDIS_URL, {
+		connectionTimeout: CONNECTION_TIMEOUT_MS,
+		autoReconnect: true,
+		maxRetries: MAX_RECONNECT_ATTEMPTS,
+		enableOfflineQueue: true,
 	})
 
-	return redisClient
+	client.onclose = (error) => {
+		console.error("[redis] connection closed", error)
+	}
+
+	if (!shutdownHookRegistered) {
+		shutdownHookRegistered = true
+		process.once("SIGTERM", () => {
+			closeRedis().catch(() => {})
+		})
+	}
+
+	return client
+}
+
+export const getRedis = (): Promise<RedisClient> => {
+	clientPromise ??= createClient().catch((error) => {
+		clientPromise = null
+		throw error
+	})
+
+	return clientPromise
+}
+
+export const closeRedis = async () => {
+	if (!clientPromise) return
+
+	const pending = clientPromise
+	clientPromise = null
+
+	const client = await pending.catch(() => null)
+	if (!client) return
+
+	// Intentional shutdown - silence the error-level disconnect log.
+	client.onclose = () => {}
+	client.close()
 }
 
 export const redisGet = async <TValue>(key: string): Promise<TValue | null> => {
-	return getRedis().get<TValue>(key)
+	const client = await getRedis()
+	const raw = await client.get(key)
+
+	if (raw === null) return null
+
+	return JSON.parse(raw)
 }
 
 export const redisSet = async <TValue>(
@@ -39,17 +90,37 @@ export const redisSet = async <TValue>(
 	value: TValue,
 	options: RedisSetOptions = {}
 ) => {
+	const client = await getRedis()
+	const payload = JSON.stringify(value)
 	const { ttlSeconds } = options
 
 	if (ttlSeconds) {
-		return getRedis().set(key, value, { ex: ttlSeconds })
+		return client.set(key, payload, "EX", ttlSeconds)
 	}
 
-	return getRedis().set(key, value)
+	return client.set(key, payload)
 }
 
 export const redisDel = async (...keys: string[]) => {
 	if (keys.length === 0) return 0
 
-	return getRedis().del(...keys)
+	const client = await getRedis()
+	return client.del(...keys)
+}
+
+export const redisSAdd = async (key: string, ...members: string[]) => {
+	if (members.length === 0) return 0
+
+	const client = await getRedis()
+	return client.sadd(key, ...members)
+}
+
+export const redisSIsMember = async (key: string, member: string): Promise<boolean> => {
+	const client = await getRedis()
+	return client.sismember(key, member)
+}
+
+export const redisExpire = async (key: string, ttlSeconds: number) => {
+	const client = await getRedis()
+	return client.expire(key, ttlSeconds)
 }

--- a/src/test/smoke-http.test.ts
+++ b/src/test/smoke-http.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { fetchWhenReady } from "../../scripts/smoke-http"
+import { fetchWhenReady, type SmokeFetcher } from "../../scripts/smoke-http"
 
 describe("fetchWhenReady", () => {
 	it("retries transient server errors until the deployment is ready", async () => {
 		const fetcher = vi
-			.fn<typeof fetch>()
+			.fn<SmokeFetcher>()
 			.mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
 			.mockResolvedValueOnce(new Response('{"status":"ok"}', { status: 200 }))
 		const sleep = vi.fn().mockResolvedValue(undefined)
@@ -23,7 +23,7 @@ describe("fetchWhenReady", () => {
 	})
 
 	it("fails after the readiness window expires", async () => {
-		const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+		const fetcher = vi.fn<SmokeFetcher>().mockResolvedValue(
 			new Response("still unavailable", {
 				status: 503,
 			})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,6 +34,9 @@ const config = defineConfig({
 	build: {
 		reportCompressedSize: false,
 		rollupOptions: {
+			// "bun" is the runtime-provided module for the native Redis client
+			// (server-only, dynamically imported); it can never be bundled.
+			external: ["bun"],
 			onwarn(warning, warn) {
 				if (
 					warning.code === "MODULE_LEVEL_DIRECTIVE" &&
@@ -51,7 +54,10 @@ const config = defineConfig({
 		devtools(),
 		nitro({
 			rollupConfig: {
-				external: [/\.node$/, /^@resvg\/resvg-js(?:-.+)?$/],
+				// "bun" is the runtime-provided module for the native Redis client;
+				// it must never be bundled (it is dynamically imported so Node-based
+				// runtimes without Redis can still load the server bundle).
+				external: [/\.node$/, /^@resvg\/resvg-js(?:-.+)?$/, "bun"],
 			},
 			traceDeps: [
 				"@resvg/resvg-js*",


### PR DESCRIPTION
Refs #288.

Completes the self-hosted Redis migration on the Bun-native client, with CI hardening for the Redis verifier and related deploy/runtime fixes.

**Commits (7)**
- `feat(redis): complete self-hosted Redis migration on Bun native client (#288)`
- `fix(deploy): gate and smoke Bun Redis runtime`
- `fix(docker): include Resvg runtime dependency`
- `fix(test): narrow smoke fetcher contract`
- `fix(ci): start Redis with authentication (#288)`
- `fix(ci): enforce Redis outage deadline (#288)`
- `fix(ci): terminate Redis verifier cleanly (#288)`

> ⚠️ Behind `stage` by 17 commits and overlaps #336's CI/Docker/Redis-verification changes — **expect merge conflicts** to resolve before merge. Verification is via CI on this PR (a local check on the stale base would be misleading).