### PR TITLE
fix(#351): make admin Pro grant a direct status toggle with reliable revoke

### DIFF
--- a/src/routes/_admin/admin/users/$id.tsx
+++ b/src/routes/_admin/admin/users/$id.tsx
@@ -1,8 +1,8 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { useState } from "react"
-import { Controller, useForm } from "react-hook-form"
+import { useForm } from "react-hook-form"
 import { sileo } from "sileo"
 
 import { Badge } from "@/components/ui/badge"
@@ -27,8 +27,9 @@ import {
 	useAdminUser,
 	useAdminUserPointsHistory,
 } from "@/features/admin/hooks/use-admin-users"
+import { ProSource } from "@/generated/prisma/enums"
 import { api } from "@/lib/api"
-import { adminAdjustPointsSchema, adminProGrantSchema } from "@/server/admin/admin.type"
+import { adminAdjustPointsSchema } from "@/server/admin/admin.type"
 
 export const Route = createFileRoute("/_admin/admin/users/$id")({
 	component: AdminUserDetailPage,
@@ -97,7 +98,7 @@ function AdminUserDetailPage() {
 				</TabsContent>
 
 				<TabsContent value="pro" className="space-y-4">
-					<ProGrantForm
+					<ProStatusCard
 						userId={user.id}
 						isPro={user.isPro}
 						proSource={user.proSource ?? null}
@@ -236,7 +237,7 @@ function PointsHistoryTable({ userId }: { userId: string }) {
 	)
 }
 
-function ProGrantForm({
+function ProStatusCard({
 	userId,
 	isPro,
 	proSource,
@@ -248,34 +249,43 @@ function ProGrantForm({
 	proExpiresAt: Date | null
 }) {
 	const queryClient = useQueryClient()
-	const [grant, setGrant] = useState(!isPro)
-	const {
-		register,
-		handleSubmit,
-		control,
-		formState: { errors, isSubmitting },
-	} = useForm({
-		resolver: zodResolver(adminProGrantSchema),
-		defaultValues: { grant: !isPro, expiresAt: null, reason: "" },
+	const [expiresAt, setExpiresAt] = useState("")
+	const [reason, setReason] = useState("")
+	const polarLocked = isPro && proSource === ProSource.POLAR_PURCHASE
+
+	const proMutation = useMutation({
+		mutationFn: async (grant: boolean) => {
+			const trimmedReason = reason.trim()
+			const { error } = await api.v3.admin.users({ id: userId }).pro.post({
+				grant,
+				expiresAt: grant && expiresAt ? new Date(expiresAt).toISOString() : null,
+				...(trimmedReason ? { reason: trimmedReason } : {}),
+			})
+			if (error) {
+				const message =
+					error.value && typeof error.value === "object" && "error" in error.value
+						? String((error.value as { error: unknown }).error)
+						: "Try again"
+				throw new Error(message)
+			}
+		},
+		onSuccess: async () => {
+			setExpiresAt("")
+			setReason("")
+			await queryClient.invalidateQueries({ queryKey: ["admin", "users", userId] })
+		},
 	})
 
-	const onSubmit = handleSubmit(async (values) => {
-		const { error } = await api.v3.admin.users({ id: userId }).pro.post({
-			grant,
-			expiresAt: values.expiresAt ?? null,
-			reason: values.reason,
+	const handleToggle = (checked: boolean) => {
+		void sileo.promise(proMutation.mutateAsync(checked), {
+			loading: { title: checked ? "Granting Pro..." : "Revoking Pro..." },
+			success: { title: checked ? "Pro granted" : "Pro revoked" },
+			error: (err) => ({
+				title: checked ? "Failed to grant Pro" : "Failed to revoke Pro",
+				description: err instanceof Error ? err.message : "Try again",
+			}),
 		})
-		if (error) {
-			const message =
-				error.value && typeof error.value === "object" && "error" in error.value
-					? String((error.value as { error: unknown }).error)
-					: "Try again"
-			sileo.error({ title: "Failed", description: message })
-			return
-		}
-		sileo.success({ title: grant ? "Pro granted" : "Pro revoked" })
-		await queryClient.invalidateQueries({ queryKey: ["admin", "users", userId] })
-	})
+	}
 
 	return (
 		<Card>
@@ -292,49 +302,47 @@ function ProGrantForm({
 					/>
 				</div>
 
-				<form onSubmit={onSubmit} className="flex flex-col gap-3">
+				<div className="flex flex-col gap-3">
 					<div className="flex items-center gap-2">
-						<Switch id="grant" checked={grant} onCheckedChange={setGrant} />
-						<Label htmlFor="grant">{grant ? "Grant Pro" : "Revoke Pro"}</Label>
+						<Switch
+							id="pro-access"
+							checked={isPro}
+							onCheckedChange={handleToggle}
+							disabled={proMutation.isPending || polarLocked}
+						/>
+						<Label htmlFor="pro-access">Pro access</Label>
 					</div>
+					{polarLocked ? (
+						<p className="text-muted-foreground text-xs">
+							This user purchased Pro via Polar — revoke by issuing a refund in Polar
+							instead.
+						</p>
+					) : null}
 					<div className="flex flex-col gap-1.5">
-						<Label htmlFor="expiresAt">Expires at (optional, grants only)</Label>
-						<Controller
-							control={control}
-							name="expiresAt"
-							render={({ field }) => (
-								<Input
-									id="expiresAt"
-									type="datetime-local"
-									disabled={isSubmitting || !grant}
-									value={
-										field.value ? new Date(field.value).toISOString().slice(0, 16) : ""
-									}
-									onChange={(e) =>
-										field.onChange(
-											e.target.value ? new Date(e.target.value).toISOString() : null
-										)
-									}
-								/>
-							)}
+						<Label htmlFor="expiresAt">
+							Expires at (optional, applies when granting)
+						</Label>
+						<Input
+							id="expiresAt"
+							type="datetime-local"
+							disabled={proMutation.isPending || isPro}
+							value={expiresAt}
+							onChange={(e) => setExpiresAt(e.target.value)}
 						/>
 					</div>
 					<div className="flex flex-col gap-1.5">
-						<Label htmlFor="pro-reason">Reason</Label>
+						<Label htmlFor="pro-reason">
+							Reason (optional, recorded in the audit log)
+						</Label>
 						<Textarea
 							id="pro-reason"
 							rows={2}
-							{...register("reason")}
-							disabled={isSubmitting}
+							value={reason}
+							onChange={(e) => setReason(e.target.value)}
+							disabled={proMutation.isPending}
 						/>
-						{errors.reason ? (
-							<span className="text-destructive text-xs">{errors.reason.message}</span>
-						) : null}
 					</div>
-					<Button type="submit" disabled={isSubmitting} className="self-end">
-						{grant ? "Grant" : "Revoke"}
-					</Button>
-				</form>
+				</div>
 			</CardContent>
 		</Card>
 	)

--- a/src/server/admin/admin.model.ts
+++ b/src/server/admin/admin.model.ts
@@ -50,7 +50,7 @@ export const adminModel = new Elysia({ name: "model/admin" }).model({
 	"admin.users.proGrant": t.Object({
 		grant: t.Boolean(),
 		expiresAt: t.Optional(t.Union([t.String({ format: "date-time" }), t.Null()])),
-		reason: t.String({ minLength: 1, maxLength: 280 }),
+		reason: t.Optional(t.String({ maxLength: 280 })),
 	}),
 	"admin.users.impersonationEnded": t.Object({
 		durationMs: t.Optional(t.Integer({ minimum: 0 })),

--- a/src/server/admin/admin.type.ts
+++ b/src/server/admin/admin.type.ts
@@ -287,21 +287,6 @@ export const adminAdjustPointsSchema = z.object({
 })
 export type AdminAdjustPointsInput = z.infer<typeof adminAdjustPointsSchema>
 
-export const adminProGrantSchema = z.object({
-	grant: z.boolean(),
-	expiresAt: z
-		.string()
-		.datetime({ error: "Must be a valid ISO datetime" })
-		.nullable()
-		.optional(),
-	reason: z
-		.string()
-		.trim()
-		.min(1, { error: "Reason is required" })
-		.max(280, { error: "Reason must be 280 characters or fewer" }),
-})
-export type AdminProGrantInput = z.infer<typeof adminProGrantSchema>
-
 export const adminBanUserSchema = z.object({
 	banned: z.boolean(),
 	reason: z

--- a/src/server/users/users.admin.controller.ts
+++ b/src/server/users/users.admin.controller.ts
@@ -82,7 +82,7 @@ export const usersAdminController = new Elysia({
 			const result = await usersAdminDao.setPro(user.id, params.id, {
 				grant: body.grant,
 				expiresAt: body.expiresAt ? new Date(body.expiresAt) : null,
-				reason: body.reason,
+				reason: body.reason ?? null,
 			})
 			if (!result.ok) {
 				if (result.error === "USER_NOT_FOUND") {

--- a/src/server/users/users.admin.dao.ts
+++ b/src/server/users/users.admin.dao.ts
@@ -154,7 +154,7 @@ export const usersAdminDao = {
 	setPro: async (
 		adminId: string,
 		userId: string,
-		input: { grant: boolean; expiresAt: Date | null; reason: string }
+		input: { grant: boolean; expiresAt: Date | null; reason: string | null }
 	): Promise<
 		| { ok: true; user: AdminUserDetailResponse }
 		| { ok: false; error: "USER_NOT_FOUND" | "POLAR_PRO_LOCKED" }
@@ -179,6 +179,7 @@ export const usersAdminDao = {
 						}
 					: {
 							isPro: false,
+							proSource: null,
 							proExpiresAt: null,
 						},
 				select: adminUserDetailSelect,


### PR DESCRIPTION
## Summary
- **Pro grant is now a direct status toggle** — the old form kept switch state in `useState(!isPro)`, an "action selector" that never resynced with the server; after a grant it still read "Grant Pro", and it never reflected actual Pro status. The new `ProStatusCard` drives the switch from `user.isPro` and flipping it fires the grant/revoke mutation immediately (toasts via `sileo.promise`, disabled while pending).
- **`reason` is now optional end-to-end** (TypeBox model, controller, DAO — parity with the ban flow) — the required reason was the main "revoke does nothing" culprit: submitting with an empty reason failed client validation with only tiny inline text as feedback.
- **Revoke clears `proSource`** — the revoke branch previously left `proSource` populated, inconsistent with the `expire-admin-pro-grants` cron which nulls all three Pro fields.
- **Polar purchasers get a disabled toggle + hint** ("revoke by issuing a refund in Polar") instead of discovering the 409 lock only after submitting.
- Removed the now-unused `adminProGrantSchema` Zod schema (client no longer uses react-hook-form for this card; server validation is the TypeBox model).

## Testing
1. `bun run typecheck && bun run check && bun run test && bun run build` — all green (75/75 tests; the `daily-loop.integration.test.ts` env failure is pre-existing on `stage`)
2. Manual: `/admin/users/<id>` → Pro tab → flip "Pro access" ON → user gains Pro (source `ADMIN_GRANT`), badge + fields refresh; flip OFF → Pro revoked, `proSource` cleared — no reason required
3. Grant with "Expires at" set → `proExpiresAt` recorded (nightly cron expires it)
4. For a `POLAR_PURCHASE` user → toggle disabled with the refund hint

Refs #351

---

## Glossary
| Term | Definition |
|------|------------|
| Action selector | UI where a control picks which operation a submit button will run, vs. a toggle that directly represents and changes state |
| `proSource` | Which path unlocked Pro: `POLAR_PURCHASE`, `POINTS_THRESHOLD`, or `ADMIN_GRANT` |
| Polar lock | Server rule (409 `POLAR_PRO_LOCKED`): Polar-purchased Pro can only be reversed by a refund in Polar, never by admin revoke |
| TypeBox model | Elysia's server-side request validation schema (`admin.users.proGrant`) — the real contract now that the client-side Zod schema is gone |
