### PR TITLE
fix(security): report-only security headers + sanitized CSP reports

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -1030,10 +1030,11 @@ export const routeTree = rootRouteImport
   ._addFileTypes<FileRouteTypes>()
 
 import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
+import type { startInstance } from './start.ts'
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -10,6 +10,7 @@ import { internalController } from "@/server/internal/internal.controller"
 import { jobsController } from "@/server/jobs/jobs.controller"
 import { leaderboardController } from "@/server/leaderboard/leaderboard.controller"
 import { auth } from "@/server/lib/auth"
+import { securityHeaders } from "@/server/lib/security-headers"
 import {
 	captureServerException,
 	initServerSentry,
@@ -53,6 +54,7 @@ const api = new Elysia({ prefix: "/api/v3" })
 
 export const app = new Elysia()
 	.use(requestLogger)
+	.use(securityHeaders)
 	.all("/api/v3/auth/*", ({ request }) => auth.handler(request), {
 		detail: { tags: ["Auth"] },
 	})

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -21,6 +21,7 @@ import { health } from "@/server/modules/health"
 import { og } from "@/server/modules/og"
 import { problemsAdminController } from "@/server/problems/problems.admin.controller"
 import { problemsController } from "@/server/problems/problems.controller"
+import { securityController } from "@/server/security/security.controller"
 import { usersAdminController } from "@/server/users/users.admin.controller"
 import { usersController } from "@/server/users/users.controller"
 import { logger, requestLogger } from "./lib/logger"
@@ -35,6 +36,7 @@ const api = new Elysia({ prefix: "/api/v3" })
 	.use(usersController)
 	.use(groupsController)
 	.use(problemsController)
+	.use(securityController)
 	.use(badgesController)
 	.use(feedbackController)
 	.use(internalController)

--- a/src/server/lib/security-headers.ts
+++ b/src/server/lib/security-headers.ts
@@ -1,0 +1,39 @@
+import { Elysia } from "elysia"
+
+const CONTENT_SECURITY_POLICY_REPORT_ONLY = [
+	"default-src 'self'",
+	"base-uri 'self'",
+	"object-src 'none'",
+	"frame-ancestors 'none'",
+	"form-action 'self' https://polar.sh https://*.polar.sh",
+	"script-src 'self' 'unsafe-inline'",
+	"style-src 'self' 'unsafe-inline'",
+	"img-src 'self' data: blob: https:",
+	"font-src 'self' data:",
+	"connect-src 'self' https://*.sentry.io https://*.posthog.com",
+	"worker-src 'self' blob:",
+	"manifest-src 'self'",
+	"media-src 'none'",
+].join("; ")
+
+const SECURITY_HEADERS = {
+	"content-security-policy-report-only": CONTENT_SECURITY_POLICY_REPORT_ONLY,
+	"permissions-policy": "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
+	"referrer-policy": "strict-origin-when-cross-origin",
+	"x-content-type-options": "nosniff",
+	"x-frame-options": "DENY",
+}
+
+export const applySecurityHeaders = (headers: Headers) => {
+	for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+		headers.set(name, value)
+	}
+}
+
+export const securityHeaders = new Elysia({ name: "security-headers" })
+	.onRequest(({ set }) => {
+		for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+			set.headers[name] = value
+		}
+	})
+	.as("global")

--- a/src/server/lib/security-headers.ts
+++ b/src/server/lib/security-headers.ts
@@ -14,12 +14,15 @@ const CONTENT_SECURITY_POLICY_REPORT_ONLY = [
 	"worker-src 'self' blob:",
 	"manifest-src 'self'",
 	"media-src 'none'",
+	"report-uri /api/v3/security/csp-report",
+	"report-to csp-endpoint",
 ].join("; ")
 
 const SECURITY_HEADERS = {
 	"content-security-policy-report-only": CONTENT_SECURITY_POLICY_REPORT_ONLY,
 	"permissions-policy": "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
 	"referrer-policy": "strict-origin-when-cross-origin",
+	"reporting-endpoints": 'csp-endpoint="/api/v3/security/csp-report"',
 	"x-content-type-options": "nosniff",
 	"x-frame-options": "DENY",
 }

--- a/src/server/lib/sentry.ts
+++ b/src/server/lib/sentry.ts
@@ -40,6 +40,13 @@ export function captureServerException(
 	}
 }
 
