### PR TITLE
fix(email): pace and retry daily SMTP dispatch

### DIFF
--- a/src/server/jobs/jobs.service.test.ts
+++ b/src/server/jobs/jobs.service.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
 	auditCachedTotals: vi.fn(),
 	notifyAdmin: vi.fn(),
 	sendEmail: vi.fn(),
+	isRetryableEmailError: vi.fn(),
 	captureServerException: vi.fn(),
 	getDailyDigestRecipients: vi.fn(),
 	assignDailyProblems: vi.fn(),
@@ -27,7 +28,10 @@ vi.mock("@/server/groups/groups.notifications", () => ({
 }))
 vi.mock("@/server/lib/bot", () => ({ notifyAdmin: mocks.notifyAdmin }))
 vi.mock("@/server/lib/db", () => ({ db: {} }))
-vi.mock("@/server/lib/email", () => ({ sendEmail: mocks.sendEmail }))
+vi.mock("@/server/lib/email", () => ({
+	sendEmail: mocks.sendEmail,
+	isRetryableEmailError: mocks.isRetryableEmailError,
+}))
 vi.mock("@/server/lib/sentry", () => ({
 	captureServerException: mocks.captureServerException,
 }))
@@ -57,6 +61,9 @@ describe("app-owned jobs", () => {
 		mocks.logSystemEvent.mockResolvedValue(undefined)
 		mocks.notifyAdmin.mockResolvedValue(undefined)
 		mocks.sendEmail.mockResolvedValue(undefined)
+		mocks.isRetryableEmailError.mockImplementation(
+			(error) => error instanceof Error && error.message === "Retryable email failure"
+		)
 	})
 
 	it("reconciles only the explicitly requested missed day", async () => {
@@ -125,11 +132,31 @@ describe("app-owned jobs", () => {
 	})
 
 	it("reports sent and failed daily digest counts without recipient identity", async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date("2026-07-14T00:00:00.000Z"))
 		mocks.assignDailyProblems.mockResolvedValue({ assigned: 1 })
 		mocks.getDailyDigestRecipients.mockResolvedValue([
 			{
 				email: "recipient-sentinel@example.test",
 				name: "Recipient Sentinel",
+				groupSlug: "sentinel-group",
+				problemTitle: "Sentinel Problem",
+				difficulty: "EASY",
+				topic: "Arrays",
+				problemSlug: "sentinel-problem",
+			},
+			{
+				email: "exhausted-recipient@example.test",
+				name: "Exhausted Recipient",
+				groupSlug: "sentinel-group",
+				problemTitle: "Sentinel Problem",
+				difficulty: "EASY",
+				topic: "Arrays",
+				problemSlug: "sentinel-problem",
+			},
+			{
+				email: "permanent-recipient@example.test",
+				name: "Permanent Recipient",
 				groupSlug: "sentinel-group",
 				problemTitle: "Sentinel Problem",
 				difficulty: "EASY",
@@ -162,22 +189,41 @@ describe("app-owned jobs", () => {
 			pausesUsed: 0,
 			handleChanges: 0,
 		})
-		mocks.sendEmail
-			.mockRejectedValueOnce(new Error("Email send failed"))
-			.mockResolvedValueOnce(undefined)
-			.mockResolvedValueOnce(null)
+		const attemptTimes: number[] = []
+		const attemptsByRecipient = new Map<string, number>()
+		mocks.sendEmail.mockImplementation(({ to }: { to: string }) => {
+			attemptTimes.push(Date.now())
+			const attempt = (attemptsByRecipient.get(to) ?? 0) + 1
+			attemptsByRecipient.set(to, attempt)
+			if (to === "recipient-sentinel@example.test" && attempt === 1) {
+				return Promise.reject(new Error("Retryable email failure"))
+			}
+			if (to === "exhausted-recipient@example.test") {
+				return Promise.reject(new Error("Retryable email failure"))
+			}
+			if (to === "permanent-recipient@example.test") {
+				return Promise.reject(new Error("Permanent email failure"))
+			}
+			return Promise.resolve(
+				to === "suppressed-recipient@example.test" ? null : undefined
+			)
+		})
 
-		await expect(
-			executeJob("assign-daily-problem", new Date("2026-07-14T00:00:00.000Z"))
-		).resolves.toEqual({
+		const execution = executeJob(
+			"assign-daily-problem",
+			new Date("2026-07-14T00:00:00.000Z")
+		)
+		await vi.runAllTimersAsync()
+		await expect(execution).resolves.toEqual({
 			assigned: 1,
-			recipients: 3,
+			recipients: 5,
 			batches: 1,
-			sent: 1,
-			failed: 1,
+			sent: 2,
+			failed: 2,
 			suppressed: 1,
 		})
 
+		expect(mocks.captureServerException).toHaveBeenCalledTimes(2)
 		expect(mocks.captureServerException).toHaveBeenCalledWith(expect.any(Error), {
 			tag: "email:daily-digest",
 			dateKey: "2026-07-14",
@@ -190,10 +236,18 @@ describe("app-owned jobs", () => {
 		expect(mocks.notifyAdmin).toHaveBeenCalledWith(
 			"digest.daily",
 			expect.objectContaining({
-				emailsSent: 1,
-				emailsFailed: 1,
+				emailsSent: 2,
+				emailsFailed: 2,
 				emailsSuppressed: 1,
 			})
 		)
+		expect(mocks.sendEmail).toHaveBeenCalledTimes(8)
+		expect(attemptsByRecipient.get("recipient-sentinel@example.test")).toBe(2)
+		expect(attemptsByRecipient.get("exhausted-recipient@example.test")).toBe(3)
+		expect(attemptsByRecipient.get("permanent-recipient@example.test")).toBe(1)
+		expect(
+			attemptTimes.slice(1).every((time, index) => time - attemptTimes[index] >= 300)
+		).toBe(true)
+		vi.useRealTimers()
 	})
 })

--- a/src/server/jobs/jobs.service.ts
+++ b/src/server/jobs/jobs.service.ts
@@ -5,7 +5,7 @@ import { groupsDao } from "@/server/groups/groups.dao"
 import { groupNotifications } from "@/server/groups/groups.notifications"
 import { notifyAdmin } from "@/server/lib/bot"
 import { db } from "@/server/lib/db"
-import { sendEmail } from "@/server/lib/email"
+import { isRetryableEmailError, sendEmail } from "@/server/lib/email"
 import { captureServerException } from "@/server/lib/sentry"
 import { auditCachedTotals } from "@/server/points/points.reconciliation"
 import { problemsDao } from "@/server/problems/problems.dao"
@@ -17,11 +17,16 @@ const DAY_MS = 86_400_000
 const HOUR_MS = 60 * 60 * 1000
 const CATCH_UP_DAYS = 14
 const DIGEST_BATCH_SIZE = 100
+const EMAIL_DISPATCH_INTERVAL_MS = 300
+const EMAIL_SEND_ATTEMPTS = 3
 const SYSTEM_EVENT_RETENTION_DAYS = 90
 const JOB_RUN_RETENTION_DAYS = 30
 
 const utcDay = (date: Date) =>
 	new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+
+const sleep = (durationMs: number) =>
+	new Promise<void>((resolve) => setTimeout(resolve, durationMs))
 
 const sendDailyDigest = async (date: Date) => {
 	const recipients = await problemsDao.getDailyDigestRecipients(date)
@@ -32,6 +37,15 @@ const sendDailyDigest = async (date: Date) => {
 	let sent = 0
 	let failed = 0
 	let suppressed = 0
+	let lastAttemptStartedAt: number | undefined
+	const waitForDispatchSlot = async () => {
+		if (lastAttemptStartedAt !== undefined) {
+			const elapsed = Date.now() - lastAttemptStartedAt
+			const remaining = EMAIL_DISPATCH_INTERVAL_MS - elapsed
+			if (remaining > 0) await sleep(remaining)
+		}
+		lastAttemptStartedAt = Date.now()
+	}
 	for (let i = 0; i < recipients.length; i += DIGEST_BATCH_SIZE) {
 		const batch = recipients.slice(i, i + DIGEST_BATCH_SIZE)
 		const batchIndex = i / DIGEST_BATCH_SIZE
@@ -52,22 +66,31 @@ const sendDailyDigest = async (date: Date) => {
 
 		// Send per-recipient through the configured transport (Resend / SMTP /
 		// log). A failed recipient is captured but never fails the batch.
-		// Sequential sends avoid exhausting SMTP connection limits when using
-		// the self-hosted Stalwart transport (Promise.all saturates the pool).
+		// Pace all attempts below Stalwart's per-IP throttle and retry transient
+		// handoff failures. Only the final failed attempt is captured so one
+		// recipient cannot produce a burst of duplicate operator alerts.
 		const outcomes: Array<"sent" | "failed" | "suppressed"> = []
 		for (const email of emails) {
-			try {
-				const result = await sendEmail(email)
-				outcomes.push(result === null ? "suppressed" : "sent")
-			} catch (err) {
-				captureServerException(err, {
-					tag: "email:daily-digest",
-					dateKey,
-					batchIndex,
-					recipientCount: 1,
-				})
-				outcomes.push("failed")
+			let outcome: "sent" | "failed" | "suppressed" = "failed"
+			for (let attempt = 1; attempt <= EMAIL_SEND_ATTEMPTS; attempt++) {
+				await waitForDispatchSlot()
+				try {
+					const result = await sendEmail(email)
+					outcome = result === null ? "suppressed" : "sent"
+					break
+				} catch (err) {
+					if (!isRetryableEmailError(err) || attempt === EMAIL_SEND_ATTEMPTS) {
+						captureServerException(err, {
+							tag: "email:daily-digest",
+							dateKey,
+							batchIndex,
+							recipientCount: 1,
+						})
+						break
+					}
+				}
 			}
+			outcomes.push(outcome)
 		}
 		for (const outcome of outcomes) {
 			if (outcome === "sent") sent++

--- a/src/server/lib/email.test.ts
+++ b/src/server/lib/email.test.ts
@@ -36,7 +36,7 @@ vi.mock("@/server/lib/logger", () => ({
 	logger: { debug: mocks.debug, info: mocks.info, error: mocks.error },
 }))
 
-import { sendEmail } from "@/server/lib/email"
+import { EmailDeliveryError, sendEmail } from "@/server/lib/email"
 
 describe("sendEmail", () => {
 	beforeEach(() => {
@@ -135,6 +135,26 @@ describe("sendEmail", () => {
 		const logged = JSON.stringify(mocks.error.mock.calls)
 		expect(logged).not.toContain("sentinel")
 		expect(logged).not.toContain("private body")
+	})
+
+	it("marks temporary SMTP responses as retryable without exposing provider details", async () => {
+		mocks.env.EMAIL_TRANSPORT = "smtp"
+		mocks.sendMail.mockRejectedValueOnce(
+			Object.assign(new Error("temporary provider detail sentinel"), {
+				responseCode: 421,
+			})
+		)
+
+		const error = await sendEmail({
+			from: "PStrack <info@pstrack.app>",
+			to: "person@example.test",
+			subject: "SMTP message",
+			html: "<p>message</p>",
+		}).catch((caught) => caught)
+
+		expect(error).toBeInstanceOf(EmailDeliveryError)
+		expect(error).toMatchObject({ message: "SMTP send failed", retryable: true })
+		expect(JSON.stringify(mocks.error.mock.calls)).not.toContain("sentinel")
 	})
 
 	it("redacts errors thrown while rendering SMTP templates", async () => {

--- a/src/server/lib/email.ts
+++ b/src/server/lib/email.ts
@@ -28,6 +28,38 @@ const resend: Resend = new Proxy({} as Resend, {
 
 let transporter: Transporter | null = null
 
+export class EmailDeliveryError extends Error {
+	readonly retryable: boolean
+
+	constructor(message: string, retryable: boolean) {
+		super(message)
+		this.name = "EmailDeliveryError"
+		this.retryable = retryable
+	}
+}
+
+export const isRetryableEmailError = (error: unknown) =>
+	error instanceof EmailDeliveryError && error.retryable
+
+const RETRYABLE_SMTP_CODES = new Set([
+	"EAI_AGAIN",
+	"ECONNECTION",
+	"ECONNRESET",
+	"ESOCKET",
+	"ETIMEDOUT",
+])
+
+const isTransientSmtpError = (error: unknown) => {
+	if (typeof error !== "object" || error === null) return false
+	const responseCode =
+		"responseCode" in error && typeof error.responseCode === "number"
+			? error.responseCode
+			: undefined
+	if (responseCode !== undefined) return responseCode >= 400 && responseCode < 500
+	const code = "code" in error && typeof error.code === "string" ? error.code : undefined
+	return code !== undefined && RETRYABLE_SMTP_CODES.has(code)
+}
+
 /**
  * Build the SMTP transporter lazily, for the same import-safety reason as the
  * Resend client above: it must never throw at import time when SMTP env is
@@ -80,12 +112,12 @@ const sendViaSmtp = async (payload: CreateEmailOptions) => {
 						}
 					: {}),
 			})
-		} catch {
+		} catch (error) {
 			logger.error(
 				{ recipientCount: Array.isArray(payload.to) ? payload.to.length : 1 },
 				"smtp send failed"
 			)
-			throw new Error("SMTP send failed")
+			throw new EmailDeliveryError("SMTP send failed", isTransientSmtpError(error))
 		}
 	})()
 
@@ -97,8 +129,9 @@ const sendViaSmtp = async (payload: CreateEmailOptions) => {
 			},
 			"smtp send rejected"
 		)
-		throw new Error(
-			`SMTP rejected ${info.rejected.length} recipient${info.rejected.length === 1 ? "" : "s"}`
+		throw new EmailDeliveryError(
+			`SMTP rejected ${info.rejected.length} recipient${info.rejected.length === 1 ? "" : "s"}`,
+			false
 		)
 	}
 	logger.debug(


### PR DESCRIPTION
## What changed

- pace SMTP delivery attempts at 300 ms intervals
- retry transient SMTP failures up to three times
- avoid retrying permanent delivery failures
- preserve accurate sent, failed, and suppressed job counts

## Root cause

The daily digest dispatched messages faster than the production Stalwart SMTP sender-IP throttle of five messages per second. The rejected attempts were swallowed by the notification layer and surfaced only as failed counts.

## Impact

Daily digest delivery now stays below the SMTP rate limit and transient failures get bounded retries. A message is counted as sent only after SMTP accepts it.

## Validation

- `bun run test` — 167 tests passed
- `bun run typecheck`
- `bun run check`