### PR TITLE
fix(deploy): retry connection-refused production smoke checks during rollout

### DIFF
--- a/scripts/smoke-prod.ts
+++ b/scripts/smoke-prod.ts
@@ -18,14 +18,26 @@ const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const checkFetch = async (path: string, init?: RequestInit) => {
 	for (let attempt = 1; attempt <= SMOKE_ATTEMPTS; attempt++) {
-		const res = await fetch(`${baseUrl}${path}`, init)
-		if (res.ok) return res
-		if (!TRANSIENT_STATUSES.has(res.status) || attempt === SMOKE_ATTEMPTS) {
-			throw new Error(`${path} returned ${res.status}`)
+		try {
+			const res = await fetch(`${baseUrl}${path}`, init)
+			if (res.ok) return res
+			if (!TRANSIENT_STATUSES.has(res.status) || attempt === SMOKE_ATTEMPTS) {
+				throw new Error(`${path} returned ${res.status}`)
+			}
+			console.warn(
+				`${path} returned ${res.status}; retrying (${attempt}/${SMOKE_ATTEMPTS})`
+			)
+		} catch (error) {
+			// A decided HTTP failure is terminal; surface it immediately.
+			if (error instanceof Error && error.message.startsWith(`${path} returned `)) {
+				throw error
+			}
+			// Connection-level failures (ConnectionRefused, DNS, TLS, timeout) are
+			// expected while Coolify swaps containers during a rollout — the new
+			// container may not accept connections yet. Retry them like transient statuses.
+			if (attempt === SMOKE_ATTEMPTS) throw error
+			console.warn(`${path} connection failed; retrying (${attempt}/${SMOKE_ATTEMPTS})`)
 		}
-		console.warn(
-			`${path} returned ${res.status}; retrying (${attempt}/${SMOKE_ATTEMPTS})`
-		)
 		await wait(SMOKE_RETRY_MS)
 	}
 	throw new Error(`${path} exhausted retries`)


### PR DESCRIPTION
## What

Make the production smoke check (\`scripts/smoke-prod.ts\`) retry **connection-level** failures during a Coolify rollout, not just transient HTTP status codes.

## Why

On the last \`main\` deploy ([run 29514944386](https://github.com/husamql3/pstrack/actions/runs/29514944386)) the **deploy succeeded** but the \`Run production smoke checks\` step failed with:

\`\`\`
error: Unable to connect. Is the computer able to access the url?
  path: "https://pstrack.app/", code: "ConnectionRefused"
\`\`\`

Production was healthy on the exact deployed commit (\`/api/v3/health\` returned the matching \`gitSha\`/\`imageDigest\`). The smoke check just raced the rollout: it ran ~25s after the container came up, in the window where Coolify was still swapping containers / the proxy hadn't rerouted, and got a connection refusal on its **first** request.

\`checkFetch\` had a 15× retry loop, but it only retried transient HTTP **status codes**. A connection-level error (\`ConnectionRefused\`, DNS, TLS, timeout) throws straight out of \`await fetch(...)\` and escaped the loop with **zero retries** — precisely the failure mode most likely during a rollout. This was the gap left by \`69a061a "retry production smoke checks during rollout"\`.

## How

Wrap the \`fetch\` in try/catch inside the existing retry loop so connection-level failures retry like transient statuses (15 × 2s ≈ 30s window). A decided HTTP failure still surfaces immediately. This mirrors what the sibling helpers already do — \`coolifyFetch\` in \`deploy-coolify.ts\` and the unit-tested \`fetchWhenReady\` in \`smoke-http.ts\` (which staging smoke already uses).

## Notes

- Scoped to one file; kept prod's existing transient-status list and timing (prod intentionally retries 408/425/429), rather than swapping wholesale to \`fetchWhenReady\`.
- Per \`docs/BRANCHING.md\` this targets \`stage\`; it reaches production via the deliberate \`stage → main\` promotion PR.