+export function captureServerMessage(message: string, context: Record<string, unknown>) {
+	Sentry.withScope((scope) => {
+		scope.setContext("additional", context)
+		Sentry.captureMessage(message, "warning")
+	})
+}
+
 export function setServerUser(user: Pick<User, "id" | "username" | "email">) {
 	Sentry.setUser(user)
 }

--- a/src/server/security/security.controller.ts
+++ b/src/server/security/security.controller.ts
@@ -1,0 +1,38 @@
+import { Elysia } from "elysia"
+
+import { securityModel } from "./security.model"
+import { recordCspViolation } from "./security.service"
+import { summarizeCspViolation } from "./security.utils"
+
+const MAX_REPORT_BYTES = 16_384
+
+export const securityController = new Elysia({
+	prefix: "/security",
+	tags: ["Security"],
+})
+	.use(securityModel)
+	.post(
+		"/csp-report",
+		({ body, request }) => {
+			const accepted = () => new Response(null, { status: 204 })
+			const declaredLength = Number(request.headers.get("content-length") ?? 0)
+			if (declaredLength > MAX_REPORT_BYTES || body.length > MAX_REPORT_BYTES) {
+				return accepted()
+			}
+
+			try {
+				const parsedBody: unknown = JSON.parse(body)
+				const reports = Array.isArray(parsedBody) ? parsedBody.slice(0, 10) : [parsedBody]
+
+				for (const report of reports) {
+					const summary = summarizeCspViolation(report)
+					if (summary) recordCspViolation(summary)
+				}
+			} catch {
+				// Browser reporting must never fail a user-facing request or create a loop.
+			}
+
+			return accepted()
+		},
+		{ parse: "text", body: "security.cspReport" }
+	)

--- a/src/server/security/security.model.ts
+++ b/src/server/security/security.model.ts
@@ -1,0 +1,5 @@
+import Elysia, { t } from "elysia"
+
+export const securityModel = new Elysia({ name: "model/security" }).model({
+	"security.cspReport": t.String(),
+})

--- a/src/server/security/security.service.ts
+++ b/src/server/security/security.service.ts
@@ -1,0 +1,25 @@
+import { captureServerMessage } from "@/server/lib/sentry"
+import type { CspViolationSummary } from "./security.type"
+
+const REPORT_DEDUPLICATION_WINDOW_MS = 5 * 60 * 1000
+const MAX_DEDUPLICATION_KEYS = 128
+const recentReports = new Map<string, number>()
+
+export const recordCspViolation = (summary: CspViolationSummary) => {
+	const now = Date.now()
+	const key = `${summary.effectiveDirective}:${summary.documentArea}`
+	const lastReportedAt = recentReports.get(key)
+	if (lastReportedAt && now - lastReportedAt < REPORT_DEDUPLICATION_WINDOW_MS) return
+
+	if (recentReports.size >= MAX_DEDUPLICATION_KEYS) {
+		for (const [existingKey, reportedAt] of recentReports) {
+			if (now - reportedAt >= REPORT_DEDUPLICATION_WINDOW_MS) {
+				recentReports.delete(existingKey)
+			}
+		}
+	}
+	if (recentReports.size >= MAX_DEDUPLICATION_KEYS) return
+
+	recentReports.set(key, now)
+	captureServerMessage("Content Security Policy violation", summary)
+}

--- a/src/server/security/security.type.test.ts
+++ b/src/server/security/security.type.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+
+import { summarizeCspViolation } from "./security.utils"
+
+describe("summarizeCspViolation", () => {
+	it("summarizes modern Reporting API bodies without retaining URLs", () => {
+		expect(
+			summarizeCspViolation({
+				type: "csp-violation",
+				url: "https://pstrack.app/settings/account?token=private",
+				body: {
+					blockedURL: "https://o123.ingest.sentry.io/api/private",
+					documentURL: "https://pstrack.app/settings/account?token=private",
+					effectiveDirective: "connect-src",
+					disposition: "enforce",
+					sample: "private sample",
+				},
+			})
+		).toEqual({
+			blockedResource: "sentry",
+			disposition: "enforce",
+			documentArea: "settings",
+			effectiveDirective: "connect-src",
+		})
+	})
+
+	it("collapses invented directive names into the bounded unknown category", () => {
+		expect(
+			summarizeCspViolation({
+				"csp-report": {
+					"effective-directive": "attacker-invented-directive",
+				},
+			})?.effectiveDirective
+		).toBe("unknown")
+	})
+})

