### PR TITLE
fix(problems): solve/verify against the correct group for multi-group users

### DIFF
--- a/src/features/dashboard/components/dashboard-page.tsx
+++ b/src/features/dashboard/components/dashboard-page.tsx
@@ -1,6 +1,18 @@
-import { IconInfoCircle, IconMedal } from "@tabler/icons-react"
+import { IconInfoCircle, IconMedal, IconPlayerPause } from "@tabler/icons-react"
 import { Link } from "@tanstack/react-router"
+import { sileo } from "sileo"
 
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
@@ -12,10 +24,13 @@ import {
 import { useUserBadges } from "@/features/badges/hooks/use-user-badges"
 import { cn } from "@/lib/utils"
 import { BADGE_CATEGORY, BADGE_LABELS } from "@/server/badges/badges.type"
+import type { TodayProblemResponse } from "@/server/problems/problems.type"
 import { useGroupTodayActivity } from "../hooks/use-group-activity"
-import { useTodayProblem } from "../hooks/use-today-problem"
+import { usePauseToday, useTodayProblems } from "../hooks/use-today-problem"
 import { GroupActivityCard } from "./group-activity-card"
 import { TodayProblemCard } from "./today-problem-card"
+
+type ReadyToday = Extract<TodayProblemResponse, { state: "READY" }>
 
 const CATEGORY_DOT: Record<string, string> = {
 	streak: "bg-amber-400",
@@ -23,12 +38,12 @@ const CATEGORY_DOT: Record<string, string> = {
 	social: "bg-purple-400",
 }
 
+const errorDescription = (err: unknown) =>
+	err instanceof Error ? err.message : "Please try again."
+
 export const DashboardPage = () => {
-	const todayQuery = useTodayProblem()
+	const todayQuery = useTodayProblems()
 	const badgesQuery = useUserBadges()
-	const groupId =
-		todayQuery.data?.state === "READY" ? todayQuery.data.group.id : undefined
-	const activityQuery = useGroupTodayActivity(groupId)
 
 	if (todayQuery.isLoading) {
 		return (
@@ -48,9 +63,9 @@ export const DashboardPage = () => {
 		)
 	}
 
-	const today = todayQuery.data
+	const todays = todayQuery.data
 
-	if (today.state === "NO_GROUP") {
+	if (todays.length === 0) {
 		return (
 			<div className="flex flex-col gap-6">
 				<DashboardHeader />
@@ -67,88 +82,49 @@ export const DashboardPage = () => {
 		)
 	}
 
-	if (today.state === "NO_PROBLEMS") {
-		return (
-			<div className="flex flex-col gap-6">
-				<DashboardHeader />
-				<section className="rounded-lg border border-border bg-background p-6">
-					<p className="font-medium text-sm">No problems have been seeded yet.</p>
-					<p className="mt-1 text-muted-foreground text-sm">
-						An admin needs to seed the roadmap before daily assignments can begin.
-					</p>
-				</section>
-			</div>
-		)
-	}
-
-	if (today.state === "NOT_STARTED") {
-		return (
-			<div className="flex flex-col gap-6">
-				<DashboardHeader />
-				<section className="rounded-lg border border-border bg-background p-6">
-					<p className="font-medium text-sm">Your group has not started yet.</p>
-					<p className="mt-1 max-w-xl text-muted-foreground text-sm">
-						{today.group.slug} is open for members, but daily problems begin after a
-						platform admin starts it and the next midnight UTC assignment runs.
-					</p>
-				</section>
-			</div>
-		)
-	}
+	// Pauses and streak/points are user-level — identical across every entry.
+	const { pausesRemaining, pausesTotal, userStats } = todays[0]
 
 	return (
 		<div className="flex flex-col gap-6">
 			<DashboardHeader />
+
 			<TooltipProvider delayDuration={200}>
-				<section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+				<section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
 					<StatCard
 						label="Current Streak"
-						value={`${today.userStats.currentStreak}d`}
+						value={`${userStats.currentStreak}d`}
 						subtitle={
-							today.userStats.currentStreak > 0 &&
-							today.userStats.currentStreak === today.userStats.longestStreak
+							userStats.currentStreak > 0 &&
+							userStats.currentStreak === userStats.longestStreak
 								? "Personal best"
-								: `Best: ${today.userStats.longestStreak}d`
+								: `Best: ${userStats.longestStreak}d`
 						}
 						highlight={
-							today.userStats.currentStreak > 0 &&
-							today.userStats.currentStreak === today.userStats.longestStreak
+							userStats.currentStreak > 0 &&
+							userStats.currentStreak === userStats.longestStreak
 						}
-						tooltip="Consecutive days you’ve solved. Misses reset it; pauses keep it alive."
+						tooltip="Consecutive days you solved at least one problem. A full no-show resets it; a pause keeps it alive."
 					/>
 					<StatCard
 						label="Total Points"
-						value={today.userStats.totalPoints.toLocaleString()}
-						subtitle="+10 today if solved"
-						tooltip="+10 per solve, +5 if first in group, −3 on miss."
+						value={userStats.totalPoints.toLocaleString()}
+						subtitle="Across all your groups"
+						tooltip="Points from solves, bonuses, and penalties across every group you're in."
 					/>
 					<StatCard
 						label="Pauses Left"
-						value={`${today.pausesRemaining}/${today.pausesTotal}`}
+						value={`${pausesRemaining}/${pausesTotal}`}
 						subtitle="this month"
-						tooltip="Skip a day without losing your streak or points. Resets monthly."
-					/>
-					<StatCard
-						label="Group Rank"
-						value={`#${today.groupRank}`}
-						subtitle={`of ${today.groupSize}`}
-						tooltip="Your position in this group, sorted by total points."
+						tooltip="Skip a whole day — across all your groups — without losing your streak. Resets monthly."
 					/>
 				</section>
 			</TooltipProvider>
 
-			<section className="grid gap-3 lg:grid-cols-3">
-				<div className="lg:col-span-2">
-					<TodayProblemCard today={today} />
-				</div>
-				<div className="lg:col-span-1">
-					<GroupActivityCard
-						groupId={today.group.id}
-						groupSlug={today.group.slug}
-						events={activityQuery.data?.events ?? []}
-						isLoading={activityQuery.isLoading}
-					/>
-				</div>
+			<section className="flex flex-col gap-3">
+				{todays.map((today, index) => (
+					<GroupTodaySection key={today.group?.id ?? `entry-${index}`} today={today} />
+				))}
 			</section>
 
 			<BadgesShelf
@@ -159,11 +135,116 @@ export const DashboardPage = () => {
 	)
 }
 
-const DashboardHeader = () => (
-	<div className="space-y-1">
-		<h1 className="font-semibold text-2xl tracking-tight">Dashboard</h1>
-	</div>
-)
+// One dashboard row per group. READY groups get the problem card + activity feed;
+// not-yet-started / unseeded groups get a compact notice.
+const GroupTodaySection = ({ today }: { today: TodayProblemResponse }) => {
+	if (today.state === "NOT_STARTED") {
+		return (
+			<section className="rounded-lg border border-border bg-background p-6">
+				<p className="font-medium text-sm">{today.group.slug} hasn't started yet.</p>
+				<p className="mt-1 max-w-xl text-muted-foreground text-sm">
+					Daily problems begin after an admin starts the group and the next midnight UTC
+					assignment runs.
+				</p>
+			</section>
+		)
+	}
+
+	if (today.state === "NO_PROBLEMS" || today.state === "NO_GROUP") {
+		return (
+			<section className="rounded-lg border border-border bg-background p-6">
+				<p className="font-medium text-sm">No problems available for this group.</p>
+				<p className="mt-1 text-muted-foreground text-sm">
+					An admin needs to seed the roadmap before daily assignments can begin.
+				</p>
+			</section>
+		)
+	}
+
+	return <ReadyGroupRow today={today} />
+}
+
+const ReadyGroupRow = ({ today }: { today: ReadyToday }) => {
+	const activityQuery = useGroupTodayActivity(today.group.id)
+
+	return (
+		<div className="grid gap-3 lg:grid-cols-3">
+			<div className="lg:col-span-2">
+				<TodayProblemCard today={today} />
+			</div>
+			<div className="lg:col-span-1">
+				<GroupActivityCard
+					groupId={today.group.id}
+					groupSlug={today.group.slug}
+					events={activityQuery.data?.events ?? []}
+					isLoading={activityQuery.isLoading}
+				/>
+			</div>
+		</div>
+	)
+}
+
+const DashboardHeader = () => {
+	const todayQuery = useTodayProblems()
+	const pauseMutation = usePauseToday()
+
+	const todays = todayQuery.data ?? []
+	const pausesRemaining = todays[0]?.pausesRemaining ?? 0
+	const solvedAny = todays.some(
+		(t) => t.state === "READY" && t.solve?.status === "SOLVED"
+	)
+	const pausableExists = todays.some((t) => t.state === "READY" && t.solve == null)
+	const canPause =
+		todays.length > 0 &&
+		pausesRemaining > 0 &&
+		!solvedAny &&
+		pausableExists &&
+		!pauseMutation.isPending
+
+	const confirmPause = async () => {
+		await sileo.promise(pauseMutation.mutateAsync(), {
+			loading: { title: "Pausing today..." },
+			success: { title: "Today is paused" },
+			error: (err: unknown) => ({
+				title: "Could not pause",
+				description: errorDescription(err),
+			}),
+		})
+	}
+
+	return (
+		<div className="flex items-center justify-between gap-4">
+			<h1 className="font-semibold text-2xl tracking-tight">Dashboard</h1>
+			{todays.length > 0 && (
+				<AlertDialog>
+					<AlertDialogTrigger asChild>
+						<Button disabled={!canPause} variant="outline" size="sm">
+							<IconPlayerPause />
+							Pause today ({pausesRemaining} left)
+						</Button>
+					</AlertDialogTrigger>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>Pause today?</AlertDialogTitle>
+							<AlertDialogDescription>
+								Pausing costs <strong>-5 points</strong> but preserves your streak and
+								skips <strong>every</strong> group's problem for today. You have{" "}
+								{pausesRemaining} {pausesRemaining === 1 ? "pause" : "pauses"} remaining
+								this month.
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel>Cancel</AlertDialogCancel>
+							<AlertDialogAction onClick={confirmPause}>
+								Pause and lose 5 points
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			)}
+		</div>
+	)
+}
 
 const StatCard = ({
 	label,

--- a/src/features/dashboard/components/today-problem-card.tsx
+++ b/src/features/dashboard/components/today-problem-card.tsx
@@ -1,22 +1,6 @@
-import {
-	IconCircleCheck,
-	IconExternalLink,
-	IconFlame,
-	IconPlayerPause,
-} from "@tabler/icons-react"
+import { IconCircleCheck, IconExternalLink, IconFlame } from "@tabler/icons-react"
 import { sileo } from "sileo"
 
-import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-	AlertDialogTrigger,
-} from "@/components/ui/alert-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -28,7 +12,7 @@ import {
 } from "@/features/problems/constants"
 import { cn } from "@/lib/utils"
 import type { TodayProblemResponse } from "@/server/problems/problems.type"
-import { useMarkTodaySolved, usePauseToday } from "../hooks/use-today-problem"
+import { useMarkTodaySolved } from "../hooks/use-today-problem"
 
 type ReadyToday = Extract<TodayProblemResponse, { state: "READY" }>
 
@@ -57,34 +41,20 @@ const errorDescription = (err: unknown) =>
 
 export const TodayProblemCard = ({ today }: { today: ReadyToday }) => {
 	const solveMutation = useMarkTodaySolved()
-	const pauseMutation = usePauseToday()
 
 	const problem = today.dailyProblem.problem
 	const solveStatus = today.solve?.status
 	const isSolved = solveStatus === "SOLVED"
+	const isPaused = solveStatus === "PAUSED"
 	const isLocked =
-		solveMutation.isPending ||
-		pauseMutation.isPending ||
-		solveStatus === "SOLVED" ||
-		solveStatus === "PAUSED"
+		solveMutation.isPending || solveStatus === "SOLVED" || solveStatus === "PAUSED"
 
 	const markSolved = async () => {
-		await sileo.promise(solveMutation.mutateAsync(), {
+		await sileo.promise(solveMutation.mutateAsync(today.group.id), {
 			loading: { title: "Validating on LeetCode..." },
-			success: { title: "Solved! +10 pts" },
+			success: { title: `Solved! +${DIFFICULTY_POINTS[problem.difficulty]} pts` },
 			error: (err: unknown) => ({
 				title: "Could not verify",
-				description: errorDescription(err),
-			}),
-		})
-	}
-
-	const confirmPause = async () => {
-		await sileo.promise(pauseMutation.mutateAsync(), {
-			loading: { title: "Pausing today..." },
-			success: { title: "Today is paused" },
-			error: (err: unknown) => ({
-				title: "Could not pause",
 				description: errorDescription(err),
 			}),
 		})
@@ -99,7 +69,7 @@ export const TodayProblemCard = ({ today }: { today: ReadyToday }) => {
 						<span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75" />
 						<span className="relative inline-flex size-2 rounded-full bg-primary" />
 					</span>
-					<span className="font-medium text-sm">Today's problem</span>
+					<span className="font-medium text-sm">{today.group.slug}</span>
 					<span className="text-muted-foreground text-sm">· {computeTimeLeft()}</span>
 				</div>
 				<span className="text-muted-foreground text-sm">#{problem.roadmapIndex}</span>
@@ -133,32 +103,8 @@ export const TodayProblemCard = ({ today }: { today: ReadyToday }) => {
 				<div className="flex flex-wrap items-center gap-2">
 					<Button disabled={isLocked} onClick={markSolved}>
 						<IconCircleCheck />
-						Mark as Solved
+						{isPaused ? "Paused today" : isSolved ? "Solved" : "Mark as Solved"}
 					</Button>
-					<AlertDialog>
-						<AlertDialogTrigger asChild>
-							<Button disabled={isLocked || today.pausesRemaining <= 0} variant="outline">
-								<IconPlayerPause />
-								Pause today ({today.pausesRemaining} left)
-							</Button>
-						</AlertDialogTrigger>
-						<AlertDialogContent>
-							<AlertDialogHeader>
-								<AlertDialogTitle>Pause today?</AlertDialogTitle>
-								<AlertDialogDescription>
-									Pausing costs <strong>-5 points</strong> but preserves your streak. You
-									have {today.pausesRemaining}{" "}
-									{today.pausesRemaining === 1 ? "pause" : "pauses"} remaining this month.
-								</AlertDialogDescription>
-							</AlertDialogHeader>
-							<AlertDialogFooter>
-								<AlertDialogCancel>Cancel</AlertDialogCancel>
-								<AlertDialogAction onClick={confirmPause}>
-									Pause and lose 5 points
-								</AlertDialogAction>
-							</AlertDialogFooter>
-						</AlertDialogContent>
-					</AlertDialog>
 					<Button asChild variant="outline">
 						<a
 							href={`https://leetcode.com/problems/${problem.slug}/`}

--- a/src/features/dashboard/hooks/use-today-problem.ts
+++ b/src/features/dashboard/hooks/use-today-problem.ts
@@ -7,12 +7,14 @@ import type { TodayProblemResponse } from "@/server/problems/problems.type"
 
 const todayProblemQueryKey = ["problems", "today"] as const
 
-export const useTodayProblem = ({ enabled = true }: { enabled?: boolean } = {}) =>
-	useQuery<TodayProblemResponse>({
+// One "today" entry per active group. Free users (≤1 group) get an array of length
+// ≤1; Pro users in multiple groups get one entry per group.
+export const useTodayProblems = ({ enabled = true }: { enabled?: boolean } = {}) =>
+	useQuery<TodayProblemResponse[]>({
 		queryKey: todayProblemQueryKey,
 		queryFn: async () => {
 			const { data, error } = await api.v3.problems.today.get()
-			if (error) throw new Error("Failed to load today's problem")
+			if (error) throw new Error("Failed to load today's problems")
 			return data
 		},
 		staleTime: 1000 * 60,
@@ -23,8 +25,8 @@ export const useMarkTodaySolved = () => {
 	const queryClient = useQueryClient()
 
 	return useMutation({
-		mutationFn: async () => {
-			const { data, error } = await api.v3.problems.today.solve.post()
+		mutationFn: async (groupId: string) => {
+			const { data, error } = await api.v3.problems.today.solve.post({ groupId })
 			if (error) throw new Error("Could not mark today's problem solved")
 			return data
 		},
@@ -32,6 +34,7 @@ export const useMarkTodaySolved = () => {
 			queryClient.invalidateQueries({ queryKey: todayProblemQueryKey })
 			queryClient.invalidateQueries({ queryKey: ["problems", "roadmap"] })
 			queryClient.invalidateQueries({ queryKey: userBadgesQueryKey })
+			queryClient.invalidateQueries({ queryKey: ["leaderboard"] })
 			authClient.getSession({ fetchOptions: { cache: "no-cache" } })
 		},
 	})

--- a/src/features/groups/hooks/use-group-problems.ts
+++ b/src/features/groups/hooks/use-group-problems.ts
@@ -107,8 +107,15 @@ export const useMarkTodaySolvedFromTable = (
 	const queryClient = useQueryClient()
 	return useMutation<SolveResult>({
 		mutationFn: async () => {
-			const { data, error } = await api.v3.problems.today.solve.post()
-			if (error) throw new Error(error.value?.error ?? "Could not verify solve")
+			const { data, error } = await api.v3.problems.today.solve.post({ groupId })
+			if (error) {
+				const value = error.value
+				const message =
+					value && typeof value === "object" && "error" in value
+						? String(value.error)
+						: "Could not verify solve"
+				throw new Error(message)
+			}
 			return data as SolveResult
 		},
 		onSuccess: () => {
@@ -116,6 +123,7 @@ export const useMarkTodaySolvedFromTable = (
 				queryKey: groupProblemsQueryKey(groupId, range),
 			})
 			queryClient.invalidateQueries({ queryKey: ["problems", "today"] })
+			queryClient.invalidateQueries({ queryKey: ["leaderboard"] })
 		},
 	})
 }

--- a/src/routes/problems.tsx
+++ b/src/routes/problems.tsx
@@ -4,7 +4,7 @@ import { z } from "zod"
 
 import { AppHeader } from "@/components/app-header"
 import { RouteErrorFallback } from "@/components/route-error-fallback"
-import { useTodayProblem } from "@/features/dashboard/hooks/use-today-problem"
+import { useTodayProblems } from "@/features/dashboard/hooks/use-today-problem"
 import { FilterRow } from "@/features/problems/components/filter-row"
 import { ProblemList } from "@/features/problems/components/problem-list"
 import { ProgressDisplay } from "@/features/problems/components/progress-display"
@@ -66,8 +66,10 @@ function ProblemsPage() {
 	const { data: session } = useSession()
 	const isLoggedIn = !!session?.user
 
-	const { data: today } = useTodayProblem({ enabled: isLoggedIn })
-	const groupRoadmap = today?.state === "READY" ? today.groupRoadmap : undefined
+	const { data: todays } = useTodayProblems({ enabled: isLoggedIn })
+	// Default the roadmap tab to the user's first (primary) started group's roadmap.
+	const readyToday = todays?.find((t) => t.state === "READY")
+	const groupRoadmap = readyToday?.state === "READY" ? readyToday.groupRoadmap : undefined
 
 	useEffect(() => {
 		if (!roadmapParam && groupRoadmap && groupRoadmap !== DEFAULT_ROADMAP_KEY) {

--- a/src/server/points/points.dao.ts
+++ b/src/server/points/points.dao.ts
@@ -219,6 +219,45 @@ export const pointsDao = {
 		})
 	},
 
+	// Per-group miss penalty: the −3 only. Used by the multi-group mark-missed path,
+	// where the streak is broken at most once per user (see breakUserStreak) rather
+	// than per missed group.
+	applyMissPoints: async (
+		tx: Tx,
+		userId: string,
+		opts: { userSolveId?: string; groupId?: string }
+	): Promise<void> => {
+		await pointsDao.applyPointsDelta(userId, -MISSED_PENALTY, PointReason.MISSED_DAY, {
+			tx,
+			userSolveId: opts.userSolveId,
+			groupId: opts.groupId,
+		})
+	},
+
+	// Break a user's streak once: claw back streak-scoped bonuses accrued since the
+	// streak started, then reset the streak. Called at most once per user per day.
+	breakUserStreak: async (
+		tx: Tx,
+		userId: string,
+		streakStartedAt: Date | null
+	): Promise<void> => {
+		if (streakStartedAt) {
+			const bonusSum = await pointsDao.sumBonusesSinceStreakStart(
+				tx,
+				userId,
+				streakStartedAt
+			)
+			if (bonusSum > 0) {
+				await pointsDao.applyPointsDelta(userId, -bonusSum, PointReason.CLAWBACK, { tx })
+			}
+		}
+
+		await tx.user.update({
+			where: { id: userId },
+			data: { currentStreak: 0, currentStreakStartedAt: null },
+		})
+	},
+
 	hasEverJoinedGroup: async (
 		tx: Tx,
 		userId: string,

--- a/src/server/problems/problems.controller.ts
+++ b/src/server/problems/problems.controller.ts
@@ -18,7 +18,7 @@ export const problemsController = new Elysia({ tags: ["Problems"] })
 		const { user, response } = await requireSessionUser(request)
 		if (!user) return response
 
-		return problemsDao.getTodayForUser(user.id)
+		return problemsDao.listTodayForUser(user.id)
 	})
 	.get(
 		"/problems/roadmap",
@@ -28,91 +28,99 @@ export const problemsController = new Elysia({ tags: ["Problems"] })
 		},
 		{ query: "problems.roadmapQuery" }
 	)
-	.post("/problems/today/solve", async ({ request }) => {
-		const { user, response } = await requireRealSession(request)
-		if (!user) return response
+	.post(
+		"/problems/today/solve",
+		async ({ request, body }) => {
+			const { user, response } = await requireRealSession(request)
+			if (!user) return response
 
-		const sessionId = request.headers.get("x-session-id")
-		axiomLog("solve_attempted", { userId: user.id, sessionId })
+			const sessionId = request.headers.get("x-session-id")
+			axiomLog("solve_attempted", { userId: user.id, sessionId, groupId: body.groupId })
 
-		const result = await problemsDao.verifyAndMarkSolved(user.id)
-		if (result.error === "NO_GROUP") return status(409, { error: "Join a group first." })
-		if (result.error === "NO_PROBLEMS")
-			return status(409, { error: "Seed problems before solving." })
-		if (result.error === "PAUSED")
-			return status(409, { error: "Today is already paused." })
-		if (result.error === "PREMIUM_SKIPPED") {
-			return status(409, {
-				error: "Premium problems are skipped until PStrack Judge is available.",
-			})
-		}
-		if (result.error === "NOT_VERIFIED") {
-			axiomLog("verification_failed", {
+			const result = await problemsDao.verifyAndMarkSolved(user.id, body.groupId)
+			if (result.error === "NO_GROUP")
+				return status(409, { error: "Join a group first." })
+			if (result.error === "NO_PROBLEMS")
+				return status(409, { error: "Seed problems before solving." })
+			if (result.error === "PAUSED")
+				return status(409, { error: "Today is already paused." })
+			if (result.error === "PREMIUM_SKIPPED") {
+				return status(409, {
+					error: "Premium problems are skipped until PStrack Judge is available.",
+				})
+			}
+			if (result.error === "NOT_VERIFIED") {
+				axiomLog("verification_failed", {
+					userId: user.id,
+					sessionId,
+					reason: "NOT_VERIFIED",
+				})
+				return status(409, {
+					error: "No accepted submission found on LeetCode for today's problem.",
+				})
+			}
+			if (result.error !== null) return result.today
+
+			axiomLog("verification_succeeded", {
 				userId: user.id,
 				sessionId,
-				reason: "NOT_VERIFIED",
-			})
-			return status(409, {
-				error: "No accepted submission found on LeetCode for today's problem.",
-			})
-		}
-		if (result.error !== null) return result.today
-
-		axiomLog("verification_succeeded", {
-			userId: user.id,
-			sessionId,
-			newStreak: result.newStreak,
-			crossedProThreshold: result.crossedProThreshold,
-			newBadges: result.newBadges,
-		})
-
-		systemEventsDao
-			.log({
-				actorId: user.id,
-				actorUsername: user.username ?? undefined,
-				actorName: user.name,
-				eventType: SystemEventType.SOLVE_VERIFIED,
-				targetType: SystemEventTargetType.USER,
-				targetId: user.id,
-				metadata: { newStreak: result.newStreak },
-			})
-			.catch(() => {})
-
-		problemNotifications
-			.sendSolveAchievementEmails(user.id, user.email, user.name, {
+				newStreak: result.newStreak,
 				crossedProThreshold: result.crossedProThreshold,
 				newBadges: result.newBadges,
-				newStreak: result.newStreak,
 			})
-			.catch(() => {})
 
-		return { today: result.today, newBadges: result.newBadges }
-	})
+			systemEventsDao
+				.log({
+					actorId: user.id,
+					actorUsername: user.username ?? undefined,
+					actorName: user.name,
+					eventType: SystemEventType.SOLVE_VERIFIED,
+					targetType: SystemEventTargetType.USER,
+					targetId: user.id,
+					metadata: { newStreak: result.newStreak },
+				})
+				.catch(() => {})
+
+			problemNotifications
+				.sendSolveAchievementEmails(user.id, user.email, user.name, {
+					crossedProThreshold: result.crossedProThreshold,
+					newBadges: result.newBadges,
+					newStreak: result.newStreak,
+				})
+				.catch(() => {})
+
+			return { today: result.today, newBadges: result.newBadges }
+		},
+		{ body: "problems.solveBody" }
+	)
 	.post("/problems/today/pause", async ({ request }) => {
 		const { user, response } = await requireRealSession(request)
 		if (!user) return response
 
 		const result = await problemsDao.pauseToday(user.id)
 		if (result.error === "NO_GROUP") return status(409, { error: "Join a group first." })
-		if (result.error === "NO_PROBLEMS") {
-			return status(409, { error: "Seed problems before pausing." })
-		}
 		if (result.error === "NO_PAUSES") {
 			return status(403, { error: "You have no pauses remaining this month." })
 		}
 		if (result.error === "ALREADY_STARTED") {
-			return status(409, { error: "You already started today's problem." })
+			return status(409, { error: "You already solved a problem today." })
+		}
+		// NOTHING_TO_PAUSE is benign (already paused / nothing open) — return the list.
+		if (result.error !== null && result.error !== "NOTHING_TO_PAUSE") {
+			return result.todays
 		}
 
-		systemEventsDao
-			.log({
-				actorId: user.id,
-				actorUsername: user.username ?? undefined,
-				actorName: user.name,
-				eventType: SystemEventType.PAUSE_USED,
-				targetType: SystemEventTargetType.USER,
-				targetId: user.id,
-			})
-			.catch(() => {})
-		return result.today
+		if (result.error === null) {
+			systemEventsDao
+				.log({
+					actorId: user.id,
+					actorUsername: user.username ?? undefined,
+					actorName: user.name,
+					eventType: SystemEventType.PAUSE_USED,
+					targetType: SystemEventTargetType.USER,
+					targetId: user.id,
+				})
+				.catch(() => {})
+		}
+		return result.todays
 	})

--- a/src/server/problems/problems.dao.test.ts
+++ b/src/server/problems/problems.dao.test.ts
@@ -46,7 +46,12 @@ vi.mock("@/server/lib/db", () => ({
 		groupMemberWarning: { create: vi.fn(), findFirst: vi.fn() },
 		problem: { count: vi.fn(), findFirst: vi.fn(), findMany: vi.fn() },
 		user: { findMany: vi.fn(), findUniqueOrThrow: vi.fn() },
-		userSolve: { count: vi.fn(), findMany: vi.fn(), findUnique: vi.fn() },
+		userSolve: {
+			count: vi.fn(),
+			findMany: vi.fn(),
+			findUnique: vi.fn(),
+			findFirst: vi.fn(),
+		},
 	},
 }))
 
@@ -274,6 +279,7 @@ describe("problemsDao", () => {
 				}))
 			)
 			pointsDao.hasEverMissed.mockResolvedValue(false)
+			db.userSolve.findFirst.mockResolvedValue(null) // no other group solved today
 			tx.userSolve.findUnique.mockResolvedValue(null) // not already solved
 			tx.userSolve.upsert.mockResolvedValue({ id: "solve-1" })
 			tx.dailyProblem.updateMany.mockResolvedValue({ count: 1 }) // winner of first-solver claim
@@ -284,7 +290,7 @@ describe("problemsDao", () => {
 			tx.groupMember.findUnique.mockResolvedValue({ id: "member-1" })
 			badgesDao.evaluateAndAward.mockResolvedValue([BadgeType.SOLVED_1])
 
-			const result = await problemsDao.verifyAndMarkSolved("user-1")
+			const result = await problemsDao.verifyAndMarkSolved("user-1", "group-1")
 
 			expect(result).toEqual({
 				error: null,
@@ -367,7 +373,7 @@ describe("problemsDao", () => {
 			vi.spyOn(problemsDao, "getTodayForUser").mockResolvedValue(premiumToday)
 			vi.stubGlobal("fetch", vi.fn())
 
-			const result = await problemsDao.verifyAndMarkSolved("user-1")
+			const result = await problemsDao.verifyAndMarkSolved("user-1", "group-1")
 
 			expect(result).toEqual({ error: "PREMIUM_SKIPPED", today: premiumToday })
 			expect(fetch).not.toHaveBeenCalled()
@@ -394,7 +400,7 @@ describe("problemsDao", () => {
 				}))
 			)
 
-			const result = await problemsDao.verifyAndMarkSolved("user-1")
+			const result = await problemsDao.verifyAndMarkSolved("user-1", "group-1")
 
 			expect(result).toEqual({ error: "NOT_VERIFIED", today: readyToday })
 			expect(tx.user.update).toHaveBeenCalledWith({
@@ -429,7 +435,7 @@ describe("problemsDao", () => {
 				}))
 			)
 
-			const result = await problemsDao.verifyAndMarkSolved("user-1")
+			const result = await problemsDao.verifyAndMarkSolved("user-1", "group-1")
 
 			expect(result).toEqual({ error: "NOT_VERIFIED", today: readyToday })
 			expect(tx.user.update).toHaveBeenCalledWith({
@@ -476,6 +482,7 @@ describe("problemsDao", () => {
 				}))
 			)
 			pointsDao.hasEverMissed.mockResolvedValue(false)
+			db.userSolve.findFirst.mockResolvedValue(null) // no other group solved today
 			tx.userSolve.findUnique.mockResolvedValue(null) // not already solved
 			tx.userSolve.upsert.mockResolvedValue({ id: "solve-1" })
 			tx.dailyProblem.updateMany.mockResolvedValue({ count: 0 }) // loser — someone else already claimed
@@ -486,7 +493,7 @@ describe("problemsDao", () => {
 			tx.groupMember.findUnique.mockResolvedValue({ id: "member-1" })
 			badgesDao.evaluateAndAward.mockResolvedValue([])
 
-			await problemsDao.verifyAndMarkSolved("user-1")
+			await problemsDao.verifyAndMarkSolved("user-1", "group-1")
 
 			// FIRST_IN_GROUP must NOT be awarded when the atomic claim returns count=0
 			const firstInGroupCall = (
@@ -537,10 +544,11 @@ describe("problemsDao", () => {
 				}))
 			)
 			pointsDao.hasEverMissed.mockResolvedValue(false)
+			db.userSolve.findFirst.mockResolvedValue(null) // no other group solved today
 			// in-transaction re-check finds the solve already SOLVED → short-circuit
 			tx.userSolve.findUnique.mockResolvedValue({ status: SolveStatus.SOLVED })
 
-			await problemsDao.verifyAndMarkSolved("user-1")
+			await problemsDao.verifyAndMarkSolved("user-1", "group-1")
 
 			// upsert must not be called — the transaction bails early
 			expect(tx.userSolve.upsert).not.toHaveBeenCalled()
@@ -551,10 +559,7 @@ describe("problemsDao", () => {
 
 	describe("pauseToday", () => {
 		it("returns NO_PAUSES without writing when the user has no pauses remaining", async () => {
-			vi.spyOn(problemsDao, "getTodayForUser").mockResolvedValue({
-				...readyToday,
-				pausesRemaining: 0,
-			})
+			vi.spyOn(problemsDao, "listTodayForUser").mockResolvedValue([{ ...readyToday }])
 			db.user.findUniqueOrThrow.mockResolvedValue({
 				isPro: false,
 				pausesUsedThisMonth: 2,
@@ -570,15 +575,15 @@ describe("problemsDao", () => {
 			expect(pointsDao.applyPointsDelta).not.toHaveBeenCalled()
 		})
 
-		it("records a pause, consumes the monthly pause, applies the pause penalty, and resolves warnings", async () => {
+		it("pauses every open group for one flat penalty, consumes a pause, and resolves warnings", async () => {
 			const updatedToday = {
 				...readyToday,
 				solve: { id: "solve-1", status: SolveStatus.PAUSED },
 				pausesRemaining: 0,
 			}
-			vi.spyOn(problemsDao, "getTodayForUser")
-				.mockResolvedValueOnce(readyToday)
-				.mockResolvedValueOnce(updatedToday)
+			vi.spyOn(problemsDao, "listTodayForUser")
+				.mockResolvedValueOnce([{ ...readyToday }])
+				.mockResolvedValueOnce([updatedToday])
 			db.user.findUniqueOrThrow.mockResolvedValue({
 				isPro: false,
 				pausesUsedThisMonth: 1,
@@ -591,7 +596,7 @@ describe("problemsDao", () => {
 
 			const result = await problemsDao.pauseToday("user-1")
 
-			expect(result).toEqual({ error: null, today: updatedToday })
+			expect(result).toEqual({ error: null, todays: [updatedToday] })
 			expect(tx.userSolve.upsert).toHaveBeenCalledWith({
 				where: {
 					userId_dailyProblemId: {

--- a/src/server/problems/problems.dao.ts
+++ b/src/server/problems/problems.dao.ts
@@ -87,6 +87,12 @@ const pauseLimitFor = (user: { isPro: boolean }) => (user.isPro ? 4 : 2)
 const INACTIVITY_WARNING_MISSES = 5
 const BATCH_SIZE = 25
 
+// Multi-group daily solving (per-group problems for users in >1 group) went live on
+// this date. mark-missed only evaluates non-primary groups for days on/after the
+// cutover — its 14-day catch-up must never retroactively mark MISSED for groups the
+// pre-multi-group code silently ignored. Set to the production deploy date.
+const MULTI_GROUP_CUTOVER_DATE = new Date("2026-07-17T00:00:00.000Z")
+
 const dailyProblemFullSelect = {
 	id: true,
 	assignedDate: true,
@@ -212,20 +218,46 @@ const ensureDailyProblem = async (groupId: string, assignedDate: Date) => {
 	}
 }
 
+const membershipGroupSelect = {
+	group: {
+		select: {
+			id: true,
+			slug: true,
+			roadmap: true,
+			isStarted: true,
+		},
+	},
+} satisfies Prisma.GroupMemberSelect
+
+type MembershipGroup = Prisma.GroupMemberGetPayload<{
+	select: typeof membershipGroupSelect
+}>["group"]
+
 const findPrimaryGroup = (userId: string) =>
 	db.groupMember.findFirst({
 		where: { userId, status: GroupMemberStatus.ACTIVE, group: { isActive: true } },
 		orderBy: { joinedAt: "asc" },
-		select: {
-			group: {
-				select: {
-					id: true,
-					slug: true,
-					roadmap: true,
-					isStarted: true,
-				},
-			},
+		select: membershipGroupSelect,
+	})
+
+const findMembershipGroup = (userId: string, groupId: string) =>
+	db.groupMember.findFirst({
+		where: {
+			userId,
+			groupId,
+			status: GroupMemberStatus.ACTIVE,
+			group: { isActive: true },
 		},
+		select: membershipGroupSelect,
+	})
+
+// All the user's active memberships, oldest-joined first — the source list for the
+// per-group dashboard. A user in N groups has N "today" problems.
+const findActiveMembershipGroups = (userId: string) =>
+	db.groupMember.findMany({
+		where: { userId, status: GroupMemberStatus.ACTIVE, group: { isActive: true } },
+		orderBy: { joinedAt: "asc" },
+		select: membershipGroupSelect,
 	})
 
 const getUserDashboardContext = async (userId: string) => {
@@ -382,6 +414,127 @@ const evaluateInactivityWarnings = async (
 	}
 
 	return { warned, removed }
+}
+
+type DashboardContext = {
+	pausesRemaining: number
+	pausesTotal: number
+	userStats: { currentStreak: number; longestStreak: number; totalPoints: number }
+}
+
+const noGroupToday = (ctx: DashboardContext): TodayProblemResponse => ({
+	state: "NO_GROUP",
+	group: null,
+	dailyProblem: null,
+	solve: null,
+	pausesRemaining: ctx.pausesRemaining,
+	pausesTotal: ctx.pausesTotal,
+	groupRank: null,
+	groupSize: null,
+	userStats: ctx.userStats,
+})
+
+// Builds the "today" payload for a single group. Shared by getTodayForUser (one
+// group) and listTodayForUser (all of the user's groups). User-level context
+// (pauses, stats) is passed in so the list variant fetches it once, not per group.
+const buildTodayForGroup = async (
+	userId: string,
+	group: MembershipGroup,
+	ctx: DashboardContext
+): Promise<TodayProblemResponse> => {
+	const { pausesRemaining, pausesTotal, userStats } = ctx
+
+	if (!group.isStarted) {
+		const { groupRank, groupSize } = await getGroupRank(group.id, userStats.totalPoints)
+		return {
+			state: "NOT_STARTED",
+			group: { id: group.id, slug: group.slug, roadmap: group.roadmap },
+			groupRoadmap: group.roadmap,
+			dailyProblem: null,
+			solve: null,
+			pausesRemaining,
+			pausesTotal,
+			groupRank,
+			groupSize,
+			userStats,
+		}
+	}
+
+	const [dailyProblem, { groupRank, groupSize }] = await Promise.all([
+		ensureDailyProblem(group.id, startOfTodayUtc()),
+		getGroupRank(group.id, userStats.totalPoints),
+	])
+
+	if (!dailyProblem) {
+		return {
+			state: "NO_PROBLEMS",
+			group: null,
+			dailyProblem: null,
+			solve: null,
+			pausesRemaining,
+			pausesTotal,
+			groupRank: null,
+			groupSize: null,
+			userStats,
+		}
+	}
+
+	const [solve, groupSolvedCount] = await Promise.all([
+		db.userSolve.findUnique({
+			where: { userId_dailyProblemId: { userId, dailyProblemId: dailyProblem.id } },
+			select: {
+				id: true,
+				status: true,
+				pointsEarned: true,
+				isFirstInGroup: true,
+				createdAt: true,
+				verifiedAt: true,
+			},
+		}),
+		db.userSolve.count({
+			where: { dailyProblemId: dailyProblem.id, status: SolveStatus.SOLVED },
+		}),
+	])
+
+	return {
+		state: "READY",
+		group: dailyProblem.group,
+		groupRoadmap: dailyProblem.group.roadmap,
+		dailyProblem: {
+			id: dailyProblem.id,
+			assignedDate: dailyProblem.assignedDate,
+			firstSolveTime: dailyProblem.firstSolveTime,
+			group: dailyProblem.group,
+			problem: dailyProblem.problem,
+		},
+		solve,
+		pausesRemaining,
+		pausesTotal,
+		groupRank,
+		groupSize,
+		groupSolvedCount,
+		userStats,
+	}
+}
+
+// Has the user already recorded a SOLVED for any group today? Drives the
+// once-per-day streak rule: the streak (and its multiplier/comeback bonuses)
+// advance only on the first solve of the day, not per group.
+const hasSolvedAnyToday = async (
+	userId: string,
+	day: Date,
+	excludeDailyProblemId?: string
+): Promise<boolean> => {
+	const row = await db.userSolve.findFirst({
+		where: {
+			userId,
+			status: SolveStatus.SOLVED,
+			dailyProblem: { assignedDate: day },
+			...(excludeDailyProblemId && { dailyProblemId: { not: excludeDailyProblemId } }),
+		},
+		select: { id: true },
+	})
+	return row !== null
 }
 
 export const problemsDao = {
@@ -616,108 +769,38 @@ export const problemsDao = {
 		return { seeded, skipped }
 	},
 
-	getTodayForUser: async (userId: string): Promise<TodayProblemResponse> => {
-		const [{ pausesRemaining, pausesTotal, userStats }, membership] = await Promise.all([
+	// Single group's today. `groupId` omitted → the user's primary (oldest) group,
+	// used internally by solve/pause when they already know the group.
+	getTodayForUser: async (
+		userId: string,
+		groupId?: string
+	): Promise<TodayProblemResponse> => {
+		const [ctx, membership] = await Promise.all([
 			getUserDashboardContext(userId),
-			findPrimaryGroup(userId),
+			groupId ? findMembershipGroup(userId, groupId) : findPrimaryGroup(userId),
 		])
 
-		if (!membership) {
-			return {
-				state: "NO_GROUP",
-				group: null,
-				dailyProblem: null,
-				solve: null,
-				pausesRemaining,
-				pausesTotal,
-				groupRank: null,
-				groupSize: null,
-				userStats,
-			}
-		}
-
-		if (!membership.group.isStarted) {
-			const { groupRank, groupSize } = await getGroupRank(
-				membership.group.id,
-				userStats.totalPoints
-			)
-			return {
-				state: "NOT_STARTED",
-				group: {
-					id: membership.group.id,
-					slug: membership.group.slug,
-					roadmap: membership.group.roadmap,
-				},
-				groupRoadmap: membership.group.roadmap,
-				dailyProblem: null,
-				solve: null,
-				pausesRemaining,
-				pausesTotal,
-				groupRank,
-				groupSize,
-				userStats,
-			}
-		}
-
-		const [dailyProblem, { groupRank, groupSize }] = await Promise.all([
-			ensureDailyProblem(membership.group.id, startOfTodayUtc()),
-			getGroupRank(membership.group.id, userStats.totalPoints),
-		])
-
-		if (!dailyProblem) {
-			return {
-				state: "NO_PROBLEMS",
-				group: null,
-				dailyProblem: null,
-				solve: null,
-				pausesRemaining,
-				pausesTotal,
-				groupRank: null,
-				groupSize: null,
-				userStats,
-			}
-		}
-
-		const [solve, groupSolvedCount] = await Promise.all([
-			db.userSolve.findUnique({
-				where: { userId_dailyProblemId: { userId, dailyProblemId: dailyProblem.id } },
-				select: {
-					id: true,
-					status: true,
-					pointsEarned: true,
-					isFirstInGroup: true,
-					createdAt: true,
-					verifiedAt: true,
-				},
-			}),
-			db.userSolve.count({
-				where: { dailyProblemId: dailyProblem.id, status: SolveStatus.SOLVED },
-			}),
-		])
-
-		return {
-			state: "READY",
-			group: dailyProblem.group,
-			groupRoadmap: dailyProblem.group.roadmap,
-			dailyProblem: {
-				id: dailyProblem.id,
-				assignedDate: dailyProblem.assignedDate,
-				firstSolveTime: dailyProblem.firstSolveTime,
-				group: dailyProblem.group,
-				problem: dailyProblem.problem,
-			},
-			solve,
-			pausesRemaining,
-			pausesTotal,
-			groupRank,
-			groupSize,
-			groupSolvedCount,
-			userStats,
-		}
+		if (!membership) return noGroupToday(ctx)
+		return buildTodayForGroup(userId, membership.group, ctx)
 	},
 
-	verifyAndMarkSolved: async (userId: string): Promise<MarkSolvedResult> => {
-		const today = await problemsDao.getTodayForUser(userId)
+	// One "today" entry per active group the user belongs to — the dashboard list.
+	// Empty array => the user is in no groups (dashboard shows the join-a-group state).
+	listTodayForUser: async (userId: string): Promise<TodayProblemResponse[]> => {
+		const [ctx, memberships] = await Promise.all([
+			getUserDashboardContext(userId),
+			findActiveMembershipGroups(userId),
+		])
+
+		if (memberships.length === 0) return []
+		return Promise.all(memberships.map((m) => buildTodayForGroup(userId, m.group, ctx)))
+	},
+
+	verifyAndMarkSolved: async (
+		userId: string,
+		groupId: string
+	): Promise<MarkSolvedResult> => {
+		const today = await problemsDao.getTodayForUser(userId, groupId)
 		if (today.state !== "READY") return { error: today.state, today }
 
 		const existing = today.solve
@@ -777,8 +860,19 @@ export const problemsDao = {
 			return { error: "NOT_VERIFIED", today }
 		}
 
+		// Streak (and its streak-scoped bonuses) advance once per day. If the user
+		// already solved another group today, this solve still earns base points,
+		// first-in-group, and early-bird — but no streak advance, multiplier, or comeback.
+		const streakAlreadyAdvancedToday = await hasSolvedAnyToday(
+			userId,
+			assignedDate,
+			dailyProblemId
+		)
+
 		const isComeback =
-			user.currentStreak === 0 ? await pointsDao.hasEverMissed(userId) : false
+			!streakAlreadyAdvancedToday && user.currentStreak === 0
+				? await pointsDao.hasEverMissed(userId)
+				: false
 
 		const baseSolvePoints =
 			problem.difficulty === Difficulty.HARD
@@ -793,14 +887,18 @@ export const problemsDao = {
 				: user.currentStreak >= 7
 					? STREAK_MULTIPLIER_7
 					: 1
-		const multiplierDelta = Math.floor(baseSolvePoints * multiplier) - baseSolvePoints
+		const multiplierDelta = streakAlreadyAdvancedToday
+			? 0
+			: Math.floor(baseSolvePoints * multiplier) - baseSolvePoints
 
 		const now = new Date()
 		const submittedAt = verifyResult.submittedAt
 		const isEarlyBird =
 			submittedAt.getTime() - assignedDate.getTime() < EARLY_BIRD_WINDOW_MS
-		const isNewStreak = user.currentStreak === 0
-		const newStreak = user.currentStreak + 1
+		const isNewStreak = !streakAlreadyAdvancedToday && user.currentStreak === 0
+		const newStreak = streakAlreadyAdvancedToday
+			? user.currentStreak
+			: user.currentStreak + 1
 		const newLongest = Math.max(newStreak, user.longestStreak)
 
 		const { crossedProThreshold, newBadges } = await db.$transaction(async (tx) => {
@@ -894,14 +992,18 @@ export const problemsDao = {
 				crossedPro ||= r4.crossedProThreshold
 			}
 
-			await tx.user.update({
-				where: { id: userId },
-				data: {
-					currentStreak: newStreak,
-					longestStreak: newLongest,
-					...(isNewStreak && { currentStreakStartedAt: now }),
-				},
-			})
+			// Only advance the streak on the first solve of the day. Later same-day
+			// group solves leave currentStreak/longestStreak untouched.
+			if (!streakAlreadyAdvancedToday) {
+				await tx.user.update({
+					where: { id: userId },
+					data: {
+						currentStreak: newStreak,
+						longestStreak: newLongest,
+						...(isNewStreak && { currentStreakStartedAt: now }),
+					},
+				})
+			}
 			await resolveActiveWarnings(
 				tx,
 				userId,
@@ -916,61 +1018,72 @@ export const problemsDao = {
 
 		return {
 			error: null,
-			today: await problemsDao.getTodayForUser(userId),
+			today: await problemsDao.getTodayForUser(userId, groupId),
 			crossedProThreshold,
 			newBadges,
 			newStreak,
 		}
 	},
 
+	// Per-day pause: takes today off across ALL of the user's groups at once for a
+	// single flat penalty and one consumed monthly pause. The streak is user-level
+	// and lenient, so a pause is only meaningful as a whole-day "I'm out".
 	pauseToday: async (userId: string): Promise<PauseTodayResult> => {
-		const today = await problemsDao.getTodayForUser(userId)
-		if (today.state !== "READY") return { error: today.state, today }
-		if (today.solve?.status === SolveStatus.PAUSED) return { error: null, today }
-		if (today.solve?.status === SolveStatus.SOLVED) {
-			return { error: "ALREADY_STARTED", today }
-		}
+		const todays = await problemsDao.listTodayForUser(userId)
+		if (todays.length === 0) return { error: "NO_GROUP", todays }
+
+		// If the user already solved any group today, the streak is already safe —
+		// pausing would only cost points. Block it.
+		const solvedAny = todays.some(
+			(t) => t.state === "READY" && t.solve?.status === SolveStatus.SOLVED
+		)
+		if (solvedAny) return { error: "ALREADY_STARTED", todays }
+
+		// Every started group whose problem is still open (no solve/pause/miss yet).
+		const pausable = todays.filter(
+			(t): t is Extract<TodayProblemResponse, { state: "READY" }> =>
+				t.state === "READY" && t.solve == null
+		)
+		if (pausable.length === 0) return { error: "NOTHING_TO_PAUSE", todays }
 
 		const { pausesRemaining } = await getUserDashboardContext(userId)
-		if (pausesRemaining <= 0) {
-			return { error: "NO_PAUSES", today }
-		}
+		if (pausesRemaining <= 0) return { error: "NO_PAUSES", todays }
 
 		await db.$transaction(async (tx) => {
-			const upserted = await tx.userSolve.upsert({
-				where: {
-					userId_dailyProblemId: {
-						userId,
-						dailyProblemId: today.dailyProblem.id,
+			let firstUpsertedId: string | undefined
+			for (const t of pausable) {
+				const upserted = await tx.userSolve.upsert({
+					where: {
+						userId_dailyProblemId: { userId, dailyProblemId: t.dailyProblem.id },
 					},
-				},
-				create: {
+					create: {
+						userId,
+						dailyProblemId: t.dailyProblem.id,
+						status: SolveStatus.PAUSED,
+					},
+					update: { status: SolveStatus.PAUSED },
+					select: { id: true },
+				})
+				if (!firstUpsertedId) firstUpsertedId = upserted.id
+				await resolveActiveWarnings(
+					tx,
 					userId,
-					dailyProblemId: today.dailyProblem.id,
-					status: SolveStatus.PAUSED,
-				},
-				update: { status: SolveStatus.PAUSED },
-				select: { id: true },
-			})
+					t.group.id,
+					WarningResolution.SOLVED_OR_PAUSED
+				)
+			}
 
 			await tx.user.update({
 				where: { id: userId },
 				data: { pausesUsedThisMonth: { increment: 1 } },
 			})
-
 			await pointsDao.applyPointsDelta(userId, -PAUSE_PENALTY, PointReason.PAUSE, {
 				tx,
-				userSolveId: upserted.id,
+				userSolveId: firstUpsertedId,
 			})
-			await resolveActiveWarnings(
-				tx,
-				userId,
-				today.group.id,
-				WarningResolution.SOLVED_OR_PAUSED
-			)
 		})
 
-		return { error: null, today: await problemsDao.getTodayForUser(userId) }
+		return { error: null, todays: await problemsDao.listTodayForUser(userId) }
 	},
 
 	markMissedForDate: async (
@@ -979,6 +1092,10 @@ export const problemsDao = {
 	) => {
 		const evaluateWarningsForDate = opts.evaluateWarnings ?? true
 		const day = startOfUtcDay(referenceDate)
+		// Before the cutover, only the primary group is evaluated (legacy behavior) so
+		// the 14-day catch-up never retroactively marks non-primary groups MISSED for
+		// days the pre-multi-group code ignored. On/after, every group counts.
+		const multiGroup = day.getTime() >= MULTI_GROUP_CUTOVER_DATE.getTime()
 
 		const memberships = await db.groupMember.findMany({
 			where: {
@@ -1003,19 +1120,32 @@ export const problemsDao = {
 		if (primaryByUser.size === 0) return { missed: 0, warned: 0, removed: 0 }
 
 		const primaryMemberships = Array.from(primaryByUser.values())
-		const groupIds = Array.from(new Set(primaryMemberships.map((m) => m.groupId)))
+		const consideredMemberships = multiGroup ? memberships : primaryMemberships
+
+		const runWarnings = async () =>
+			evaluateWarningsForDate
+				? await evaluateInactivityWarnings(primaryMemberships, day)
+				: { warned: 0, removed: 0 }
+
+		const groupIds = Array.from(new Set(consideredMemberships.map((m) => m.groupId)))
 		const dailyProblems = await db.dailyProblem.findMany({
 			where: { groupId: { in: groupIds }, assignedDate: day },
 			select: { id: true, groupId: true },
 		})
 		const dailyByGroup = new Map(dailyProblems.map((dp) => [dp.groupId, dp.id]))
 
-		const candidates: { userId: string; dailyProblemId: string }[] = []
-		for (const membership of primaryMemberships) {
+		const candidates: { userId: string; groupId: string; dailyProblemId: string }[] = []
+		for (const membership of consideredMemberships) {
 			const dpId = dailyByGroup.get(membership.groupId)
-			if (dpId) candidates.push({ userId: membership.userId, dailyProblemId: dpId })
+			if (dpId) {
+				candidates.push({
+					userId: membership.userId,
+					groupId: membership.groupId,
+					dailyProblemId: dpId,
+				})
+			}
 		}
-		if (candidates.length === 0) return { missed: 0, warned: 0, removed: 0 }
+		if (candidates.length === 0) return { missed: 0, ...(await runWarnings()) }
 
 		const userIds = Array.from(new Set(candidates.map((c) => c.userId)))
 		const dailyProblemIds = Array.from(new Set(candidates.map((c) => c.dailyProblemId)))
@@ -1023,7 +1153,7 @@ export const problemsDao = {
 		const [existingSolves, usersWithStreak] = await Promise.all([
 			db.userSolve.findMany({
 				where: { userId: { in: userIds }, dailyProblemId: { in: dailyProblemIds } },
-				select: { userId: true, dailyProblemId: true },
+				select: { userId: true, dailyProblemId: true, status: true },
 			}),
 			db.user.findMany({
 				where: { id: { in: userIds } },
@@ -1034,6 +1164,12 @@ export const problemsDao = {
 		const existingKey = new Set(
 			existingSolves.map((s) => `${s.userId}:${s.dailyProblemId}`)
 		)
+		// A user is "engaged" today if they have any non-MISSED row across their
+		// considered groups (SOLVED, PAUSED, or an in-flight/failed verification).
+		// Engagement keeps the lenient user-level streak alive — a full no-show breaks it.
+		const engagedTodayByUser = new Set(
+			existingSolves.filter((s) => s.status !== SolveStatus.MISSED).map((s) => s.userId)
+		)
 		const streakStartByUser = new Map(
 			usersWithStreak.map((u) => [u.id, u.currentStreakStartedAt])
 		)
@@ -1041,15 +1177,11 @@ export const problemsDao = {
 		const toMiss = candidates.filter(
 			(c) => !existingKey.has(`${c.userId}:${c.dailyProblemId}`)
 		)
-		if (toMiss.length === 0) {
-			const warningResult = evaluateWarningsForDate
-				? await evaluateInactivityWarnings(primaryMemberships, day)
-				: { warned: 0, removed: 0 }
-			return { missed: 0, ...warningResult }
-		}
+		if (toMiss.length === 0) return { missed: 0, ...(await runWarnings()) }
 
 		let missed = 0
-		for (const { userId, dailyProblemId } of toMiss) {
+		const missedUserIds = new Set<string>()
+		for (const { userId, groupId, dailyProblemId } of toMiss) {
 			try {
 				await db.$transaction(async (tx) => {
 					const solve = await tx.userSolve.create({
@@ -1062,12 +1194,21 @@ export const problemsDao = {
 						select: { id: true },
 					})
 
-					await pointsDao.applyMissPenalty(tx, userId, {
-						userSolveId: solve.id,
-						streakStartedAt: streakStartByUser.get(userId) ?? null,
-					})
+					if (multiGroup) {
+						// −3 per missed group; the streak is broken once per user below.
+						await pointsDao.applyMissPoints(tx, userId, {
+							userSolveId: solve.id,
+							groupId,
+						})
+					} else {
+						await pointsDao.applyMissPenalty(tx, userId, {
+							userSolveId: solve.id,
+							streakStartedAt: streakStartByUser.get(userId) ?? null,
+						})
+					}
 				})
 				missed++
+				missedUserIds.add(userId)
 			} catch (err) {
 				if (err && typeof err === "object" && "code" in err && err.code === "P2002") {
 					continue
@@ -1076,10 +1217,19 @@ export const problemsDao = {
 			}
 		}
 
-		const warningResult = evaluateWarningsForDate
-			? await evaluateInactivityWarnings(primaryMemberships, day)
-			: { warned: 0, removed: 0 }
-		return { missed, ...warningResult }
+		// Multi-group: break each user's streak at most once, and only on a full
+		// no-show (they neither solved nor paused any group today). Legacy already
+		// reset the streak inside applyMissPenalty.
+		if (multiGroup) {
+			for (const userId of missedUserIds) {
+				if (engagedTodayByUser.has(userId)) continue
+				await db.$transaction((tx) =>
+					pointsDao.breakUserStreak(tx, userId, streakStartByUser.get(userId) ?? null)
+				)
+			}
+		}
+
+		return { missed, ...(await runWarnings()) }
 	},
 
 	resetMonthlyCounters: async () => {

--- a/src/server/problems/problems.model.ts
+++ b/src/server/problems/problems.model.ts
@@ -4,4 +4,7 @@ export const problemsModel = new Elysia({ name: "model/problems" }).model({
 	"problems.roadmapQuery": t.Object({
 		roadmap: t.Optional(t.String({ minLength: 1 })),
 	}),
+	"problems.solveBody": t.Object({
+		groupId: t.String({ minLength: 1 }),
+	}),
 })

--- a/src/server/problems/problems.type.ts
+++ b/src/server/problems/problems.type.ts
@@ -133,12 +133,15 @@ export type MarkSolvedResult =
 			newStreak: number
 	  }
 
+// Pause is a per-day action: it pauses every one of the user's unsolved problems
+// across all their groups at once, so it returns the full per-group list rather
+// than a single group's today.
 export type PauseTodayResult =
 	| {
-			error: "NO_GROUP" | "NO_PROBLEMS" | "NOT_STARTED" | "NO_PAUSES" | "ALREADY_STARTED"
-			today: TodayProblemResponse
+			error: "NO_GROUP" | "NO_PAUSES" | "ALREADY_STARTED" | "NOTHING_TO_PAUSE"
+			todays: TodayProblemResponse[]
 	  }
-	| { error: null; today: TodayProblemResponse }
+	| { error: null; todays: TodayProblemResponse[] }
 
 export type DailyProblemRecipient = {
 	email: string

--- a/src/server/stress/api.stress.integration.test.ts
+++ b/src/server/stress/api.stress.integration.test.ts
@@ -594,6 +594,7 @@ const createEndpointScenarios = (ctx: StressContext): StressScenario[] => [
 		key: { method: "POST", path: "/api/v3/problems/today/solve" },
 		method: "POST",
 		path: "/api/v3/problems/today/solve",
+		body: { groupId: ctx.publicGroupId },
 		userId: ctx.user.id,
 		allowedStatuses: [200, 409],
 	},


### PR DESCRIPTION
## Problem

User feedback: someone in multiple groups saw the **wrong** group's problem name in the success modal, and solving never checked the group they were actually working on.

**Root cause:** every daily-problem path resolved the group via `findPrimaryGroup()` — the *oldest joined* group. So `getToday`, solve/verify, pause, and `mark-missed` all operated on the wrong group for any user in >1 group (which requires Pro; Free is capped at 1 group).

## Model (grilled out with the reporter)

Daily solving is **per-group**: a user in N groups has N "today" problems, each solved/verified independently.

- **Dashboard** — one adaptive view with **stacked per-group cards**, keyed on group count not tier. Free users get one card (unchanged).
- **Streak** — user-level and lenient: solving ≥1 group advances it once/day; a pause preserves it; a full no-show breaks it. Streak multiplier + comeback fire once/day too.
- **Points** — per group: base (difficulty) + first-in-group + early-bird per solve; −3 per missed group. Streak leniency doesn't erase point penalties.
- **Pause** — per-day: one flat −5, one consumed pause, marks every open group `PAUSED`.

## Changes

- `problems.dao.ts`: `listTodayForUser` (per-group list) + `getTodayForUser(userId, groupId?)`; `verifyAndMarkSolved(userId, groupId)` with once-per-day streak; per-day `pauseToday`; `markMissedForDate` multi-group with a **cutover date** so the 14-day catch-up never retroactively penalizes non-primary groups.
- `points.dao.ts`: `applyMissPoints` (per-group −3) + `breakUserStreak` (clawback+reset once/user); legacy `applyMissPenalty` unchanged. Miss rows tagged with `groupId`.
- Controller: solve takes `{ groupId }`; today + pause return the list.
- Frontend: stacked cards, per-group solve, day-level pause control; group table + roadmap default-tab updated.

## ⚠️ Before deploy

Set `MULTI_GROUP_CUTOVER_DATE` in `problems.dao.ts` to the **actual production deploy date** (currently 2026-07-17). Days between now and deploy would otherwise let the catch-up mark non-primary groups missed retroactively.

## Deferred (agreed)

Group-leaderboard scoping (still ranks by global points) and multi-group digest email. Miss rows now carry `groupId` so the leaderboard follow-up has the data.

## Verification

`typecheck` ✓ · `biome check` ✓ · `knip` ✓ · `vitest` 166/166 ✓