### PR TITLE
feat(runtime): non-root image + hardened OG rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ todos.json
 deploy-evidence.json
 smoke-evidence.json
 staging-smoke-evidence.json
+resource-measurement-evidence.json
 generated/
 .vercel
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,17 @@ WORKDIR /app
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 10001 pstrack \
+    && useradd --uid 10001 --gid 10001 --no-create-home --home-dir /nonexistent \
+        --shell /usr/sbin/nologin pstrack
 
 COPY .output/ ./.output/
 
 ENV NODE_ENV=production
 ENV PORT=3000
+ENV HOME=/nonexistent
+ENV TMPDIR=/tmp
 
 EXPOSE 3000
 
@@ -48,5 +53,7 @@ EXPOSE 3000
 # one. Without this, Coolify falls back to stop-then-start (= downtime).
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=3 \
     CMD curl -fsS http://localhost:3000/api/v3/health || exit 1
+
+USER 10001:10001
 
 CMD ["node", ".output/server/index.mjs"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,14 @@ ENV VITE_BASE_URL=$VITE_BASE_URL \
 
 RUN bun run build
 
+# Nitro leaves Resvg external to the server bundle. Install production packages
+# in an isolated stage so the runtime can copy only that native dependency.
+FROM oven/bun:1.3-slim AS runtime-deps
+WORKDIR /app
+
+COPY bun.lock package.json ./
+RUN bun install --frozen-lockfile --production --ignore-scripts
+
 # ── runtime-prebuilt ─────────────────────────────────────────────────────────
 # Stage used by CI: the app is already built outside Docker (.output/ present),
 # we just copy it in. Uses node:22-slim (glibc) to match the linux-x64-gnu
@@ -39,7 +47,11 @@ RUN apt-get update \
     && useradd --uid 10001 --gid 10001 --no-create-home --home-dir /nonexistent \
         --shell /usr/sbin/nologin pstrack
 
+COPY --from=runtime-deps /app/node_modules/@resvg ./node_modules/@resvg
 COPY .output/ ./.output/
+
+# Fail the image build if the native OG renderer cannot load and produce PNG.
+RUN node --input-type=module -e 'const { Resvg } = await import("@resvg/resvg-js"); const png = new Resvg("<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"/>").render().asPng(); if (png.length === 0) process.exit(1)'
 
 ENV NODE_ENV=production
 ENV PORT=3000

--- a/docs/RUNTIME_HARDENING.md
+++ b/docs/RUNTIME_HARDENING.md
@@ -1,0 +1,43 @@
+# Runtime hardening measurements
+
+Issue [#291](https://github.com/husamql3/pstrack/issues/291) requires measured
+resource limits. Limits must be based on both steady-state production samples
+and controlled staging load; a quiet production snapshot is not a peak.
+
+## Capture a sanitized steady-state window
+
+The operator SSH alias `pstrack` must already be configured. The command reads
+Docker metadata and stats only; it does not read container environments, logs,
+mount contents, hostnames, addresses, or container IDs.
+
+```bash
+bun run ops:measure-resources
+```
+
+Defaults: 12 samples, five seconds between samples. Override the bounded run
+for a longer observation window when needed:
+
+```bash
+RESOURCE_SAMPLE_COUNT=60 RESOURCE_SAMPLE_INTERVAL_MS=10000 \
+  bun run ops:measure-resources
+```
+
+The ignored `resource-measurement-evidence.json` contains host CPU/memory
+capacity and average/maximum CPU, memory, and PID use grouped into `app`,
+`database`, `mail`, `backup`, service-level Coolify categories, a
+`coolify-total` reserve, and `other`. Runtime names and images
+are used only in memory for categorization and never enter the evidence file.
+
+## Before choosing or applying limits
+
+1. Capture several steady-state windows, including an hourly backup and normal
+   mail/job activity.
+2. Repeat the same measurement during the #287 staging stress suite and a
+   synthetic backup/restore drill.
+3. Choose service-specific headroom from the observed peaks while reserving
+   host capacity for Coolify, the proxy, and recovery operations.
+4. Apply one service at a time in staging. Verify health, latency, restart/OOM
+   behavior, scheduled jobs, mail, backup creation, and isolated restore.
+5. Promote only after rollback settings and pre-change evidence are recorded.
+
+Do not infer a safe production limit from a single quiet window.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"env:sync:stage": "bun run scripts/sync-vercel.ts",
 		"env:sync:stage:dry-run": "bun run scripts/sync-vercel.ts --dry-run",
 		"smoke:stage": "bun run scripts/smoke-stage.ts",
+		"ops:measure-resources": "bun run scripts/measure-container-resources.ts",
 		"jobs:reconcile-mark-missed": "bun run scripts/reconcile-mark-missed.ts",
 		"points:reconcile": "bun run scripts/reconcile-points.ts"
 	},

--- a/scripts/measure-container-resources.ts
+++ b/scripts/measure-container-resources.ts
@@ -1,0 +1,349 @@
+import { spawn } from "node:child_process"
+import { writeFile } from "node:fs/promises"
+import type { Readable } from "node:stream"
+
+export type ResourceCategory =
+	| "app"
+	| "database"
+	| "mail"
+	| "backup"
+	| "coolify-proxy"
+	| "coolify-database"
+	| "coolify-cache"
+	| "coolify-platform"
+	| "coolify-total"
+	| "other"
+
+export type ResourceObservation = {
+	category: ResourceCategory
+	cpuPercent: number
+	memoryBytes: number
+	pids: number
+}
+
+type SummaryOptions = {
+	capturedAt: string
+	durationMs: number
+	intervalMs: number
+	hostCpuCount: number
+	hostMemoryBytes: number
+}
+
+const round = (value: number) => Math.round(value * 100) / 100
+
+export const classifyContainer = (image: string, name: string): ResourceCategory => {
+	const normalizedImage = image.toLowerCase()
+	const normalizedName = name.toLowerCase()
+
+	if (
+		normalizedImage.includes("pstrack-db-backups") ||
+		normalizedName.includes("pstrack-db-backups")
+	) {
+		return "backup"
+	}
+	if (normalizedImage.includes("husamql3/pstrack")) return "app"
+	if (normalizedImage.includes("stalwart")) return "mail"
+	if (normalizedImage.includes("traefik")) return "coolify-proxy"
+	if (normalizedName.includes("coolify") && normalizedImage.startsWith("postgres:")) {
+		return "coolify-database"
+	}
+	if (
+		normalizedName.includes("coolify") &&
+		(normalizedImage.includes("redis") || normalizedImage.includes("keydb"))
+	) {
+		return "coolify-cache"
+	}
+	if (normalizedName.includes("coolify") || normalizedImage.includes("coollabsio")) {
+		return "coolify-platform"
+	}
+	if (normalizedImage.startsWith("postgres:")) return "database"
+	return "other"
+}
+
+const MEMORY_UNITS: Record<string, number> = {
+	b: 1,
+	kib: 1024,
+	mib: 1024 ** 2,
+	gib: 1024 ** 3,
+	tib: 1024 ** 4,
+	kb: 1000,
+	mb: 1000 ** 2,
+	gb: 1000 ** 3,
+	tb: 1000 ** 4,
+}
+
+export const parseDockerMemoryBytes = (usage: string) => {
+	const current = usage.split("/")[0]?.trim() ?? ""
+	const match = current.match(/^([0-9]+(?:\.[0-9]+)?)\s*([a-z]+)$/i)
+	if (!match) throw new Error("Docker returned an invalid memory measurement")
+	const value = Number(match[1])
+	const multiplier = MEMORY_UNITS[match[2]?.toLowerCase() ?? ""]
+	if (!Number.isFinite(value) || !multiplier) {
+		throw new Error("Docker returned an unsupported memory measurement")
+	}
+	return Math.round(value * multiplier)
+}
+
+export const summarizeResourceSamples = (
+	samples: ResourceObservation[][],
+	options: SummaryOptions
+) => {
+	const byCategory = new Map<
+		ResourceCategory,
+		Array<{ cpuPercent: number; memoryBytes: number; pids: number }>
+	>()
+
+	for (const sample of samples) {
+		const totals = new Map<
+			ResourceCategory,
+			{ cpuPercent: number; memoryBytes: number; pids: number }
+		>()
+		for (const observation of sample) {
+			const current = totals.get(observation.category) ?? {
+				cpuPercent: 0,
+				memoryBytes: 0,
+				pids: 0,
+			}
+			current.cpuPercent += observation.cpuPercent
+			current.memoryBytes += observation.memoryBytes
+			current.pids += observation.pids
+			totals.set(observation.category, current)
+			if (observation.category.startsWith("coolify-")) {
+				const aggregate = totals.get("coolify-total") ?? {
+					cpuPercent: 0,
+					memoryBytes: 0,
+					pids: 0,
+				}
+				aggregate.cpuPercent += observation.cpuPercent
+				aggregate.memoryBytes += observation.memoryBytes
+				aggregate.pids += observation.pids
+				totals.set("coolify-total", aggregate)
+			}
+		}
+		for (const [category, total] of totals) {
+			const values = byCategory.get(category) ?? []
+			values.push(total)
+			byCategory.set(category, values)
+		}
+	}
+
+	const categories = Object.fromEntries(
+		[...byCategory.entries()].map(([category, values]) => {
+			const average = (field: "cpuPercent" | "memoryBytes" | "pids") =>
+				round(values.reduce((sum, value) => sum + value[field], 0) / values.length)
+			const maximum = (field: "cpuPercent" | "memoryBytes" | "pids") =>
+				round(Math.max(...values.map((value) => value[field])))
+			return [
+				category,
+				{
+					observations: values.length,
+					cpuPercent: {
+						average: average("cpuPercent"),
+						maximum: maximum("cpuPercent"),
+					},
+					memoryBytes: {
+						average: average("memoryBytes"),
+						maximum: maximum("memoryBytes"),
+					},
+					pids: { average: average("pids"), maximum: maximum("pids") },
+				},
+			]
+		})
+	)
+
+	return {
+		capturedAt: options.capturedAt,
+		durationMs: options.durationMs,
+		sampleCount: samples.length,
+		intervalMs: options.intervalMs,
+		hostCapacity: {
+			cpuCount: options.hostCpuCount,
+			memoryBytes: options.hostMemoryBytes,
+		},
+		categories,
+	}
+}
+
+const readIntegerInRange = (
+	name: string,
+	fallback: number,
+	{ minimum, maximum }: { minimum: number; maximum: number }
+) => {
+	const raw = process.env[name]
+	if (!raw) return fallback
+	const value = Number(raw)
+	if (!Number.isInteger(value) || value < minimum || value > maximum) {
+		throw new Error(`${name} must be an integer from ${minimum} to ${maximum}`)
+	}
+	return value
+}
+
+const parseJsonLines = (value: string) =>
+	value
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.map((line): unknown => JSON.parse(line))
+
+const readString = (value: unknown, key: string) => {
+	if (!value || typeof value !== "object") return null
+	const field = Reflect.get(value, key)
+	return typeof field === "string" ? field : null
+}
+
+export type ResourceCommand = {
+	stdout: Readable
+	once: (
+		event: "error" | "close",
+		listener: (value?: Error | number | null) => void
+	) => ResourceCommand
+	kill: (signal: NodeJS.Signals) => boolean
+}
+
+export const collectCommandOutput = (child: ResourceCommand, timeoutMs: number) =>
+	new Promise<string>((resolve, reject) => {
+		let stdout = ""
+		let settled = false
+		const finish = (callback: () => void) => {
+			if (settled) return
+			settled = true
+			clearTimeout(timeout)
+			callback()
+		}
+		const timeout = setTimeout(() => {
+			child.kill("SIGKILL")
+			finish(() => reject(new Error("Remote Docker inspection timed out")))
+		}, timeoutMs)
+		child.stdout.setEncoding("utf8")
+		child.stdout.on("data", (chunk: string) => {
+			stdout += chunk
+		})
+		child.once("error", () =>
+			finish(() => reject(new Error("Remote Docker inspection failed")))
+		)
+		child.once("close", (exitCode) => {
+			finish(() => {
+				if (exitCode === 0) resolve(stdout)
+				else reject(new Error("Remote Docker inspection failed"))
+			})
+		})
+	})
+
+const readNumber = (value: unknown, key: string) => {
+	if (!value || typeof value !== "object") return null
+	const field = Reflect.get(value, key)
+	return typeof field === "number" && Number.isFinite(field) ? field : null
+}
+
+const runSshDocker = async (host: string, args: string[]) => {
+	return new Promise<string>((resolve, reject) => {
+		const remoteCommand = ["docker", ...args]
+			.map((value) => `'${value.replaceAll("'", `'\\''`)}'`)
+			.join(" ")
+		const child = spawn(
+			"ssh",
+			["-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host, remoteCommand],
+			{ stdio: ["ignore", "pipe", "ignore"] }
+		)
+		collectCommandOutput(child, 30_000).then(resolve, reject)
+	})
+}
+
+export const parseResourceStats = (
+	stats: unknown[],
+	categoryByName: Map<string, ResourceCategory>
+) => {
+	const observations = stats.map((stat) => {
+		const name = readString(stat, "Name")
+		const cpu = readString(stat, "CPUPerc")
+		const memory = readString(stat, "MemUsage")
+		const pids = readString(stat, "PIDs")
+		if (!name || !cpu || !memory || !pids) {
+			throw new Error("Docker returned incomplete resource stats")
+		}
+		const cpuPercent = Number(cpu.replace(/%$/, ""))
+		const pidCount = Number(pids)
+		if (!Number.isFinite(cpuPercent) || !Number.isFinite(pidCount)) {
+			throw new Error("Docker returned invalid resource stats")
+		}
+		const category = categoryByName.get(name)
+		if (!category) throw new Error("Docker stats did not match container metadata")
+		return {
+			category,
+			cpuPercent,
+			memoryBytes: parseDockerMemoryBytes(memory),
+			pids: pidCount,
+		}
+	})
+	if (observations.length === 0) throw new Error("Docker returned no resource stats")
+	return observations
+}
+
+const collectSample = async (host: string): Promise<ResourceObservation[]> => {
+	const containers = parseJsonLines(
+		await runSshDocker(host, ["ps", "--format", "{{json .}}"])
+	)
+	const categoryByName = new Map<string, ResourceCategory>()
+	for (const container of containers) {
+		const name = readString(container, "Names")
+		const image = readString(container, "Image")
+		if (name && image) categoryByName.set(name, classifyContainer(image, name))
+	}
+
+	const stats = parseJsonLines(
+		await runSshDocker(host, ["stats", "--no-stream", "--format", "{{json .}}"])
+	)
+	return parseResourceStats(stats, categoryByName)
+}
+
+const main = async () => {
+	const host = process.env.PSTRACK_SSH_HOST ?? "pstrack"
+	if (!/^[a-z0-9._-]+$/i.test(host)) throw new Error("PSTRACK_SSH_HOST is invalid")
+	const sampleCount = readIntegerInRange("RESOURCE_SAMPLE_COUNT", 12, {
+		minimum: 1,
+		maximum: 360,
+	})
+	const intervalMs = readIntegerInRange("RESOURCE_SAMPLE_INTERVAL_MS", 5000, {
+		minimum: 250,
+		maximum: 60_000,
+	})
+	const startedAt = new Date()
+
+	const infoRows = parseJsonLines(
+		await runSshDocker(host, ["info", "--format", "{{json .}}"])
+	)
+	const info = infoRows[0]
+	const hostCpuCount = readNumber(info, "NCPU")
+	const hostMemoryBytes = readNumber(info, "MemTotal")
+	if (!hostCpuCount || !hostMemoryBytes) {
+		throw new Error("Docker did not report host capacity")
+	}
+
+	const samples: ResourceObservation[][] = []
+	for (let index = 0; index < sampleCount; index++) {
+		samples.push(await collectSample(host))
+		if (index + 1 < sampleCount) {
+			await new Promise((resolve) => setTimeout(resolve, intervalMs))
+		}
+	}
+
+	const evidence = summarizeResourceSamples(samples, {
+		capturedAt: startedAt.toISOString(),
+		durationMs: Date.now() - startedAt.getTime(),
+		intervalMs,
+		hostCpuCount,
+		hostMemoryBytes,
+	})
+	await writeFile(
+		"resource-measurement-evidence.json",
+		`${JSON.stringify(evidence, null, 2)}\n`
+	)
+	console.log(JSON.stringify(evidence, null, 2))
+}
+
+if (import.meta.main) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : "Resource measurement failed")
+		process.exit(1)
+	})
+}

--- a/scripts/measure-container-resources.ts
+++ b/scripts/measure-container-resources.ts
@@ -92,6 +92,10 @@ export const summarizeResourceSamples = (
 		ResourceCategory,
 		Array<{ cpuPercent: number; memoryBytes: number; pids: number }>
 	>()
+	const totalsBySample: Map<
+		ResourceCategory,
+		{ cpuPercent: number; memoryBytes: number; pids: number }
+	>[] = []
 
 	for (const sample of samples) {
 		const totals = new Map<
@@ -120,14 +124,20 @@ export const summarizeResourceSamples = (
 				totals.set("coolify-total", aggregate)
 			}
 		}
-		for (const [category, total] of totals) {
-			const values = byCategory.get(category) ?? []
-			values.push(total)
-			byCategory.set(category, values)
-		}
+		totalsBySample.push(totals)
 	}
 
-	const categories = Object.fromEntries(
+	const categories = new Set(totalsBySample.flatMap((totals) => [...totals.keys()]))
+	for (const category of categories) {
+		byCategory.set(
+			category,
+			totalsBySample.map(
+				(totals) => totals.get(category) ?? { cpuPercent: 0, memoryBytes: 0, pids: 0 }
+			)
+		)
+	}
+
+	const categorySummaries = Object.fromEntries(
 		[...byCategory.entries()].map(([category, values]) => {
 			const average = (field: "cpuPercent" | "memoryBytes" | "pids") =>
 				round(values.reduce((sum, value) => sum + value[field], 0) / values.length)
@@ -160,7 +170,7 @@ export const summarizeResourceSamples = (
 			cpuCount: options.hostCpuCount,
 			memoryBytes: options.hostMemoryBytes,
 		},
-		categories,
+		categories: categorySummaries,
 	}
 }
 

--- a/scripts/smoke-prod.ts
+++ b/scripts/smoke-prod.ts
@@ -48,6 +48,16 @@ const main = async () => {
 	if (sessionBody !== null)
 		throw new Error("Anonymous auth session check returned a session")
 
+	const og = await checkFetch("/api/v3/og?title=Production%20Smoke")
+	if (og.headers.get("content-type") !== "image/png") {
+		throw new Error("OpenGraph smoke check did not return image/png")
+	}
+	const png = new Uint8Array(await og.arrayBuffer())
+	const pngSignature = [137, 80, 78, 71, 13, 10, 26, 10]
+	if (!pngSignature.every((byte, index) => png[index] === byte)) {
+		throw new Error("OpenGraph smoke check returned an invalid PNG")
+	}
+
 	if (jobSecret) {
 		const freshness = await checkFetch("/api/v3/internal/jobs/freshness", {
 			headers: { Authorization: `Bearer ${jobSecret}` },

--- a/src/test/container-resource-measurement.test.ts
+++ b/src/test/container-resource-measurement.test.ts
@@ -1,0 +1,156 @@
+import { EventEmitter } from "node:events"
+import { PassThrough } from "node:stream"
+import { describe, expect, it } from "vitest"
+
+import type {
+	ResourceCategory,
+	ResourceCommand,
+} from "../../scripts/measure-container-resources"
+import {
+	classifyContainer,
+	collectCommandOutput,
+	parseDockerMemoryBytes,
+	parseResourceStats,
+	summarizeResourceSamples,
+} from "../../scripts/measure-container-resources"
+
+describe("container resource measurement", () => {
+	it("classifies containers without retaining runtime names", () => {
+		expect(classifyContainer("ghcr.io/husamql3/pstrack:main", "generated-name")).toBe(
+			"app"
+		)
+		expect(
+			classifyContainer(
+				"ghcr.io/husamql3/pstrack-db-backups:main",
+				"generated-backup-name"
+			)
+		).toBe("backup")
+		expect(classifyContainer("deploy-pstrack-db-backups", "backup")).toBe("backup")
+		expect(classifyContainer("postgres:18-alpine", "generated-db-name")).toBe("database")
+		expect(classifyContainer("postgres:15-alpine", "coolify-db")).toBe("coolify-database")
+		expect(classifyContainer("stalwartlabs/stalwart:v0.16.12", "mail")).toBe("mail")
+		expect(classifyContainer("traefik:v3.6", "coolify-proxy")).toBe("coolify-proxy")
+		expect(classifyContainer("redis:7-alpine", "coolify-redis")).toBe("coolify-cache")
+	})
+
+	it("parses Docker binary memory units", () => {
+		expect(parseDockerMemoryBytes("282.7MiB / 3.824GiB")).toBe(296_432_435)
+		expect(parseDockerMemoryBytes("1.5GiB / 4GiB")).toBe(1_610_612_736)
+	})
+
+	it("summarizes samples by category without container identifiers", () => {
+		const evidence = summarizeResourceSamples(
+			[
+				[
+					{ category: "app", cpuPercent: 2, memoryBytes: 100, pids: 10 },
+					{
+						category: "coolify-platform",
+						cpuPercent: 1,
+						memoryBytes: 50,
+						pids: 5,
+					},
+				],
+				[
+					{ category: "app", cpuPercent: 4, memoryBytes: 140, pids: 12 },
+					{
+						category: "coolify-platform",
+						cpuPercent: 3,
+						memoryBytes: 70,
+						pids: 7,
+					},
+				],
+			],
+			{
+				capturedAt: "2026-07-14T13:00:00.000Z",
+				durationMs: 5000,
+				intervalMs: 5000,
+				hostCpuCount: 2,
+				hostMemoryBytes: 4_000,
+			}
+		)
+
+		expect(evidence).toEqual({
+			capturedAt: "2026-07-14T13:00:00.000Z",
+			durationMs: 5000,
+			sampleCount: 2,
+			intervalMs: 5000,
+			hostCapacity: { cpuCount: 2, memoryBytes: 4_000 },
+			categories: {
+				app: {
+					observations: 2,
+					cpuPercent: { average: 3, maximum: 4 },
+					memoryBytes: { average: 120, maximum: 140 },
+					pids: { average: 11, maximum: 12 },
+				},
+				"coolify-platform": {
+					observations: 2,
+					cpuPercent: { average: 2, maximum: 3 },
+					memoryBytes: { average: 60, maximum: 70 },
+					pids: { average: 6, maximum: 7 },
+				},
+				"coolify-total": {
+					observations: 2,
+					cpuPercent: { average: 2, maximum: 3 },
+					memoryBytes: { average: 60, maximum: 70 },
+					pids: { average: 6, maximum: 7 },
+				},
+			},
+		})
+		expect(JSON.stringify(evidence)).not.toContain("generated")
+	})
+
+	it("fails closed for empty, malformed, and unmatched Docker stats", () => {
+		const categories = new Map<string, ResourceCategory>([["app-1", "app"]])
+		expect(() => parseResourceStats([], categories)).toThrow("no resource stats")
+		expect(() => parseResourceStats([{ Name: "app-1" }], categories)).toThrow(
+			"incomplete resource stats"
+		)
+		expect(() =>
+			parseResourceStats(
+				[
+					{
+						Name: "app-1",
+						CPUPerc: "invalid",
+						MemUsage: "1MiB / 4GiB",
+						PIDs: "1",
+					},
+				],
+				categories
+			)
+		).toThrow("invalid resource stats")
+		expect(() =>
+			parseResourceStats(
+				[
+					{
+						Name: "unknown",
+						CPUPerc: "1%",
+						MemUsage: "1MiB / 4GiB",
+						PIDs: "1",
+					},
+				],
+				categories
+			)
+		).toThrow("did not match container metadata")
+	})
+
+	it("kills timed-out commands and ignores a late close", async () => {
+		const events = new EventEmitter()
+		const stdout = new PassThrough()
+		let killed = false
+		const command: ResourceCommand = {
+			stdout,
+			once: (event, listener) => {
+				events.once(event, listener)
+				return command
+			},
+			kill: () => {
+				killed = true
+				return true
+			},
+		}
+		const result = collectCommandOutput(command, 1)
+		await expect(result).rejects.toThrow("timed out")
+		expect(killed).toBe(true)
+		events.emit("close", 0)
+	})
+})

--- a/src/test/container-resource-measurement.test.ts
+++ b/src/test/container-resource-measurement.test.ts
@@ -99,6 +99,26 @@ describe("container resource measurement", () => {
 		expect(JSON.stringify(evidence)).not.toContain("generated")
 	})
 
+	it("averages transient categories across the complete measurement window", () => {
+		const evidence = summarizeResourceSamples(
+			[[{ category: "backup", cpuPercent: 10, memoryBytes: 100, pids: 2 }], []],
+			{
+				capturedAt: "2026-07-14T18:00:00.000Z",
+				durationMs: 5000,
+				intervalMs: 5000,
+				hostCpuCount: 2,
+				hostMemoryBytes: 4_000,
+			}
+		)
+
+		expect(evidence.categories.backup).toEqual({
+			observations: 2,
+			cpuPercent: { average: 5, maximum: 10 },
+			memoryBytes: { average: 50, maximum: 100 },
+			pids: { average: 1, maximum: 2 },
+		})
+	})
+
 	it("fails closed for empty, malformed, and unmatched Docker stats", () => {
 		const categories = new Map<string, ResourceCategory>([["app-1", "app"]])
 		expect(() => parseResourceStats([], categories)).toThrow("no resource stats")


### PR DESCRIPTION
Refs #291.

Runs the app image as a numeric non-root user, adds a container resource baseline measurement, and verifies hardened OG rendering.

**Commits (3)**
- `feat(runtime): run app image as numeric non-root user (#291)`
- `feat(ops): measure container resource baseline (#291)`
- `fix(runtime): verify hardened OG rendering (#291)`

> ⚠️ Behind `stage` by 17 commits (overlaps #336's Dockerfile changes) — may need a rebase before merge. Verification is via CI on this PR.