--- a/src/server/security/security.type.ts
+++ b/src/server/security/security.type.ts
@@ -1,0 +1,29 @@
+export type CspBlockedResource =
+	| "blob"
+	| "data"
+	| "eval"
+	| "http-external"
+	| "https-external"
+	| "inline"
+	| "other"
+	| "polar"
+	| "posthog"
+	| "self"
+	| "sentry"
+	| "unknown"
+
+export type CspDocumentArea =
+	| "admin"
+	| "api"
+	| "app"
+	| "auth"
+	| "profile"
+	| "settings"
+	| "unknown"
+
+export type CspViolationSummary = {
+	blockedResource: CspBlockedResource
+	disposition: "enforce" | "report" | "unknown"
+	documentArea: CspDocumentArea
+	effectiveDirective: string
+}

--- a/src/server/security/security.utils.ts
+++ b/src/server/security/security.utils.ts
@@ -1,0 +1,96 @@
+import type {
+	CspBlockedResource,
+	CspDocumentArea,
+	CspViolationSummary,
+} from "./security.type"
+
+const CSP_DIRECTIVES = new Set([
+	"base-uri",
+	"connect-src",
+	"default-src",
+	"font-src",
+	"form-action",
+	"frame-ancestors",
+	"img-src",
+	"manifest-src",
+	"media-src",
+	"object-src",
+	"script-src",
+	"script-src-attr",
+	"script-src-elem",
+	"style-src",
+	"style-src-attr",
+	"style-src-elem",
+	"worker-src",
+])
+
+const readString = (value: unknown, key: string) => {
+	if (!value || typeof value !== "object") return undefined
+	const field = Reflect.get(value, key)
+	return typeof field === "string" ? field : undefined
+}
+
+const normalizeDirective = (value: unknown) => {
+	if (typeof value !== "string") return "unknown"
+	return CSP_DIRECTIVES.has(value) ? value : "unknown"
+}
+
+const categorizeDocumentArea = (value: unknown): CspDocumentArea => {
+	if (typeof value !== "string") return "unknown"
+	try {
+		const path = new URL(value).pathname
+		if (path === "/admin" || path.startsWith("/admin/")) return "admin"
+		if (path === "/login" || path === "/signup") return "auth"
+		if (path === "/profile" || path.startsWith("/profile/")) return "profile"
+		if (path === "/settings" || path.startsWith("/settings/")) return "settings"
+		if (path === "/api" || path.startsWith("/api/")) return "api"
+		return "app"
+	} catch {
+		return "unknown"
+	}
+}
+
+const categorizeBlockedResource = (value: unknown): CspBlockedResource => {
+	if (value === "inline" || value === "eval" || value === "self") return value
+	if (value === "data" || value === "blob") return value
+	if (typeof value !== "string") return "unknown"
+	try {
+		const url = new URL(value)
+		if (url.hostname.endsWith(".sentry.io")) return "sentry"
+		if (url.hostname.endsWith(".posthog.com")) return "posthog"
+		if (url.hostname === "polar.sh" || url.hostname.endsWith(".polar.sh")) {
+			return "polar"
+		}
+		if (url.protocol === "https:") return "https-external"
+		if (url.protocol === "http:") return "http-external"
+		return "other"
+	} catch {
+		return "other"
+	}
+}
+
+export const summarizeCspViolation = (
+	value: unknown
+): CspViolationSummary | undefined => {
+	if (!value || typeof value !== "object") return undefined
+	const legacyReport = Reflect.get(value, "csp-report")
+	const modernReport = Reflect.get(value, "body")
+	const report = legacyReport ?? modernReport ?? value
+	if (!report || typeof report !== "object") return undefined
+
+	const disposition = readString(report, "disposition")
+	return {
+		blockedResource: categorizeBlockedResource(
+			readString(report, "blocked-uri") ?? readString(report, "blockedURL")
+		),
+		disposition:
+			disposition === "report" || disposition === "enforce" ? disposition : "unknown",
+		documentArea: categorizeDocumentArea(
+			readString(report, "document-uri") ?? readString(report, "documentURL")
+		),
+		effectiveDirective: normalizeDirective(
+			readString(report, "effective-directive") ??
+				readString(report, "effectiveDirective")
+		),
+	}
+}

--- a/src/server/stress/api.stress.integration.test.ts
+++ b/src/server/stress/api.stress.integration.test.ts
@@ -1103,6 +1103,30 @@ describe("API stress suite", () => {
 		)
 	})
 
+	it("serves report-only security headers across auth, API, and OpenGraph responses", async () => {
+		const responses = await Promise.all([
+			app.handle(new Request("https://stress.test/api/v3/auth/get-session")),
+			app.handle(new Request("https://stress.test/api/v3/openapi/json")),
+			app.handle(new Request("https://stress.test/api/v3/og/?title=Security")),
+		])
+
+		for (const response of responses) {
+			expect(response.headers.get("content-security-policy-report-only")).toContain(
+				"default-src 'self'"
+			)
+			expect(response.headers.get("content-security-policy")).toBeNull()
+			expect(response.headers.get("strict-transport-security")).toBeNull()
+			expect(response.headers.get("x-content-type-options")).toBe("nosniff")
+			expect(response.headers.get("referrer-policy")).toBe(
+				"strict-origin-when-cross-origin"
+			)
+			expect(response.headers.get("permissions-policy")).toBe(
+				"camera=(), microphone=(), geolocation=(), payment=(), usb=()"
+			)
+			expect(response.headers.get("x-frame-options")).toBe("DENY")
+		}
+	})
+
 	it("keeps every endpoint inside its allowed response envelope under representative pressure", async () => {
 		const ctx = await seedStressContext()
 		const scenarios = createEndpointScenarios(ctx)

--- a/src/server/stress/api.stress.integration.test.ts
+++ b/src/server/stress/api.stress.integration.test.ts
@@ -14,6 +14,10 @@ const authMock = vi.hoisted(() => {
 	}
 })
 
+const sentryMock = vi.hoisted(() => ({
+	captureServerMessage: vi.fn(),
+}))
+
 vi.mock("@/server/lib/auth", () => ({
 	auth: {
 		api: {
@@ -40,6 +44,7 @@ vi.mock("@/server/lib/email", () => ({
 
 vi.mock("@/server/lib/sentry", () => ({
 	captureServerException: vi.fn(),
+	captureServerMessage: sentryMock.captureServerMessage,
 	initServerSentry: vi.fn(),
 	ServerSentry: { flush: vi.fn() },
 }))
@@ -600,6 +605,20 @@ const createEndpointScenarios = (ctx: StressContext): StressScenario[] => [
 		allowedStatuses: [200, 409],
 	},
 	{
+		key: { method: "POST", path: "/api/v3/security/csp-report" },
+		method: "POST",
+		path: "/api/v3/security/csp-report",
+		body: {
+			"csp-report": {
+				"blocked-uri": "inline",
+				"document-uri": "https://stress.test/dashboard",
+				"effective-directive": "script-src",
+				disposition: "report",
+			},
+		},
+		allowedStatuses: [204],
+	},
+	{
 		key: { method: "GET", path: "/api/v3/badges/me" },
 		method: "GET",
 		path: "/api/v3/badges/me",
@@ -1037,6 +1056,7 @@ describe("API stress suite", () => {
 	})
 
 	beforeEach(() => {
+		sentryMock.captureServerMessage.mockReset()
 		sessions.clear()
 		authMock.handler.mockImplementation(async () => new Response("auth"))
 		authMock.getSession.mockImplementation(async ({ headers }) => {
@@ -1111,8 +1131,12 @@ describe("API stress suite", () => {
 		])
 
 		for (const response of responses) {
-			expect(response.headers.get("content-security-policy-report-only")).toContain(
-				"default-src 'self'"
+			const reportOnlyPolicy = response.headers.get("content-security-policy-report-only")
+			expect(reportOnlyPolicy).toContain("default-src 'self'")
+			expect(reportOnlyPolicy).toContain("report-uri /api/v3/security/csp-report")
+			expect(reportOnlyPolicy).toContain("report-to csp-endpoint")
+			expect(response.headers.get("reporting-endpoints")).toBe(
+				'csp-endpoint="/api/v3/security/csp-report"'
 			)
 			expect(response.headers.get("content-security-policy")).toBeNull()
 			expect(response.headers.get("strict-transport-security")).toBeNull()
@@ -1125,6 +1149,81 @@ describe("API stress suite", () => {
 			)
 			expect(response.headers.get("x-frame-options")).toBe("DENY")
 		}
+	})
+
+	it("collects CSP reports without forwarding URLs or report samples", async () => {
+		const response = await app.handle(
+			new Request("https://stress.test/api/v3/security/csp-report", {
+				method: "POST",
+				headers: { "content-type": "application/csp-report" },
+				body: JSON.stringify({
+					"csp-report": {
+						"document-uri":
+							"https://stress.test/profile/private-user?token=private-query-token",
+						"blocked-uri":
+							"https://private-service.internal/secret?token=blocked-query-token",
+						"effective-directive": "script-src-elem",
+						disposition: "report",
+						"source-file": "https://stress.test/assets/private-file.js",
+						"script-sample": "private-code-sample",
+					},
+				}),
+			})
+		)
+
+		expect(response.status).toBe(204)
+		expect(sentryMock.captureServerMessage).toHaveBeenCalledWith(
+			"Content Security Policy violation",
+			{
+				blockedResource: "https-external",
+				disposition: "report",
+				documentArea: "profile",
+				effectiveDirective: "script-src-elem",
+			}
+		)
+		const captured = JSON.stringify(sentryMock.captureServerMessage.mock.calls)
+		expect(captured).not.toContain("private-service")
+		expect(captured).not.toContain("private-user")
+		expect(captured).not.toContain("private-query-token")
+		expect(captured).not.toContain("blocked-query-token")
+		expect(captured).not.toContain("private-file")
+		expect(captured).not.toContain("private-code-sample")
+		const duplicateResponse = await app.handle(
+			new Request("https://stress.test/api/v3/security/csp-report", {
+				method: "POST",
+				headers: { "content-type": "application/csp-report" },
+				body: JSON.stringify({
+					"csp-report": {
+						"document-uri": "https://stress.test/profile/another-private-user",
+						"blocked-uri": "https://another-private-host.invalid/asset.js",
+						"effective-directive": "script-src-elem",
+						disposition: "report",
+					},
+				}),
+			})
+		)
+		expect(duplicateResponse.status).toBe(204)
+		expect(sentryMock.captureServerMessage).toHaveBeenCalledTimes(1)
+
+		sentryMock.captureServerMessage.mockImplementationOnce(() => {
+			throw new Error("telemetry unavailable")
+		})
+		const telemetryFailureResponse = await app.handle(
+			new Request("https://stress.test/api/v3/security/csp-report", {
+				method: "POST",
+				headers: { "content-type": "application/reports+json" },
+				body: JSON.stringify([
+					{
+						body: {
+							blockedURL: "inline",
+							documentURL: "https://stress.test/dashboard",
+							effectiveDirective: "script-src",
+						},
+					},
+				]),
+			})
+		)
+		expect(telemetryFailureResponse.status).toBe(204)
 	})
 
 	it("keeps every endpoint inside its allowed response envelope under representative pressure", async () => {

--- a/src/server/stress/manifest.stress.integration.test.ts
+++ b/src/server/stress/manifest.stress.integration.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/server/lib/auth", () => ({
 
 vi.mock("@/server/lib/sentry", () => ({
 	captureServerException: vi.fn(),
+	captureServerMessage: vi.fn(),
 	initServerSentry: vi.fn(),
 	ServerSentry: { flush: vi.fn() },
 }))

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,0 +1,22 @@
+import { createMiddleware, createStart } from "@tanstack/react-start"
+
+import { applySecurityHeaders } from "@/server/lib/security-headers"
+
+const securityHeadersMiddleware = createMiddleware().server(async ({ next }) => {
+	const result = await next()
+	const headers = new Headers(result.response.headers)
+	applySecurityHeaders(headers)
+
+	return {
+		...result,
+		response: new Response(result.response.body, {
+			headers,
+			status: result.response.status,
+			statusText: result.response.statusText,
+		}),
+	}
+})
+
+export const startInstance = createStart(() => ({
+	requestMiddleware: [securityHeadersMiddleware],
+}))

--- a/src/test/stress-manifest.ts
+++ b/src/test/stress-manifest.ts
@@ -202,6 +202,12 @@ export const STRESS_ENDPOINTS: StressEndpoint[] = [
 		dimensions: ["auth", "concurrency", "idempotency", "invariant"],
 	},
 	{
+		method: "POST",
+		path: "/api/v3/security/csp-report",
+		module: "security",
+		dimensions: ["fuzz", "load", "side-effect"],
+	},
+	{
 		method: "GET",
 		path: "/api/v3/badges/me",
 		module: "badges",


### PR DESCRIPTION
Refs #292.

Adds report-only security response headers and a sanitized CSP report collection endpoint.

**Commits (2)**
- `fix(security): add report-only response headers (#292)`
- `fix(security): collect sanitized CSP reports (#292)`

> ⚠️ Behind `stage` by 17 commits — may need a rebase before merge. Verification is via CI on this PR.